### PR TITLE
tableplace-28: roll a random adjective-noun lobby instead of 'default'

### DIFF
--- a/src/lib/utils/__tests__/lobby-name.test.ts
+++ b/src/lib/utils/__tests__/lobby-name.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { randomLobbyName } from '../lobby-name';
+
+describe('randomLobbyName', () => {
+	it('is lowercase, hyphenated and URL-safe', () => {
+		for (let i = 0; i < 200; i++) {
+			const name = randomLobbyName();
+			expect(name).toMatch(/^[a-z]+-[a-z]+$/);
+			expect(encodeURIComponent(name)).toBe(name);
+		}
+	});
+
+	it('rolls more than one distinct value', () => {
+		const names = new Set(Array.from({ length: 100 }, () => randomLobbyName()));
+		expect(names.size).toBeGreaterThan(1);
+	});
+});

--- a/src/lib/utils/lobby-name.ts
+++ b/src/lib/utils/lobby-name.ts
@@ -1,0 +1,124 @@
+/**
+ * Human-readable lobby names — the slug in `/play?lobby=<slug>` *is* the invite
+ * link, so it has to be easy to read out loud and easy to type. 50 x 50 words
+ * is ~2500 combinations, plenty for a hobby app where collisions just mean two
+ * strangers share a table.
+ */
+
+const ADJECTIVES = [
+	'amber',
+	'ancient',
+	'bold',
+	'brave',
+	'brisk',
+	'bronze',
+	'calm',
+	'clever',
+	'copper',
+	'crimson',
+	'curious',
+	'dapper',
+	'dusty',
+	'eager',
+	'early',
+	'fabled',
+	'fancy',
+	'feral',
+	'fleet',
+	'frosty',
+	'gentle',
+	'gilded',
+	'golden',
+	'happy',
+	'hidden',
+	'humble',
+	'ivory',
+	'jolly',
+	'keen',
+	'lucky',
+	'merry',
+	'mighty',
+	'misty',
+	'noble',
+	'plucky',
+	'polite',
+	'proud',
+	'quiet',
+	'rapid',
+	'rustic',
+	'scarlet',
+	'silent',
+	'silver',
+	'sleepy',
+	'snowy',
+	'swift',
+	'tidy',
+	'velvet',
+	'wandering',
+	'witty'
+] as const;
+
+const NOUNS = [
+	'badger',
+	'beacon',
+	'bishop',
+	'boulder',
+	'canyon',
+	'castle',
+	'cedar',
+	'chalice',
+	'comet',
+	'compass',
+	'cove',
+	'dagger',
+	'delta',
+	'ember',
+	'falcon',
+	'ferret',
+	'garden',
+	'gazelle',
+	'harbor',
+	'heron',
+	'hollow',
+	'ibis',
+	'jackal',
+	'kestrel',
+	'lantern',
+	'ledger',
+	'lynx',
+	'magpie',
+	'marble',
+	'meadow',
+	'mongoose',
+	'otter',
+	'panther',
+	'pebble',
+	'pelican',
+	'quarry',
+	'raven',
+	'ridge',
+	'saffron',
+	'sparrow',
+	'stallion',
+	'tavern',
+	'thicket',
+	'thistle',
+	'tundra',
+	'vulture',
+	'walrus',
+	'willow',
+	'wombat',
+	'zephyr'
+] as const;
+
+function pick<T>(words: readonly T[]): T {
+	return words[Math.floor(Math.random() * words.length)];
+}
+
+/**
+ * Roll a fresh lobby id, e.g. `swift-otter`. Always lowercase, hyphenated and
+ * URL-safe: matches /^[a-z]+-[a-z]+$/.
+ */
+export function randomLobbyName(): string {
+	return `${pick(ADJECTIVES)}-${pick(NOUNS)}`;
+}

--- a/src/lib/websocket/connection.ts
+++ b/src/lib/websocket/connection.ts
@@ -26,7 +26,6 @@ function normalizeServerHost(url: string): string {
 const CACHE_SERVER_URL = normalizeServerHost(localStorage.getItem('serverurl') ?? 'localhost:8080');
 const SECURITY = CACHE_SERVER_URL.includes('localhost') ? 'ws' : 'wss';
 const WS_SERVER_URL = `${SECURITY}://${CACHE_SERVER_URL}/ws`;
-const DEFAULT_LOBBY = 'default';
 
 // State
 let socket: WebSocket | null = null;
@@ -43,13 +42,10 @@ const messageCallbacks: MessageCallback[] = [];
 
 /**
  * Connect to the websocket server
- * @param lobbyId The lobby ID to connect to (defaults to 'default')
+ * @param lobbyId The lobby ID to connect to
  * @returns Promise that resolves when connected
  */
-export async function connect(
-	lobbyId: string = DEFAULT_LOBBY,
-	serverUrl?: string
-): Promise<boolean> {
+export async function connect(lobbyId: string, serverUrl?: string): Promise<boolean> {
 	if (isConnected) {
 		console.log('Already connected to websocket server');
 		return true;
@@ -84,10 +80,7 @@ export async function connect(
 			socket = new WebSocket(wsUrl);
 
 			socket.onopen = () => {
-				console.log(
-					'Connected to websocket server. Reconnection attempts:',
-					reconnectAttempts
-				);
+				console.log('Connected to websocket server. Reconnection attempts:', reconnectAttempts);
 				toast(`Connected to lobby: ${lobbyId}`);
 				isConnected = true;
 				isConnecting = false;
@@ -151,12 +144,10 @@ export async function connect(
 
 /**
  * Join a lobby as the current player
- * @param lobbyId Lobby ID to join (defaults to 'default')
+ * @param lobbyId Lobby ID to join
  * @returns Promise that resolves when joined
  */
-export async function joinLobby(
-	lobbyId: string = DEFAULT_LOBBY
-): Promise<boolean> {
+export async function joinLobby(lobbyId: string): Promise<boolean> {
 	// First ensure we're connected
 	if (!isConnected) {
 		const connected = await connect(lobbyId);

--- a/src/lib/websocket/index.ts
+++ b/src/lib/websocket/index.ts
@@ -12,14 +12,12 @@ import { prewarmGameState } from '$lib/packs/prewarm-state';
 import toast from 'svelte-french-toast';
 
 /**
- * Initialize websocket connection and join the default lobby
+ * Initialize websocket connection and join the given lobby
+ * @param lobbyId Lobby to join — callers roll one with randomLobbyName() when
+ * the URL has no ?lobby, so there is no shared fallback room
  * @returns Promise that resolves when connected and joined
  */
-export async function initWebsocket(
-	_lobbyId?: string,
-	serverUrl?: string
-): Promise<boolean> {
-	const lobbyId = _lobbyId ?? 'default';
+export async function initWebsocket(lobbyId: string, serverUrl?: string): Promise<boolean> {
 	// Check if player exists, if not create a player
 	const player = gameActions.getMe();
 	if (!player) {
@@ -28,21 +26,21 @@ export async function initWebsocket(
 	}
 
 	try {
-		// Connect to the default lobby
+		// Connect to the lobby
 		const connected = await connect(lobbyId, serverUrl);
 		if (!connected) {
 			console.error('Failed to connect to websocket server');
 			return false;
 		}
 
-		// Join the default lobby
+		// Join the lobby
 		const joined = await joinLobby(lobbyId);
 		if (!joined) {
-			console.error('Failed to join default lobby');
+			console.error(`Failed to join lobby ${lobbyId}`);
 			return false;
 		}
 
-		console.log('Successfully connected and joined default lobby');
+		console.log(`Successfully connected and joined lobby ${lobbyId}`);
 
 		// Set up event listeners for incoming messages
 		setupMessageHandlers();
@@ -96,7 +94,9 @@ function setupMessageHandlers(): void {
 				prewarmGameState(message.value, ({ total, failed }) => {
 					gameStore.updateStateSilently({});
 					toast(
-						failed > 0 ? `Card art: ${total - failed}/${total} loaded` : `Card art ready (${total})`,
+						failed > 0
+							? `Card art: ${total - failed}/${total} loaded`
+							: `Card art ready (${total})`,
 						{ duration: 3000 }
 					);
 				});

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,4 +1,16 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
+	import { randomLobbyName } from '$lib/utils/lobby-name';
+
+	// href is a working fallback (middle-click / no JS); the click handler rolls a
+	// fresh name so every launch from this page gets its own table
+	let lobby = $state(randomLobbyName());
+
+	function openTable(event: MouseEvent) {
+		event.preventDefault();
+		lobby = randomLobbyName();
+		goto(`/play?lobby=${lobby}`);
+	}
 </script>
 
 <svelte:head>
@@ -18,12 +30,17 @@
 			<li>Click <strong>Open Table</strong> and spawn a deck of cards</li>
 		</ol>
 		<p class="mb-4">
-			In the Settings pane (⚙️), set the Server to <code>localhost:8080</code> or your ngrok URL, and
-			enter a Lobby ID.
+			In the Settings pane (⚙️), set the Server to <code>localhost:8080</code> or your ngrok URL.
 		</p>
-		<a href="/play" class="block rounded bg-emerald-400 py-2 text-center font-medium text-white"
-			>Open Table</a
+		<a
+			href="/play?lobby={lobby}"
+			onclick={openTable}
+			class="block rounded bg-emerald-400 py-2 text-center font-medium text-white">Open Table</a
 		>
+		<p class="mt-2 text-sm text-gray-500">
+			Every table gets its own name — the table's URL is your invite link, so share it with whoever
+			you want to play with.
+		</p>
 		<a
 			href="/setup"
 			class="mt-2 block rounded border border-emerald-400 py-2 text-center font-medium text-emerald-600"

--- a/src/routes/play/+page.svelte
+++ b/src/routes/play/+page.svelte
@@ -11,6 +11,8 @@
 	import { claimSeat, seatPlaceholderId, type SeatIndex } from '$lib/scenario/scenario';
 	import Pane from './Pane.svelte';
 	import { page } from '$app/state';
+	import { replaceState } from '$app/navigation';
+	import { randomLobbyName } from '$lib/utils/lobby-name';
 	import PaneDecks from './PaneDecks.svelte';
 	import toast from 'svelte-french-toast';
 
@@ -51,7 +53,16 @@
 	}
 
 	onMount(() => {
-		const lobbyId = page?.url?.searchParams?.get('lobby') ?? undefined;
+		// no ?lobby means someone hit /play directly — roll a name and pin it into
+		// the URL *before* connecting, so a refresh rejoins the same table and the
+		// address bar is always a copy-pasteable invite
+		let lobbyId = page?.url?.searchParams?.get('lobby') ?? undefined;
+		if (!lobbyId) {
+			lobbyId = randomLobbyName();
+			const url = new URL(page.url);
+			url.searchParams.set('lobby', lobbyId);
+			replaceState(`${url.pathname}${url.search}${url.hash}`, page.state);
+		}
 		const serverUrl = page?.url?.searchParams?.get('server') ?? undefined;
 		const seatParam = page?.url?.searchParams?.get('seat');
 		const connected = initWebsocket(lobbyId, serverUrl);

--- a/src/routes/play/Pane.svelte
+++ b/src/routes/play/Pane.svelte
@@ -56,6 +56,12 @@
 	});
 
 	let lobbyId = $state(page.url.searchParams.get('lobby') ?? '');
+	// /play with no ?lobby rolls a name and replaceState()s it in after this pane
+	// has already mounted — adopt it so the share link isn't empty
+	$effect(() => {
+		const fromUrl = page.url.searchParams.get('lobby');
+		if (fromUrl && !lobbyId) lobbyId = fromUrl;
+	});
 	const lobbyUrl = $derived(
 		new URLSearchParams({ server: $connectionStore.serverUrl, lobby: lobbyId }).toString()
 	);


### PR DESCRIPTION
Task: tableplace-28

Closes #28

Landing CTA used to link to bare `/play`, which fell through to `DEFAULT_LOBBY = 'default'` — two strangers clicking "Open Table" landed in the same table.

## Changes
- **`src/lib/utils/lobby-name.ts`** — `randomLobbyName()` backed by a bundled 50 adjective x 50 noun list (no new npm dependency). Output is lowercase/hyphenated/URL-safe, `/^[a-z]+-[a-z]+$/`, e.g. `swift-otter`.
- **Landing** — "Open Table" rolls a fresh slug on every click and navigates to `/play?lobby=<slug>`. The `href` carries a pre-rolled slug so middle-click / no-JS still works. Copy drops the "enter a Lobby ID" instruction and says the table URL is the invite link.
- **`/play`** — with no `?lobby`, rolls a name and `replaceState`s `/play?lobby=<slug>` **before** `initWebsocket` runs, so a refresh rejoins the same lobby. An explicit `?lobby=x` is honored unchanged (no roll, no redirect).
- **Websocket** — `lobbyId` is now a required param on `initWebsocket` / `connect` / `joinLobby`; `DEFAULT_LOBBY` removed. `'default'` is no longer reachable through the UI.
- **Settings pane** — adopts the rolled lobby via an effect on `page.url` (the pane mounts before the play page's `onMount` replaceState), so the share link isn't empty.

## Tests
- New `src/lib/utils/__tests__/lobby-name.test.ts`: 200 rolls all match the regex and survive `encodeURIComponent` unchanged; 100 rolls yield more than one distinct value.
- `bun run test` — 31 tests / 5 files pass. `bun run check` — 0 errors. `bun run build` — clean. ESLint/prettier on touched files show no new problems (repo has pre-existing lint debt, unchanged at 59 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RFJYffaWhGzdD7eTkFvXT