### PR TITLE
tableplace-29: player HUD — who's at the table and their hidden counts

### DIFF
--- a/src/lib/hud/PlayerHud.svelte
+++ b/src/lib/hud/PlayerHud.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	/**
+	 * Read-only overlay listing who is at the table: seat, hand size, deck
+	 * counts, and which seats are still open. Counts only — another player's
+	 * card faces/ids are never rendered.
+	 *
+	 * Plain DOM (not svelte-tweakpane-ui) since this is player-facing game
+	 * info, and anchored top-right so it clears the Settings (x=0) and Decks
+	 * (x=310) panes.
+	 */
+	import { gameActions } from '$lib/store/game/actions';
+	import { gameStore } from '$lib/store/game/gameStore.svelte';
+	import { derivePlayerRows, summarize, type DeckCount } from './players';
+
+	/** `main 34 · discard 6` */
+	const deckLine = (decks: DeckCount[]) => decks.map((d) => `${d.slot} ${d.count}`).join(' · ');
+
+	const COLLAPSE_KEY = 'hud:players:collapsed';
+
+	// getMyId() reads localStorage, which is only written once the websocket
+	// init creates a player — re-read it whenever the store changes so a
+	// first-time visitor's own row still gets marked
+	const rows = $derived(derivePlayerRows($gameStore, gameActions.getMyId() ?? undefined));
+	const summary = $derived(summarize(rows));
+
+	let collapsed = $state(readCollapsed());
+
+	function readCollapsed() {
+		try {
+			return localStorage.getItem(COLLAPSE_KEY) === 'true';
+		} catch {
+			return false;
+		}
+	}
+
+	function toggle() {
+		collapsed = !collapsed;
+		try {
+			localStorage.setItem(COLLAPSE_KEY, String(collapsed));
+		} catch {
+			// private mode / storage disabled — collapse still works for this session
+		}
+	}
+</script>
+
+<!-- wrapper is click-through so cards can still be dragged underneath -->
+<div class="pointer-events-none fixed top-2 right-2 z-50 font-sans">
+	<div
+		class="pointer-events-auto w-64 rounded-md border border-white/10 bg-gray-900/80 text-white shadow-lg backdrop-blur-sm"
+	>
+		<button
+			type="button"
+			onclick={toggle}
+			class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-xs tracking-wide uppercase opacity-70 hover:opacity-100"
+			aria-expanded={!collapsed}
+		>
+			<span>Players</span>
+			<span class="flex items-center gap-2 normal-case opacity-80">
+				{summary}
+				<span class="text-[0.6rem]">{collapsed ? '▸' : '▾'}</span>
+			</span>
+		</button>
+
+		{#if !collapsed}
+			<ul class="max-h-[70vh] overflow-y-auto border-t border-white/10">
+				{#if rows.length === 0}
+					<li class="px-3 py-2 text-xs opacity-50">Nobody at the table yet</li>
+				{/if}
+				{#each rows as row (row.id)}
+					<li
+						class={[
+							'flex gap-2 border-b border-white/5 px-3 py-2 text-xs last:border-b-0',
+							row.isOpenSeat && 'opacity-50',
+							row.isMe && 'bg-emerald-400/10'
+						]}
+						data-open-seat={row.isOpenSeat}
+					>
+						<span
+							class={[
+								'mt-0.5 flex h-6 w-6 shrink-0 flex-col items-center justify-center rounded',
+								row.isOpenSeat ? 'border border-dashed border-white/30' : 'bg-white/10'
+							]}
+							title="seat {row.seat} — {row.rotationDeg}°"
+						>
+							<span class="text-[0.65rem] leading-none font-bold">{row.seat}</span>
+							<span class="text-[0.5rem] leading-none opacity-60">{row.rotationDeg}°</span>
+						</span>
+
+						<span class="min-w-0 flex-1">
+							{#if row.isOpenSeat}
+								<span class="block italic">Seat {row.seat} — open</span>
+							{:else}
+								<span class="flex items-baseline gap-1">
+									<span class="truncate font-medium" title={row.id}>{row.id}</span>
+									{#if row.isMe}
+										<span class="shrink-0 text-[0.6rem] text-emerald-300 uppercase">you</span>
+									{/if}
+								</span>
+								<span class="block opacity-70">
+									hand {row.handCount}{#if row.tableCount > 0}&nbsp;· table {row.tableCount}{/if}
+								</span>
+							{/if}
+							{#if row.decks.length > 0}
+								<span class="block opacity-70">{deckLine(row.decks)}</span>
+							{/if}
+						</span>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</div>
+</div>

--- a/src/lib/hud/__tests__/PlayerHud.test.ts
+++ b/src/lib/hud/__tests__/PlayerHud.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte';
+import PlayerHud from '../PlayerHud.svelte';
+import { gameStore } from '$lib/store/game/gameStore.svelte';
+import type { GameDTO } from '$lib/store/game/types';
+
+const card = {
+	position: [0, 0, 0] as [number, number, number],
+	rotation: [0, 0, 0] as [number, number, number],
+	faceImageUrl: 'face.png'
+};
+
+const state: Partial<GameDTO> = {
+	players: {
+		me: { id: 'me', seat: 0, joinTimestamp: 10, tray: { 'card:me:main-1': card }, metadata: {} },
+		them: {
+			id: 'them',
+			seat: 1,
+			joinTimestamp: 20,
+			tray: { 'card:them:secret-ace': card, 'card:them:secret-king': card },
+			metadata: {}
+		},
+		seat2: { id: 'seat2', seat: 2, joinTimestamp: 0, tray: {}, metadata: {} }
+	},
+	decks: {
+		'deck:them:main': {
+			id: 'deck:them:main',
+			cards: [{ id: 'card:them:main-1', faceImageUrl: 'face.png' }]
+		}
+	},
+	cards: {}
+};
+
+describe('PlayerHud', () => {
+	beforeEach(() => {
+		cleanup();
+		localStorage.clear();
+		localStorage.setItem('myPlayerId', 'me');
+		gameStore.set(state);
+	});
+
+	it('lists every player, marks me, and shows open seats', () => {
+		render(PlayerHud);
+		expect(screen.getByText('me')).toBeTruthy();
+		expect(screen.getByText('them')).toBeTruthy();
+		expect(screen.getByText('you')).toBeTruthy();
+		expect(screen.getByText('Seat 2 — open')).toBeTruthy();
+	});
+
+	it('shows counts only — never another player’s card ids', () => {
+		const { container } = render(PlayerHud);
+		expect(container.textContent).toContain('hand 2');
+		expect(container.textContent).toContain('main');
+		expect(container.textContent).not.toContain('secret-ace');
+		expect(container.textContent).not.toContain('secret-king');
+		expect(container.querySelectorAll('img').length).toBe(0);
+	});
+
+	it('updates live when a card moves from a deck into a tray', async () => {
+		const { container } = render(PlayerHud);
+		expect(container.textContent).toContain('main 1');
+
+		gameStore.set({
+			...state,
+			players: {
+				...state.players,
+				them: { ...state.players!.them, tray: { ...state.players!.them.tray, extra: card } }
+			},
+			decks: { 'deck:them:main': { id: 'deck:them:main', cards: [] } }
+		} as Partial<GameDTO>);
+		await Promise.resolve();
+
+		expect(container.textContent).toContain('hand 3');
+		expect(container.textContent).toContain('main 0');
+	});
+
+	it('collapses to a summary and persists the choice', async () => {
+		const { container, unmount } = render(PlayerHud);
+		await fireEvent.click(screen.getByRole('button'));
+
+		expect(container.textContent).toContain('2 players · 1 open');
+		expect(container.textContent).not.toContain('Seat 2 — open');
+		expect(localStorage.getItem('hud:players:collapsed')).toBe('true');
+
+		// a reload re-reads the flag and starts collapsed
+		unmount();
+		const reloaded = render(PlayerHud);
+		expect(reloaded.container.textContent).not.toContain('Seat 2 — open');
+	});
+
+	it('lets pointer events through everywhere but the HUD box', () => {
+		const { container } = render(PlayerHud);
+		const wrapper = container.querySelector('div');
+		expect(wrapper?.className).toContain('pointer-events-none');
+		expect(wrapper?.firstElementChild?.className).toContain('pointer-events-auto');
+	});
+});

--- a/src/lib/hud/__tests__/players.test.ts
+++ b/src/lib/hud/__tests__/players.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import { derivePlayerRows, summarize, SEAT_ROTATION_DEG } from '../players';
+import type { GameDTO } from '$lib/store/game/types';
+
+const card = {
+	position: [0, 0, 0] as [number, number, number],
+	rotation: [0, 0, 0] as [number, number, number],
+	faceImageUrl: 'face.png'
+};
+
+const deckCards = (n: number, prefix: string) =>
+	Array.from({ length: n }, (_, i) => ({ id: `card:${prefix}-${i}`, faceImageUrl: 'face.png' }));
+
+const state: Partial<GameDTO> = {
+	players: {
+		alice: { id: 'alice', seat: 0, joinTimestamp: 10, tray: { a1: card, a2: card }, metadata: {} },
+		bob: {
+			id: 'bob',
+			seat: 1,
+			joinTimestamp: 20,
+			tray: { b1: card, b2: card, b3: card },
+			metadata: {}
+		},
+		seat2: { id: 'seat2', seat: 2, joinTimestamp: 0, tray: {}, metadata: {} },
+		seat3: { id: 'seat3', seat: 3, joinTimestamp: 0, tray: {}, metadata: {} }
+	},
+	decks: {
+		'deck:alice:main': { id: 'deck:alice:main', cards: deckCards(34, 'alice') },
+		'deck:alice:discard': { id: 'deck:alice:discard', cards: deckCards(6, 'alice-d') },
+		'deck:bob:main': { id: 'deck:bob:main', cards: deckCards(50, 'bob') },
+		'deck:seat2:main': { id: 'deck:seat2:main', cards: deckCards(3, 'seat2') }
+	},
+	cards: {
+		'card:alice:main-1': card,
+		'card:alice:main-2': card,
+		'card:bob:main-7': card
+	}
+};
+
+describe('derivePlayerRows', () => {
+	it('returns one row per player sorted by seat then join time', () => {
+		const rows = derivePlayerRows(state, 'alice');
+		expect(rows.map((r) => r.id)).toEqual(['alice', 'bob', 'seat2', 'seat3']);
+		expect(rows.map((r) => r.seat)).toEqual([0, 1, 2, 3]);
+	});
+
+	it('sorts same-seat players by joinTimestamp', () => {
+		const rows = derivePlayerRows({
+			players: {
+				late: { id: 'late', seat: 0, joinTimestamp: 99, tray: {}, metadata: {} },
+				early: { id: 'early', seat: 0, joinTimestamp: 1, tray: {}, metadata: {} }
+			}
+		});
+		expect(rows.map((r) => r.id)).toEqual(['early', 'late']);
+	});
+
+	it('maps each seat to its table rotation', () => {
+		const rows = derivePlayerRows(state);
+		expect(rows.map((r) => r.rotationDeg)).toEqual([
+			SEAT_ROTATION_DEG[0],
+			SEAT_ROTATION_DEG[1],
+			SEAT_ROTATION_DEG[2],
+			SEAT_ROTATION_DEG[3]
+		]);
+		expect(rows.map((r) => r.rotationDeg)).toEqual([0, 180, 90, 270]);
+	});
+
+	it('counts tray entries as hand size', () => {
+		const rows = derivePlayerRows(state);
+		expect(rows.find((r) => r.id === 'alice')?.handCount).toBe(2);
+		expect(rows.find((r) => r.id === 'bob')?.handCount).toBe(3);
+		expect(rows.find((r) => r.id === 'seat2')?.handCount).toBe(0);
+	});
+
+	it('groups decks by owner from the deck id, sorted by slot', () => {
+		const rows = derivePlayerRows(state);
+		expect(rows.find((r) => r.id === 'alice')?.decks).toEqual([
+			{ slot: 'discard', count: 6 },
+			{ slot: 'main', count: 34 }
+		]);
+		expect(rows.find((r) => r.id === 'bob')?.decks).toEqual([{ slot: 'main', count: 50 }]);
+	});
+
+	it('counts a player’s cards on the table', () => {
+		const rows = derivePlayerRows(state);
+		expect(rows.find((r) => r.id === 'alice')?.tableCount).toBe(2);
+		expect(rows.find((r) => r.id === 'bob')?.tableCount).toBe(1);
+		expect(rows.find((r) => r.id === 'seat3')?.tableCount).toBe(0);
+	});
+
+	it('flags placeholder seats as open and the local player as me', () => {
+		const rows = derivePlayerRows(state, 'bob');
+		expect(rows.filter((r) => r.isOpenSeat).map((r) => r.id)).toEqual(['seat2', 'seat3']);
+		expect(rows.filter((r) => r.isMe).map((r) => r.id)).toEqual(['bob']);
+	});
+
+	it('drops a placeholder row once the seat is claimed', () => {
+		const claimed: Partial<GameDTO> = {
+			...state,
+			players: {
+				alice: state.players!.alice,
+				carol: { id: 'carol', seat: 2, joinTimestamp: 30, tray: { c1: card }, metadata: {} },
+				seat3: state.players!.seat3
+			},
+			decks: { 'deck:carol:main': { id: 'deck:carol:main', cards: deckCards(3, 'carol') } }
+		};
+		const rows = derivePlayerRows(claimed, 'alice');
+		expect(rows.map((r) => r.id)).toEqual(['alice', 'carol', 'seat3']);
+		expect(rows.find((r) => r.id === 'carol')?.isOpenSeat).toBe(false);
+		expect(rows.find((r) => r.id === 'carol')?.decks).toEqual([{ slot: 'main', count: 3 }]);
+	});
+
+	it('never leaks other players’ tray card ids', () => {
+		const rows = derivePlayerRows(state, 'alice');
+		expect(Object.keys(rows.find((r) => r.id === 'bob') ?? {})).not.toContain('tray');
+		expect(JSON.stringify(rows)).not.toContain('b1');
+	});
+
+	it('handles empty and missing state', () => {
+		expect(derivePlayerRows(undefined)).toEqual([]);
+		expect(derivePlayerRows({})).toEqual([]);
+		const sparse = derivePlayerRows({ players: { solo: { id: 'solo' } } });
+		expect(sparse).toEqual([
+			{
+				id: 'solo',
+				seat: 0,
+				rotationDeg: 0,
+				joinTimestamp: 0,
+				isMe: false,
+				isOpenSeat: false,
+				handCount: 0,
+				decks: [],
+				tableCount: 0
+			}
+		]);
+	});
+});
+
+describe('summarize', () => {
+	it('counts seated players and open seats', () => {
+		expect(summarize(derivePlayerRows(state))).toBe('2 players · 2 open');
+	});
+
+	it('uses the singular for one player and omits empty open seats', () => {
+		const rows = derivePlayerRows({
+			players: { solo: { id: 'solo', seat: 0, joinTimestamp: 1, tray: {}, metadata: {} } }
+		});
+		expect(summarize(rows)).toBe('1 player');
+	});
+});

--- a/src/lib/hud/players.ts
+++ b/src/lib/hud/players.ts
@@ -1,0 +1,117 @@
+/**
+ * Derivation for the player HUD: turn a GameDTO snapshot into one row per
+ * player at the table.
+ *
+ * Everything here is read-only and comes from state that already syncs to
+ * every client — entity ids encode ownership (`deck:<playerId>:<slot>`,
+ * `card:<playerId>:…`), so an opponent's hand size and deck counts are
+ * derivable without any new wire messages.
+ *
+ * Only counts are exposed for other players. Card faces/ids of somebody
+ * else's tray must never leave this module.
+ */
+
+import { isSeatPlaceholder } from '$lib/scenario/scenario';
+import type { GameDTO } from '$lib/store/game/types';
+
+/** Table rotation each seat index maps to — see `SeatState` in store/game/types.ts */
+export const SEAT_ROTATION_DEG: Record<number, number> = {
+	0: 0,
+	1: 180,
+	2: 90,
+	3: 270
+};
+
+export type DeckCount = {
+	/** the `<slot>` part of `deck:<playerId>:<slot>` */
+	slot: string;
+	count: number;
+};
+
+export type PlayerHudRow = {
+	/** player id, or the `seat0`–`seat3` placeholder id for an open seat */
+	id: string;
+	seat: number;
+	rotationDeg: number;
+	joinTimestamp: number;
+	/** this client's own player */
+	isMe: boolean;
+	/** a `seat0`–`seat3` placeholder — nobody is sitting here yet */
+	isOpenSeat: boolean;
+	/** number of cards in the tray (hand); counts only, never the cards */
+	handCount: number;
+	/** decks owned by this player, sorted by slot */
+	decks: DeckCount[];
+	/** cards owned by this player currently on the table */
+	tableCount: number;
+};
+
+/** `deck:alice:main` → `alice`; ids without an owner segment return undefined. */
+function ownerOf(entityId: string): string | undefined {
+	const parts = entityId.split(':');
+	return parts.length >= 3 ? parts[1] : undefined;
+}
+
+/** `deck:alice:main` → `main`; falls back to the whole id when it is malformed. */
+function slotOf(deckId: string): string {
+	const parts = deckId.split(':');
+	return parts.length >= 3 ? parts.slice(2).join(':') : deckId;
+}
+
+function countOwnedBy(ids: string[]): Record<string, number> {
+	const counts: Record<string, number> = {};
+	for (const id of ids) {
+		const owner = ownerOf(id);
+		if (!owner) continue;
+		counts[owner] = (counts[owner] ?? 0) + 1;
+	}
+	return counts;
+}
+
+/**
+ * One row per player in the lobby, sorted by seat then join time.
+ * Placeholder seats (`seat0`–`seat3`) come through as `isOpenSeat` rows.
+ */
+export function derivePlayerRows(
+	state: Partial<GameDTO> | undefined | null,
+	myId?: string | null
+): PlayerHudRow[] {
+	const players = state?.players ?? {};
+
+	const decksByOwner: Record<string, DeckCount[]> = {};
+	for (const [deckId, deck] of Object.entries(state?.decks ?? {})) {
+		const owner = ownerOf(deckId);
+		if (!owner || !deck) continue;
+		(decksByOwner[owner] ??= []).push({ slot: slotOf(deckId), count: deck.cards?.length ?? 0 });
+	}
+	for (const decks of Object.values(decksByOwner))
+		decks.sort((a, b) => a.slot.localeCompare(b.slot));
+
+	const tableByOwner = countOwnedBy(Object.keys(state?.cards ?? {}));
+
+	return Object.entries(players)
+		.filter(([, player]) => !!player)
+		.map(([id, player]) => {
+			const seat = player?.seat ?? 0;
+			return {
+				id,
+				seat,
+				rotationDeg: SEAT_ROTATION_DEG[seat] ?? 0,
+				joinTimestamp: player?.joinTimestamp ?? 0,
+				isMe: !!myId && id === myId,
+				isOpenSeat: isSeatPlaceholder(id),
+				handCount: Object.keys(player?.tray ?? {}).length,
+				decks: decksByOwner[id] ?? [],
+				tableCount: tableByOwner[id] ?? 0
+			};
+		})
+		.sort((a, b) => a.seat - b.seat || a.joinTimestamp - b.joinTimestamp);
+}
+
+/** `3 players` / `1 player` — the collapsed header summary. */
+export function summarize(rows: PlayerHudRow[]): string {
+	const seated = rows.filter((row) => !row.isOpenSeat).length;
+	const open = rows.length - seated;
+	const players = `${seated} player${seated === 1 ? '' : 's'}`;
+	return open > 0 ? `${players} · ${open} open` : players;
+}

--- a/src/routes/play/+page.svelte
+++ b/src/routes/play/+page.svelte
@@ -12,6 +12,7 @@
 	import Pane from './Pane.svelte';
 	import { page } from '$app/state';
 	import PaneDecks from './PaneDecks.svelte';
+	import PlayerHud from '$lib/hud/PlayerHud.svelte';
 	import toast from 'svelte-french-toast';
 
 	function handleKeyDown(event: KeyboardEvent) {
@@ -71,6 +72,7 @@
 
 <Pane />
 <PaneDecks />
+<PlayerHud />
 
 <div
 	class="h-screen w-screen overflow-clip transition-all"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,9 @@ import { sveltekit } from '@sveltejs/kit/vite';
 
 export default defineConfig({
   plugins: [sveltekit()],
+  // svelte resolves to its server build by default, which cannot mount()
+  // components — component tests need the browser build
+  resolve: { conditions: ['browser'] },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
Task: tableplace-29

Closes #29

## What

A read-only player HUD on `/play` (`src/lib/hud/PlayerHud.svelte`), mounted next to `<Pane />` / `<PaneDecks />`. One row per player, sorted by seat then `joinTimestamp`:

- **seat** badge with the seat index and its table rotation (0°/180°/90°/270°)
- **player** id, with a `YOU` marker for `gameActions.getMyId()`
- **hand** — `Object.keys(player.tray).length`
- **table** — cards owned by that player currently on the table
- **decks** — `main 34 · discard 6`, from `deck:<playerId>:<slot>`

Placeholder players (`seat0`–`seat3`) render as dimmed, italic "Seat N — open" rows with a dashed badge; they drop out of the list as each seat is claimed.

All of it derives from already-synced state (`GameDTO.players` / `.decks` / `.cards` plus id ownership conventions) — no server, wire-protocol, or DTO changes. Counts only: another player's tray card ids and faces are never rendered.

The derivation lives in `src/lib/hud/players.ts` so it is testable on its own.

## Behaviour

- Anchored top-right; the wrapper is `pointer-events-none` and only the HUD box is `pointer-events-auto`, so dragging cards under it still works.
- Click the header to collapse to `2 players · 2 open`; the choice persists in `localStorage['hud:players:collapsed']`.

## Verified

- `bun run test` — 46 pass, including a `GameDTO`-fixture unit test for the derivation (hand size, deck grouping, table counts, placeholder filtering, sorting) and a jsdom render test for the component (live update, collapse persistence, no card ids leaked, pointer-events).
- `bun run check` — 0 errors (8 pre-existing warnings in `Card.svelte`/`Piece.svelte`).
- End-to-end against the real Go server: a second client joined `?lobby=…` over the websocket and drew a card from its deck into its tray — the opponent's row went `hand 0 / main 3` → `hand 1 / main 2` live, no reload. A 1440×900 screenshot confirms the HUD clears the Settings (x=0, w=300) and Decks (x=310, w=300) panes.
- `bun run lint` still fails, but identically to `main` (29 files with pre-existing prettier drift, 59 pre-existing eslint errors). Every file touched here is clean under both `prettier --check` and `eslint`; reformatting the rest of the repo felt out of scope for this ticket — happy to do it as a separate commit if you want.

## Note on one non-obvious change

`vitest.config.ts` gains `resolve: { conditions: ['browser'] }`. Without it svelte resolves to its server build and `mount()` throws, so no component can be rendered in a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1ba6Jshcz19T8MuZTRU8c