### PR TITLE
tableplace-31: Spawn primitives by hand — tokens, pawns and health-dial counters

### DIFF
--- a/src/lib/HUDPieces.svelte
+++ b/src/lib/HUDPieces.svelte
@@ -1,0 +1,89 @@
+<!--
+	Spawn/remove table pieces. Shared by the /play settings pane and the
+	/setup scenario editor so the two surfaces can't drift — each route only
+	supplies the owner id (my player id vs. the edited seat's placeholder).
+-->
+<script lang="ts">
+	import {
+		AutoValue,
+		Button,
+		Color,
+		Folder,
+		List,
+		Text,
+		TabGroup,
+		TabPage
+	} from 'svelte-tweakpane-ui';
+	import { gameStore } from '$lib/store/game/gameStore.svelte';
+	import { gameActions } from '$lib/store/game/actions';
+	import { COUNTER_MAX_DEFAULT } from '$lib/utils/constants-pieces';
+	import type { PieceKind } from '$lib/store/game/types';
+	import toast from 'svelte-french-toast';
+
+	let {
+		ownerId,
+		expanded = false,
+		beforeSpawn
+	}: {
+		/** owner segment of the new piece id — `getMyId()` on /play, `seatPlaceholderId()` on /setup */
+		ownerId?: string;
+		expanded?: boolean;
+		/** run before spawning (the scenario editor ensures its seat placeholder exists) */
+		beforeSpawn?: () => void;
+	} = $props();
+
+	const kindOptions: Record<string, PieceKind> = {
+		Token: 'token',
+		Pawn: 'pawn',
+		Counter: 'counter'
+	};
+
+	let kind: PieceKind = $state('token');
+	let name = $state('');
+	let color = $state('#c8c4b8');
+	let imageUrl = $state('');
+	let maxValue = $state(COUNTER_MAX_DEFAULT);
+
+	// every piece on the table, any owner — TTS imports included
+	const pieceIds = $derived(
+		Object.keys($gameStore?.pieces ?? {}).filter((key) => $gameStore?.pieces?.[key])
+	);
+
+	function spawn() {
+		beforeSpawn?.();
+		const id = gameActions.addPiece(kind, {
+			ownerId,
+			name: name.trim() || undefined,
+			color,
+			imageUrl: kind === 'token' ? imageUrl.trim() || undefined : undefined,
+			maxValue: kind === 'counter' ? maxValue : undefined
+		});
+		if (!id) return toast.error('Could not spawn — no player id yet');
+		toast(`Spawned ${id.split(':').slice(2).join(':')}`);
+	}
+</script>
+
+<Folder title="Pieces" {expanded}>
+	<List label="Kind" bind:value={kind} options={kindOptions} />
+	<Text label="Name" bind:value={name} />
+	<Color label="Color" bind:value={color} />
+	{#if kind === 'token'}
+		<Text label="Image URL" bind:value={imageUrl} />
+	{/if}
+	{#if kind === 'counter'}
+		<AutoValue label="Max value" bind:value={maxValue} />
+	{/if}
+	<Button title="Spawn {kind}" on:click={spawn} />
+	{#if pieceIds.length > 0}
+		<TabGroup>
+			{#each pieceIds as pieceId (pieceId)}
+				{@const piece = $gameStore?.pieces?.[pieceId]}
+				<TabPage title={pieceId.split(':').slice(2).join(':')}>
+					<Text label="kind" value={piece?.kind ?? ''} disabled />
+					<Text label="owner" value={pieceId.split(':')[1] ?? ''} disabled />
+					<Button title="Remove" on:click={() => gameActions.removePiece(pieceId)} />
+				</TabPage>
+			{/each}
+		</TabGroup>
+	{/if}
+</Folder>

--- a/src/lib/__tests__/HUDPieces.test.ts
+++ b/src/lib/__tests__/HUDPieces.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The Pieces pane is shared by /play and /setup, so a break here breaks both.
+ * Drives the real tweakpane controls in jsdom rather than calling the actions
+ * directly — that's what proves the pane is wired to the store.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import HUDPieces from '../HUDPieces.svelte';
+import { gameStore } from '../store/game/gameStore.svelte';
+
+/** tweakpane renders asynchronously; let its microtasks flush */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 20));
+
+const button = (container: HTMLElement, label: string) =>
+	[...container.querySelectorAll('button')].find((b) => b.textContent?.includes(label));
+
+const labels = (container: HTMLElement) =>
+	[...container.querySelectorAll('.tp-lblv_l')].map((el) => el.textContent);
+
+/** tweakpane's List binds by option index, not by value */
+function selectKind(container: HTMLElement, index: number) {
+	const select = container.querySelector('select') as HTMLSelectElement;
+	select.selectedIndex = index;
+	select.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+async function mount(ownerId = 'seat0') {
+	const { container } = render(HUDPieces, { props: { ownerId, expanded: true } });
+	await settle();
+	return container;
+}
+
+describe('HUDPieces', () => {
+	beforeEach(() => {
+		gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {} });
+	});
+
+	it('spawns a token for the owner it was given', async () => {
+		const container = await mount('seat0');
+		expect(button(container, 'Spawn token')).toBeTruthy();
+
+		button(container, 'Spawn')!.click();
+		await settle();
+
+		expect(get(gameStore).pieces).toMatchObject({
+			'piece:seat0:token-0': { kind: 'token', radius: 0.75 }
+		});
+	});
+
+	it('swaps the kind-specific controls and spawns a full counter', async () => {
+		const container = await mount();
+		expect(labels(container)).toContain('Image URL'); // token-only
+		expect(labels(container)).not.toContain('Max value');
+
+		selectKind(container, 2); // Token, Pawn, Counter
+		await settle();
+
+		expect(labels(container)).toContain('Max value'); // counter-only
+		expect(labels(container)).not.toContain('Image URL');
+		expect(button(container, 'Spawn counter')).toBeTruthy();
+
+		button(container, 'Spawn')!.click();
+		await settle();
+
+		expect(get(gameStore).pieces?.['piece:seat0:counter-0']).toMatchObject({
+			kind: 'counter',
+			value: 20,
+			maxValue: 20
+		});
+	});
+
+	it('lists and removes every piece on the table, whoever owns it', async () => {
+		gameStore.set({
+			players: {},
+			pieces: { 'piece:someone-else:imported-0': { kind: 'pawn', name: 'From TTS' } }
+		});
+		const container = await mount('seat0');
+
+		expect(button(container, 'Remove')).toBeTruthy();
+		button(container, 'Remove')!.click();
+		await settle();
+
+		expect(get(gameStore).pieces).toEqual({});
+	});
+});

--- a/src/lib/scenario/__tests__/scenario-pieces.test.ts
+++ b/src/lib/scenario/__tests__/scenario-pieces.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Hand-spawned pieces have to survive the whole scenario pipeline:
+ * /setup spawn → save → load → export/import → seed a lobby → claim the seat.
+ * The last step is why addPiece follows the `kind:owner:slug` id convention.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { gameActions } from '$lib/store/game/actions';
+import {
+	applyScenario,
+	claimSeat,
+	ensureSeatPlaceholder,
+	getScenario,
+	importScenarioFromText,
+	saveScenario,
+	seatPlaceholderId
+} from '../scenario';
+
+function buildSeatZeroTable() {
+	gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {} });
+	ensureSeatPlaceholder(0);
+	const owner = seatPlaceholderId(0);
+	return {
+		token: gameActions.addPiece('token', {
+			ownerId: owner,
+			name: 'Objective',
+			imageUrl: 'https://example.com/objective.png'
+		}),
+		counter: gameActions.addPiece('counter', { ownerId: owner, name: 'HP', maxValue: 25 })
+	};
+}
+
+describe('scenario round-trip with hand-spawned pieces', () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	it('saves and reloads pieces', () => {
+		const { token, counter } = buildSeatZeroTable();
+		const before = get(gameStore).pieces;
+		saveScenario('pieces-test');
+
+		gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {} });
+		applyScenario(getScenario('pieces-test')!);
+
+		const after = get(gameStore).pieces ?? {};
+		expect(after).toEqual(before);
+		expect(after[token]).toMatchObject({ imageUrl: 'https://example.com/objective.png' });
+		expect(after[counter]).toMatchObject({ value: 25, maxValue: 25 });
+	});
+
+	it('survives an export/import of the scenario file', () => {
+		buildSeatZeroTable();
+		const saved = saveScenario('pieces-file');
+		// exportScenarioToFile just serializes the scenario
+		const reimported = importScenarioFromText(JSON.stringify(saved, null, '\t'));
+		expect(reimported.state.pieces).toEqual(saved.state.pieces);
+	});
+
+	it('renames piece owners onto the player who claims the seat', () => {
+		const { token, counter } = buildSeatZeroTable();
+		const spawned = get(gameStore).pieces ?? {};
+		saveScenario('pieces-claim');
+
+		// a fresh lobby: my player joins, the preset is seeded, I claim seat 0
+		gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {} });
+		localStorage.setItem('myPlayerId', 'player9');
+		gameActions.addPlayer('player9');
+		applyScenario(getScenario('pieces-claim')!);
+		expect(claimSeat(0)).toBe(true);
+
+		const pieces = get(gameStore).pieces ?? {};
+		expect(Object.keys(pieces).sort()).toEqual(['piece:player9:hp-0', 'piece:player9:objective-0']);
+		// state rides along unchanged; only the owner segment moved
+		expect(pieces['piece:player9:objective-0']).toEqual(spawned[token]);
+		expect(pieces['piece:player9:hp-0']).toEqual(spawned[counter]);
+		expect(get(gameStore).players?.player9?.seat).toBe(0);
+	});
+});

--- a/src/lib/store/__tests__/piece.test.ts
+++ b/src/lib/store/__tests__/piece.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import { gameStore } from '../game/gameStore.svelte';
+import { gameActions } from '../game/actions';
+import { COUNTER_MAX_DEFAULT, PIECE_RADIUS, PIECE_REST_Y } from '$lib/utils/constants-pieces';
+
+const OWNER = 'seat0';
+
+describe('addPiece', () => {
+	beforeEach(() => {
+		gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {} });
+	});
+
+	it('uses the kind:owner:slug id convention so claimSeat can rename the owner', () => {
+		const id = gameActions.addPiece('token', { ownerId: OWNER, name: 'Blast Marker' });
+		expect(id).toBe('piece:seat0:blast-marker-0');
+		expect(id.split(':')[1]).toBe(OWNER);
+	});
+
+	it('disambiguates repeats of the same name', () => {
+		const first = gameActions.addPiece('pawn', { ownerId: OWNER, name: 'Hero' });
+		const second = gameActions.addPiece('pawn', { ownerId: OWNER, name: 'Hero' });
+		expect([first, second]).toEqual(['piece:seat0:hero-0', 'piece:seat0:hero-1']);
+		expect(Object.keys(get(gameStore).pieces ?? {})).toHaveLength(2);
+	});
+
+	it('falls back to the kind when the name has no slug characters', () => {
+		expect(gameActions.addPiece('counter', { ownerId: OWNER, name: '!!!' })).toBe(
+			'piece:seat0:counter-0'
+		);
+	});
+
+	it('applies per-kind defaults', () => {
+		const token = gameActions.addPiece('token', { ownerId: OWNER });
+		const pawn = gameActions.addPiece('pawn', { ownerId: OWNER });
+		const counter = gameActions.addPiece('counter', { ownerId: OWNER });
+		const pieces = get(gameStore).pieces ?? {};
+
+		expect(pieces[token]).toMatchObject({
+			kind: 'token',
+			name: 'Token',
+			radius: PIECE_RADIUS.token
+		});
+		expect(pieces[pawn]).toMatchObject({ kind: 'pawn', name: 'Pawn', radius: PIECE_RADIUS.pawn });
+		expect(pieces[counter]).toMatchObject({ kind: 'counter', radius: PIECE_RADIUS.counter });
+	});
+
+	it('spawns counters full: value = maxValue', () => {
+		const dial = gameActions.addPiece('counter', { ownerId: OWNER, maxValue: 30 });
+		const fallback = gameActions.addPiece('counter', { ownerId: OWNER, name: 'Dial 2' });
+		const pieces = get(gameStore).pieces ?? {};
+
+		expect(pieces[dial]).toMatchObject({ value: 30, maxValue: 30 });
+		expect(pieces[fallback]).toMatchObject({
+			value: COUNTER_MAX_DEFAULT,
+			maxValue: COUNTER_MAX_DEFAULT
+		});
+	});
+
+	it('leaves counter state off non-counters', () => {
+		const id = gameActions.addPiece('token', { ownerId: OWNER, maxValue: 30 });
+		const piece = (get(gameStore).pieces ?? {})[id];
+		expect(piece?.value).toBeUndefined();
+		expect(piece?.maxValue).toBeUndefined();
+	});
+
+	it('carries optional color and image through', () => {
+		const id = gameActions.addPiece('token', {
+			ownerId: OWNER,
+			color: '#ff0000',
+			imageUrl: 'https://example.com/token.png'
+		});
+		expect((get(gameStore).pieces ?? {})[id]).toMatchObject({
+			color: '#ff0000',
+			imageUrl: 'https://example.com/token.png'
+		});
+	});
+
+	it('spawns at piece rest height, seat-relative, fanning sideways', () => {
+		const first = gameActions.addPiece('token', { ownerId: 'seat0', name: 'a' });
+		const second = gameActions.addPiece('token', { ownerId: 'seat0', name: 'b' });
+		const pieces = get(gameStore).pieces ?? {};
+
+		expect(pieces[first]?.position).toEqual([0, PIECE_REST_Y, 4.5]);
+		// second lands beside the first, never on top of it
+		expect(pieces[second]?.position?.[0]).not.toBe(pieces[first]?.position?.[0]);
+		expect(pieces[second]?.position?.[2]).toBe(4.5);
+	});
+
+	it('mirrors the spawn onto the far side for seat 1', () => {
+		const id = gameActions.addPiece('token', { ownerId: 'seat1' });
+		expect((get(gameStore).pieces ?? {})[id]?.position).toEqual([0, PIECE_REST_Y, -4.5]);
+	});
+
+	it('reads the seat off a real player when the owner is not a placeholder', () => {
+		gameStore.set({ players: { alice: { id: 'alice', seat: 1 } }, pieces: {} });
+		const id = gameActions.addPiece('token', { ownerId: 'alice' });
+		expect(id).toBe('piece:alice:token-0');
+		expect((get(gameStore).pieces ?? {})[id]?.position?.[2]).toBe(-4.5);
+	});
+
+	it('honours an explicit position', () => {
+		const id = gameActions.addPiece('pawn', { ownerId: OWNER, position: [1, 2, 3] });
+		expect((get(gameStore).pieces ?? {})[id]?.position).toEqual([1, 2, 3]);
+	});
+
+	it('defaults the owner to the local player', () => {
+		localStorage.setItem('myPlayerId', 'abc123');
+		expect(gameActions.addPiece('token')).toBe('piece:abc123:token-0');
+		localStorage.removeItem('myPlayerId');
+	});
+
+	it('refuses to spawn with no owner at all', () => {
+		localStorage.removeItem('myPlayerId');
+		expect(gameActions.addPiece('token')).toBe('');
+		expect(get(gameStore).pieces).toEqual({});
+	});
+});
+
+describe('removePiece', () => {
+	beforeEach(() => {
+		gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {} });
+	});
+
+	it('drops the piece off the table', () => {
+		const id = gameActions.addPiece('token', { ownerId: OWNER });
+		gameActions.removePiece(id);
+		expect(get(gameStore).pieces?.[id]).toBeUndefined();
+	});
+
+	it('removes pieces that arrived with any id (e.g. a TTS import)', () => {
+		gameStore.set({
+			pieces: {
+				'piece:someone:imported-3': { kind: 'token', name: 'Imported' }
+			}
+		});
+		gameActions.removePiece('piece:someone:imported-3');
+		expect(get(gameStore).pieces).toEqual({});
+	});
+});
+
+describe('incrementCounter', () => {
+	beforeEach(() => {
+		gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {} });
+	});
+
+	it('clamps to [0, maxValue]', () => {
+		const id = gameActions.addPiece('counter', { ownerId: OWNER, maxValue: 3 });
+		gameActions.incrementCounter(id, 5);
+		expect(get(gameStore).pieces?.[id]?.value).toBe(3);
+		gameActions.incrementCounter(id, -10);
+		expect(get(gameStore).pieces?.[id]?.value).toBe(0);
+		gameActions.incrementCounter(id, 2);
+		expect(get(gameStore).pieces?.[id]?.value).toBe(2);
+	});
+});

--- a/src/lib/store/game/actions/piece.ts
+++ b/src/lib/store/game/actions/piece.ts
@@ -1,5 +1,11 @@
 import { get } from 'svelte/store';
+import { gameActions } from '.';
 import { gameStore } from '../gameStore.svelte';
+import { degrees } from '$lib/utils/constants-rotation';
+import { COUNTER_MAX_DEFAULT, PIECE_RADIUS, PIECE_REST_Y } from '$lib/utils/constants-pieces';
+import type { GameDTO, PieceKind } from '../types';
+
+type PieceState = NonNullable<NonNullable<GameDTO['pieces']>[string]>;
 
 function getPieceState(pieceId: string) {
 	return get(gameStore)?.pieces?.[pieceId];
@@ -22,8 +28,115 @@ function incrementCounter(pieceId: string, delta: number) {
 	return gameStore.updateState({ pieces: { [pieceId]: { value } } });
 }
 
+/** Spawns fan sideways in front of the acting seat, wrapping to further rows. */
+const SPAWN_SPACING = 1.6;
+const SPAWN_PER_ROW = 8;
+const SPAWN_EDGE_Z = 4.5;
+
+const KIND_LABEL: Record<PieceKind, string> = {
+	token: 'Token',
+	pawn: 'Pawn',
+	counter: 'Counter'
+};
+
+function slugify(name: string, fallback: string): string {
+	const slug = name
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '');
+	return slug || fallback;
+}
+
+/**
+ * Seat of the acting owner. The scenario editor owns entities with
+ * `seat0`…`seat3` placeholders (see scenario.ts) — matched here by shape
+ * rather than by import, since scenario.ts already imports these actions.
+ */
+function ownerSeat(ownerId: string): number {
+	const placeholder = /^seat([0-3])$/.exec(ownerId);
+	if (placeholder) return Number(placeholder[1]);
+	return get(gameStore)?.players?.[ownerId]?.seat ?? 0;
+}
+
+/** Rotate a seat-local (x, z) offset into world space around the table center */
+function seatToWorld(seat: number, x: number, z: number): [number, number] {
+	const theta = degrees[seat % degrees.length];
+	const cos = Math.cos(theta);
+	const sin = Math.sin(theta);
+	const round = (v: number) => Math.round(v * 1000) / 1000;
+	return [round(x * cos + z * sin), round(z * cos - x * sin)];
+}
+
+function spawnPosition(seat: number, index: number): [number, number, number] {
+	const column = index % SPAWN_PER_ROW;
+	const row = Math.floor(index / SPAWN_PER_ROW);
+	// fan out from the middle of the seat's edge: 0, -1, +1, -2, +2, …
+	const offsetX = Math.ceil(column / 2) * SPAWN_SPACING * (column % 2 === 1 ? -1 : 1);
+	const [x, z] = seatToWorld(seat, offsetX, SPAWN_EDGE_Z - row * SPAWN_SPACING);
+	return [x, PIECE_REST_Y, z];
+}
+
+/** ids are `kind:owner:slug` (claimSeat renames the owner segment) — `-n` disambiguates repeats */
+function nextPieceId(ownerId: string, slug: string): string {
+	const pieces = get(gameStore)?.pieces ?? {};
+	let n = 0;
+	while (pieces[`piece:${ownerId}:${slug}-${n}`]) n++;
+	return `piece:${ownerId}:${slug}-${n}`;
+}
+
+export type AddPieceOptions = {
+	name?: string;
+	color?: string;
+	/** resolved like card faces — a plain https:// url works */
+	imageUrl?: string;
+	radius?: number;
+	/** counters only; the piece spawns full (`value = maxValue`) */
+	maxValue?: number;
+	/** defaults to the local player; the scenario editor passes placeholder seat ids */
+	ownerId?: string;
+	position?: [number, number, number];
+};
+
+/**
+ * Spawn a token / pawn / counter in front of the acting seat.
+ * Goes through updateState, so /play broadcasts to the lobby and /setup
+ * stays local. Returns the new piece id ('' if there's no owner to spawn for).
+ */
+function addPiece(kind: PieceKind, opts: AddPieceOptions = {}): string {
+	const ownerId = opts.ownerId || gameActions.getMyId();
+	if (!ownerId) {
+		console.error('Cannot add a piece without an owner id');
+		return '';
+	}
+
+	const name = opts.name?.trim() || KIND_LABEL[kind];
+	const id = nextPieceId(ownerId, slugify(name, kind));
+	const owned = Object.keys(get(gameStore)?.pieces ?? {}).filter((key) =>
+		key.includes(`:${ownerId}:`)
+	).length;
+
+	const piece: Partial<PieceState> = {
+		kind,
+		name,
+		position: opts.position ?? spawnPosition(ownerSeat(ownerId), owned),
+		rotation: [0, 0, 0],
+		radius: opts.radius ?? PIECE_RADIUS[kind]
+	};
+	if (opts.color) piece.color = opts.color;
+	if (opts.imageUrl) piece.imageUrl = opts.imageUrl;
+	if (kind === 'counter') {
+		const maxValue = opts.maxValue ?? COUNTER_MAX_DEFAULT;
+		piece.maxValue = maxValue;
+		piece.value = maxValue;
+	}
+
+	gameStore.updateState({ pieces: { [id]: piece } });
+	return id;
+}
+
 export const pieceActions = {
 	getPieceState,
+	addPiece,
 	removePiece,
 	movePiece,
 	incrementCounter

--- a/src/lib/store/game/types.ts
+++ b/src/lib/store/game/types.ts
@@ -50,10 +50,12 @@ type PlayerDTO = SeatState & {
  * Non-card table objects (tokens, pawns, counters). One generic shape
  * with a kind discriminator — see SPEC.md §4a.
  */
+export type PieceKind = 'token' | 'pawn' | 'counter';
+
 type PieceDTO = {
 	position: [number, number, number];
 	rotation: [number, number, number];
-	kind: 'token' | 'pawn' | 'counter';
+	kind: PieceKind;
 	name: string;
 	/** hex tint; pawns/counters without images render in this color */
 	color?: string;

--- a/src/lib/tts/import.ts
+++ b/src/lib/tts/import.ts
@@ -8,6 +8,7 @@ import { gameActions } from '$lib/store/game/actions';
 import { CARD_BACK_DEFAULT } from '$lib/packs';
 import { makeSheetRef, prewarmSheetRef } from '$lib/packs/resolve.svelte';
 import { CARD_REST_Y } from '$lib/utils/constants-cards';
+import { PIECE_REST_Y } from '$lib/utils/constants-pieces';
 import { parseSavedObject, type ParsedCard } from './parse';
 import { sliceCell } from './slice';
 
@@ -134,7 +135,6 @@ export async function importTtsFile(
 	// tokens / pawns / counters land at their (mirrored) TTS table positions.
 	// TTS stacks health dials exactly on top of their pawn/token — offset
 	// counters sideways so they're visible and clickable next to their owner.
-	const PIECE_REST_Y = 0.255 + 0.08;
 	parsed.pieces.forEach((piece, i) => {
 		report.pieces += 1;
 		const offsetX = piece.kind === 'counter' ? 1.5 : 0;

--- a/src/lib/utils/constants-pieces.ts
+++ b/src/lib/utils/constants-pieces.ts
@@ -11,3 +11,18 @@ export const PIECE_DEFAULT_RADIUS = 0.75;
 
 /** Height a piece floats at while being dragged */
 export const PIECE_DRAG_Y = 1.2;
+
+/**
+ * Radius a hand-spawned piece is given per kind. Tokens and counters are flat
+ * discs; pawns are procedural (base + stem + head) but sized off the same
+ * radius. These match what the TTS parser assigns, so imported and
+ * hand-spawned pieces of the same kind come out the same size.
+ */
+export const PIECE_RADIUS = {
+	token: PIECE_DEFAULT_RADIUS,
+	pawn: 0.3,
+	counter: 0.6
+} as const;
+
+/** Starting max for a hand-spawned health dial */
+export const COUNTER_MAX_DEFAULT = 20;

--- a/src/routes/play/Pane.svelte
+++ b/src/routes/play/Pane.svelte
@@ -26,6 +26,7 @@
 		type SeatIndex
 	} from '$lib/scenario/scenario';
 	import { List } from 'svelte-tweakpane-ui';
+	import HUDPieces from '$lib/HUDPieces.svelte';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import toast from 'svelte-french-toast';
@@ -154,6 +155,7 @@
 			value={`Build presets at /setup. Seeding replaces the table for the whole lobby; each player then claims a seat to take over its decks.`}
 		/>
 	</Folder>
+	<HUDPieces ownerId={gameActions.getMyId() ?? undefined} />
 	<Folder title="Overlays" expanded={false}>
 		<Button title="Clear overlay" on:click={clearOverlay} />
 		<Text label="Image URL" bind:value={imageUrl}></Text>

--- a/src/routes/setup/SetupPane.svelte
+++ b/src/routes/setup/SetupPane.svelte
@@ -31,6 +31,7 @@
 		importScenarioFromText,
 		type SeatIndex
 	} from '$lib/scenario/scenario';
+	import HUDPieces from '$lib/HUDPieces.svelte';
 	import { purgeUndefinedValues } from '$lib/utils/transforms/data';
 	import { DEG2RAD } from 'three/src/math/MathUtils.js';
 	import type { GameDTO } from '$lib/store/game/types';
@@ -249,6 +250,10 @@
 			</TabGroup>
 		</Folder>
 	{/if}
+	<HUDPieces
+		ownerId={seatPlaceholderId(activeSeat)}
+		beforeSpawn={() => ensureSeatPlaceholder(activeSeat)}
+	/>
 	<Folder title="Overlay (map)" expanded={false}>
 		<Text label="Image URL" bind:value={imageUrl}></Text>
 		<Point bind:value={point3d} label="Position" />


### PR DESCRIPTION
Task: tableplace-31

Closes #31

## What

Pieces could only reach the table as a side effect of a TTS import, and no UI could remove one. Both HUD panes now have a **Pieces** section that spawns and removes them.

### `addPiece(kind, opts)` — `store/game/actions/piece.ts`

- Ids follow the repo's `kind:owner:slug` convention: `piece:<ownerId>:<slug>-<n>`, so `claimSeat()` renames the owner segment onto the claiming player and a piece spawned under a placeholder seat follows that seat into a lobby.
- Owner defaults to `getMyId()`; `/setup` passes `seatPlaceholderId(activeSeat)`.
- Per-kind defaults match the TTS parser — token `0.75`, pawn `0.3`, counter `0.6` + `maxValue` (default 20) spawning full at `value = maxValue`.
- Seat-relative spawn at `PIECE_REST_Y`: the first piece lands in front of the acting seat, later ones fan sideways (0, −1, +1, −2, …) and wrap to further rows, so they never stack.
- Goes through `gameStore.updateState` — `/play` broadcasts to the lobby, `/setup` stays local. No websocket work.

### Shared pane — `src/lib/HUDPieces.svelte`

One `<Folder title="Pieces">` rendered by both `routes/play/Pane.svelte` and `routes/setup/SetupPane.svelte`; the routes differ only in the owner id they pass, so the two surfaces can't drift. Kind picker, name, color swatch, image URL (tokens only, resolved through `resolveCardImage`), max value (counters only), Spawn, and a `TabGroup` of every piece on the table — TTS imports included — each with a Remove button.

### Cleanup

`PIECE_REST_Y` existed three times (`Piece.svelte`, `Table.svelte`, `tts/import.ts`); it, the thickness and the per-kind radii now live in `utils/constants-pieces.ts`.

## Rebased onto #34 + #35 + #32

Three conflicts, all resolved by taking `main`:

- **`Piece.svelte`** — #35 made the identical `PIECE_THICKNESS` / `PIECE_REST_Y` lift, plus `PIECE_DRAG_Y`. Took theirs wholesale and dropped my per-kind radius *fallback*, so the rendered piece and `resolveDrop()`'s footprint agree on `PIECE_DEFAULT_RADIUS`. `addPiece` still writes an explicit per-kind radius, which `resolveDrop` reads — a hand-spawned pawn previews as a 0.3 circle, not the 0.75 fallback.
- **`Table.svelte`** — my `PIECE_REST_Y` import is superseded: `handleDragEnd` now routes through `resolveDrop()`, which already returns `PIECE_REST_Y` for `piece:` ids. Took #35's version unchanged.
- **`vitest.config.ts`** — #34 added the same `resolve.conditions` line. Took theirs.

`constants-pieces.ts` was an add/add conflict: the merged file keeps #35's `TABLE_TOP_Y`-derived `PIECE_REST_Y`, `PIECE_DEFAULT_RADIUS` and `PIECE_DRAG_Y`, and adds this branch's `PIECE_RADIUS` map (with `token: PIECE_DEFAULT_RADIUS`, so 0.75 has one source of truth) and `COUNTER_MAX_DEFAULT`.

Net result: the diff is now purely additive apart from two one-line edits (`types.ts`, `tts/import.ts`) and the two pane insertions.

## Verification

`bun run test` — 51 pass (7 files), `bun run check` — 0 errors, `bun run build` clean. New tests:

- `store/__tests__/piece.test.ts` (16) — id format and disambiguation, per-kind defaults, `value = maxValue`, seat-relative placement, owner fallback, remove, counter clamping.
- `__tests__/HUDPieces.test.ts` (3) — drives the real tweakpane controls in jsdom: spawning a token, switching kind (Image URL ↔ Max value, counter spawns at 20/20), and removing a piece that arrived with a foreign owner id.
- `scenario/__tests__/scenario-pieces.test.ts` (3) — save → load, export/import file text, and seed-then-claim renaming `piece:seat0:*` to `piece:player9:*` with state intact.

Component tests need `resolve: { conditions: ['browser'] }` in `vitest.config.ts` — otherwise `mount()` resolves to svelte's server entry. #34 added exactly that line, so it's no longer part of this diff.

Not verified interactively: no browser was available in this environment, so the two-tab lobby sync and the on-table drag were checked by code path (`TableScene`/`Table` already special-case `piece:` ids; the ws wrapper already throttles `pieces` position updates) rather than by hand.

`bun run lint` is red on `main` (unformatted files plus 57 eslint errors) — this branch adds none: eslint is still exactly 57 and every new/changed file passes `prettier --check`. Repo-wide `bun run format` was deliberately *not* committed, since it rewrites the TTS JSON fixtures and would collide with the other live branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LV4JhUoXHaK5DcrdsPsFme
