### PR TITLE
tableplace-40: health dial counter — click/right-click/wheel adjust value

### DIFF
--- a/src/lib/Piece.svelte
+++ b/src/lib/Piece.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { T } from '@threlte/core';
 	import { Billboard, Text, ImageMaterial } from '@threlte/extras';
+	import type { IntersectionEvent } from '@threlte/extras';
 	import { Spring } from 'svelte/motion';
 	import { dragStart, dragStore } from './store/dragStore.svelte';
 	import { gameStore } from './store/game/gameStore.svelte';
@@ -57,25 +58,100 @@
 		planar.current.z
 	]);
 
-	function handlePointerDown(e: { nativeEvent?: PointerEvent } & PointerEvent) {
-		// counters: click adjusts value (shift = decrement); drag still works via move
-		if (kind === 'counter' && (e.shiftKey || e.altKey)) {
-			gameActions.incrementCounter(id, -1);
-			return;
-		}
+	// px the pointer may travel between down and up and still count as a click
+	const DRAG_THRESHOLD_PX = 5;
+
+	let pendingDrag: { x: number; y: number } | null = null;
+	let dragMoved = false;
+
+	function liftIntoDrag() {
 		dragStart(id, position[1]);
 		height.target = PIECE_DRAG_Y;
 	}
 
-	function handleClick(e: PointerEvent) {
+	// Counters defer the lift until the pointer actually travels, so a plain
+	// click can adjust the value without picking the piece up and dropping it.
+	function onPendingMove(ne: PointerEvent) {
+		if (!pendingDrag) return;
+		if (Math.hypot(ne.clientX - pendingDrag.x, ne.clientY - pendingDrag.y) < DRAG_THRESHOLD_PX)
+			return;
+		cancelPendingDrag();
+		dragMoved = true;
+		liftIntoDrag();
+	}
+
+	function cancelPendingDrag() {
+		pendingDrag = null;
+		window.removeEventListener('pointermove', onPendingMove);
+		window.removeEventListener('pointerup', cancelPendingDrag);
+	}
+
+	$effect(() => cancelPendingDrag);
+
+	function handlePointerDown(e: IntersectionEvent<PointerEvent>) {
+		if (e.nativeEvent.button !== 0) return; // right-click is contextmenu, not drag
+		if (kind !== 'counter') {
+			liftIntoDrag();
+			return;
+		}
+		// keep OrbitControls from rotating during the pre-threshold pixels
+		e.stopImmediatePropagation();
+		dragMoved = false;
+		pendingDrag = { x: e.nativeEvent.clientX, y: e.nativeEvent.clientY };
+		window.addEventListener('pointermove', onPendingMove);
+		window.addEventListener('pointerup', cancelPendingDrag);
+	}
+
+	function handleClick(e: IntersectionEvent<MouseEvent>) {
 		if (kind !== 'counter') return;
-		if (e.shiftKey || e.altKey) return; // handled on pointerdown
+		if (dragMoved || e.delta > DRAG_THRESHOLD_PX) return; // was a drag, not a click
+		// click deals damage; shift (or alt) heals
+		const ne = e.nativeEvent;
+		gameActions.incrementCounter(id, ne.shiftKey || ne.altKey ? 1 : -1);
+	}
+
+	function handleContextMenu(e: IntersectionEvent<MouseEvent>) {
+		if (kind !== 'counter') return;
+		e.nativeEvent.preventDefault();
+		if (e.delta > DRAG_THRESHOLD_PX) return;
 		gameActions.incrementCounter(id, 1);
 	}
 
-	const label = $derived(
-		kind === 'counter' ? `${piece?.value ?? piece?.maxValue ?? 0}` : (piece?.name ?? '')
-	);
+	// ±1 per wheel notch; accumulate so trackpads don't spray increments
+	let wheelAccum = 0;
+	const WHEEL_NOTCH = 100;
+	function handleWheel(e: IntersectionEvent<WheelEvent>) {
+		if (kind !== 'counter') return;
+		e.stopImmediatePropagation(); // don't zoom the camera while adjusting
+		const ne = e.nativeEvent;
+		wheelAccum += ne.deltaMode === 1 ? ne.deltaY * (WHEEL_NOTCH / 3) : ne.deltaY;
+		while (wheelAccum >= WHEEL_NOTCH) {
+			wheelAccum -= WHEEL_NOTCH;
+			gameActions.incrementCounter(id, -1);
+		}
+		while (wheelAccum <= -WHEEL_NOTCH) {
+			wheelAccum += WHEEL_NOTCH;
+			gameActions.incrementCounter(id, 1);
+		}
+	}
+
+	const label = $derived.by(() => {
+		if (kind !== 'counter') return piece?.name ?? '';
+		const value = piece?.value ?? piece?.maxValue ?? 0;
+		return piece?.maxValue != null ? `${value}/${piece.maxValue}` : `${value}`;
+	});
+
+	// pulse the label when the value changes (local or remote) so it's noticed
+	const labelScale = new Spring(1, { stiffness: 0.15, damping: 0.5, precision: 0.001 });
+	let prevValue: number | undefined = undefined;
+	$effect(() => {
+		const v = piece?.value;
+		if (prevValue !== undefined && v !== undefined && v !== prevValue) {
+			labelScale.set(1.6, { instant: true });
+			labelScale.target = 1;
+		}
+		prevValue = v;
+	});
 </script>
 
 {#if piece}
@@ -83,6 +159,8 @@
 		{position}
 		onpointerdown={handlePointerDown}
 		onclick={handleClick}
+		oncontextmenu={handleContextMenu}
+		onwheel={handleWheel}
 		onpointerenter={() => (isHovered = true)}
 		onpointerleave={() => (isHovered = false)}
 	>
@@ -122,6 +200,7 @@
 					text={label}
 					fontSize={kind === 'counter' ? 0.55 : 0.35}
 					position={[0, kind === 'pawn' ? 1.5 : 0.75, 0]}
+					scale={kind === 'counter' ? labelScale.current : 1}
 					anchorX="center"
 					color="#ffffff"
 					outlineWidth={0.02}


### PR DESCRIPTION
## Summary

Counters imported from TTS were inert as life trackers: every click just picked the piece up, and the modifier-key checks read `e.shiftKey` off the Threlte `IntersectionEvent` (always `undefined` — modifiers live on `e.nativeEvent`), so the value never changed.

- **Click = −1** (dealing damage is the dominant interaction), **shift/alt-click = +1**, **right-click = +1** with `preventDefault()` on the native event so the browser menu stays closed.
- **Scroll wheel = ±1 per notch** (up increments), with delta accumulation so trackpads don't spray increments and `deltaMode` normalization for line-scrolling browsers. `stopImmediatePropagation()` keeps OrbitControls from zooming underneath.
- **Drag still moves the piece**: counters no longer lift on pointerdown — a window-level pointermove watcher promotes the press to a drag once the pointer travels ≥5px; `e.delta` (plus a `dragMoved` flag for out-and-back paths) suppresses the value change on click. `stopImmediatePropagation()` on pointerdown keeps the camera from rotating during the pre-threshold pixels. Non-counter pieces keep the old lift-on-pointerdown behavior (now left-button only).
- **Label shows `value/max`** (e.g. `14/16`) and pulses via a scale spring whenever the value changes, locally or from a remote player.
- Value changes still sync through `gameStore.updateState` via `incrementCounter`, which already clamps to `0..max` — no store or schema changes.

Task: tableplace-40
Closes #40

## Verification

- `bun run check` — 0 errors (8 pre-existing warnings, unchanged)
- `bunx eslint src/lib/Piece.svelte` — clean; file passes prettier (repo-wide `lint` fails on 26 pre-existing unformatted files, same on clean tree)
- `bun run test` — 63/63 pass
- `bun run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxpAfYsb4RRMrqSYusavFD