### PR TITLE
tableplace-41: rounded card/deck body geometry + stacked-edge deck sides

### DIFF
--- a/src/lib/Card.svelte
+++ b/src/lib/Card.svelte
@@ -14,7 +14,8 @@
 		CARD_HEIGHT,
 		CARD_THICKNESS,
 		CARD_REST_Y,
-		CARD_DRAG_Y
+		CARD_DRAG_Y,
+		cardBodyGeometry
 	} from '$lib/utils/constants-cards';
 	import { resolveCardImage, sheetRefCache } from '$lib/packs';
 	type Vec3Array = [number, number, number];
@@ -144,9 +145,13 @@
 	onpointerleave={handlePointerLeave}
 	onpointerenter={handlePointerEnter}
 >
-	<!-- card body: visible paper edge between the two faces (unlit so side faces never go black) -->
+	<!-- card body: visible paper edge between the two faces (unlit so side faces
+	     never go black). Rounded to match the face's corner radius — a square box
+	     pokes white nubs past the ImageMaterial's alpha-cutout arc. The geometry
+	     is shared across all cards: dispose={false} keeps one card's unmount from
+	     destroying it for everyone. -->
 	<T.Mesh castShadow>
-		<T.BoxGeometry args={[CARD_WIDTH - 0.04, CARD_THICKNESS * 0.92, CARD_HEIGHT - 0.04]} />
+		<T is={cardBodyGeometry} attach="geometry" dispose={false} />
 		<T.MeshBasicMaterial color="#d9d6c9" />
 	</T.Mesh>
 	<!-- key the MESH, not the material: threlte 8.5 material swaps on a live

--- a/src/lib/Deck.svelte
+++ b/src/lib/Deck.svelte
@@ -4,7 +4,15 @@
 	import { Text, Billboard, ImageMaterial, interactivity } from '@threlte/extras';
 	import { dragStart, dragStore, setDeckHover } from '$lib/store/dragStore.svelte';
 	import { degrees } from '$lib/utils/constants-rotation';
-	import { CARD_DRAG_Y, CARD_WIDTH, CARD_HEIGHT } from '$lib/utils/constants-cards';
+	import {
+		CARD_DRAG_Y,
+		CARD_WIDTH,
+		CARD_HEIGHT,
+		deckBodyGeometry,
+		deckHeightForCount
+	} from '$lib/utils/constants-cards';
+	import { createDeckEdgeTexture, deckEdgeRepeatY } from '$lib/utils/deck-edge-texture';
+	import { browser } from '$app/environment';
 	import { DEG2RAD } from 'three/src/math/MathUtils.js';
 	import { gameStore } from './store/game/gameStore.svelte';
 	import { gameActions } from './store/game/actions';
@@ -26,6 +34,23 @@
 	const displayedImage = $derived(
 		resolveCardImage(isFaceUp ? lastCardImage : deckBackImage, $sheetRefCache)
 	);
+
+	// body height tracks how many cards are in the stack (clamped)
+	const height = $derived(deckHeightForCount(cards?.length ?? 0));
+
+	// Stacked-card-edge look for the sides: per-deck texture clone so repeat.y
+	// can track this deck's height (stripes stay one-card-thick as the deck
+	// shrinks). Materials stay UNLIT — side faces must never go black under the
+	// current lighting rig; the stripes supply the depth cue instead.
+	const edgeTexture = browser ? createDeckEdgeTexture() : null;
+	// ExtrudeGeometry has two material groups: 0 = top/bottom lids, 1 = side walls
+	const bodyMaterials = [
+		new THREE.MeshBasicMaterial({ color: '#e2dfd2' }),
+		new THREE.MeshBasicMaterial(edgeTexture ? { map: edgeTexture } : { color: '#e2dfd2' })
+	];
+	$effect(() => {
+		if (edgeTexture) edgeTexture.repeat.y = deckEdgeRepeatY(height);
+	});
 
 	const isHovered = $derived(id === $dragStore.isDeckHovered);
 	// dropping here replaces the table landing entirely, so the deck has to be
@@ -73,7 +98,7 @@
 	</Billboard>
 	{#if cards?.length > 0}
 		{#key displayedImage}
-			<T.Mesh castShadow receiveShadow rotation.x={-Math.PI / 2} position.y={0.21}>
+			<T.Mesh castShadow receiveShadow rotation.x={-Math.PI / 2} position.y={height / 2 + 0.01}>
 				<T.PlaneGeometry args={[1.4, 2]} />
 				<ImageMaterial url={displayedImage} side={2} radius={0.1} opacity={isHovered ? 0.8 : 1} />
 			</T.Mesh>
@@ -92,7 +117,7 @@
 	{/if}
 
 	{#if isDropTarget}
-		<T.Group rotation.x={-Math.PI / 2} position.y={0.23}>
+		<T.Group rotation.x={-Math.PI / 2} position.y={height / 2 + 0.03}>
 			<DropFootprint
 				shape="rect"
 				w={CARD_WIDTH + 0.3}
@@ -105,9 +130,11 @@
 		</T.Group>
 	{/if}
 
-	<!-- deck body: reads as a stack of card edges, not a black slab -->
-	<T.Mesh>
-		<T.BoxGeometry args={[1.38, 0.4, 1.98]} />
-		<T.MeshBasicMaterial color="#e2dfd2" />
+	<!-- deck body: rounded slab (matches the top image's corner radius) whose
+	     sides wear the stacked-card-edge stripes. Unit-height shared geometry,
+	     scaled to this deck's height; dispose={false} keeps one deck's unmount
+	     from destroying the shared geometry for everyone. -->
+	<T.Mesh scale.y={height} material={bodyMaterials}>
+		<T is={deckBodyGeometry} attach="geometry" dispose={false} />
 	</T.Mesh>
 </T.Group>

--- a/src/lib/utils/constants-cards.ts
+++ b/src/lib/utils/constants-cards.ts
@@ -1,3 +1,5 @@
+import * as THREE from 'three';
+
 /**
  * Physical card dimensions in world units.
  * Cards need real thickness so stacked cards never share a plane —
@@ -6,6 +8,85 @@
 export const CARD_WIDTH = 1.4;
 export const CARD_HEIGHT = 2;
 export const CARD_THICKNESS = 0.04;
+
+/** Corner radius of the printed face (ImageMaterial radius prop) */
+export const CARD_CORNER_RADIUS = 0.1;
+
+function roundedRectShape(width: number, height: number, radius: number): THREE.Shape {
+	const w = width / 2;
+	const h = height / 2;
+	const s = new THREE.Shape();
+	s.moveTo(-w + radius, -h);
+	s.lineTo(w - radius, -h);
+	s.absarc(w - radius, -h + radius, radius, -Math.PI / 2, 0, false);
+	s.lineTo(w, h - radius);
+	s.absarc(w - radius, h - radius, radius, 0, Math.PI / 2, false);
+	s.lineTo(-w + radius, h);
+	s.absarc(-w + radius, h - radius, radius, Math.PI / 2, Math.PI, false);
+	s.lineTo(-w, -h + radius);
+	s.absarc(-w + radius, -h + radius, radius, Math.PI, Math.PI * 1.5, false);
+	return s;
+}
+
+/**
+ * Rounded-rect slab lying flat: width along X, height along Z, thickness
+ * along Y, centered on the origin. Extrude side-wall UVs put v along the
+ * thickness axis (v = 1 - z before rotation), so a repeat-wrapped texture's
+ * rows wrap around the sides as horizontal bands.
+ */
+function roundedSlabGeometry(
+	width: number,
+	height: number,
+	radius: number,
+	thickness: number
+): THREE.ExtrudeGeometry {
+	const geometry = new THREE.ExtrudeGeometry(roundedRectShape(width, height, radius), {
+		depth: thickness,
+		bevelEnabled: false,
+		curveSegments: 8
+	});
+	geometry.translate(0, 0, -thickness / 2);
+	geometry.rotateX(-Math.PI / 2);
+	return geometry;
+}
+
+/**
+ * Shared body geometry for every card: inset under the printed face so the
+ * face always overhangs the paper edge, with the corner radius shrunk by the
+ * same inset so the arc stays concentric inside the face's rounded corner.
+ * Static — build once, share across all card instances.
+ */
+const CARD_BODY_INSET = 0.02; // per side
+export const cardBodyGeometry = roundedSlabGeometry(
+	CARD_WIDTH - CARD_BODY_INSET * 2,
+	CARD_HEIGHT - CARD_BODY_INSET * 2,
+	CARD_CORNER_RADIUS - CARD_BODY_INSET,
+	CARD_THICKNESS * 0.92
+);
+
+/**
+ * Shared deck body geometry, unit height (scale the mesh's Y to the deck's
+ * actual height). Side-wall v spans exactly 0..1 over the unit thickness, so
+ * texture.repeat.y = number of stripe-texture repeats across the full height.
+ */
+const DECK_BODY_INSET = 0.01; // per side
+export const deckBodyGeometry = roundedSlabGeometry(
+	CARD_WIDTH - DECK_BODY_INSET * 2,
+	CARD_HEIGHT - DECK_BODY_INSET * 2,
+	CARD_CORNER_RADIUS - DECK_BODY_INSET,
+	1
+);
+
+/**
+ * Deck body height per card, clamped so a huge deck doesn't tower and an
+ * almost-empty pile is still grabbable. 40 cards ≈ the old fixed 0.4 slab.
+ */
+export const DECK_HEIGHT_PER_CARD = 0.01;
+export const DECK_MIN_HEIGHT = 0.1;
+export const DECK_MAX_HEIGHT = 0.5;
+export function deckHeightForCount(count: number): number {
+	return THREE.MathUtils.clamp(count * DECK_HEIGHT_PER_CARD, DECK_MIN_HEIGHT, DECK_MAX_HEIGHT);
+}
 
 /** Resting height of a card lying directly on the table/overlay */
 export const CARD_REST_Y = 0.26;

--- a/src/lib/utils/deck-edge-texture.ts
+++ b/src/lib/utils/deck-edge-texture.ts
@@ -1,0 +1,52 @@
+import * as THREE from 'three';
+import { DECK_HEIGHT_PER_CARD } from './constants-cards';
+
+/**
+ * Procedural stacked-card-edge texture for deck sides: thin horizontal
+ * stripes with per-line lightness jitter around the paper base color.
+ * One shared canvas; each deck gets its own CanvasTexture clone so its
+ * repeat.y can track that deck's height independently.
+ */
+
+/** Stripes drawn into one repeat of the canvas */
+export const DECK_EDGE_STRIPES_PER_REPEAT = 64;
+
+/** World-space thickness of one stripe — one stripe per card in the stack */
+const STRIPE_WORLD_THICKNESS = DECK_HEIGHT_PER_CARD;
+
+let sharedCanvas: HTMLCanvasElement | null = null;
+
+function getStripeCanvas(): HTMLCanvasElement {
+	if (sharedCanvas) return sharedCanvas;
+	const stripePx = 2;
+	const canvas = document.createElement('canvas');
+	canvas.width = 4;
+	canvas.height = DECK_EDGE_STRIPES_PER_REPEAT * stripePx;
+	const ctx = canvas.getContext('2d')!;
+	// base paper color (#e2dfd2 ≈ hsl(48, 22%, 85%))
+	for (let i = 0; i < DECK_EDGE_STRIPES_PER_REPEAT; i++) {
+		const lightness = 85 + (Math.random() * 14 - 9); // jitter, biased slightly dark
+		ctx.fillStyle = `hsl(48, 22%, ${lightness}%)`;
+		ctx.fillRect(0, i * stripePx, canvas.width, stripePx);
+	}
+	sharedCanvas = canvas;
+	return canvas;
+}
+
+/** Create a deck-side texture. Browser only — call from component init. */
+export function createDeckEdgeTexture(): THREE.CanvasTexture {
+	const texture = new THREE.CanvasTexture(getStripeCanvas());
+	texture.wrapS = THREE.RepeatWrapping;
+	texture.wrapT = THREE.RepeatWrapping;
+	texture.colorSpace = THREE.SRGBColorSpace;
+	return texture;
+}
+
+/**
+ * repeat.y that keeps stripes at constant world thickness (≈ one card edge)
+ * regardless of deck height. The unit-height deck geometry maps v 0..1 over
+ * the full side, so repeats = height / (stripes-per-repeat × stripe size).
+ */
+export function deckEdgeRepeatY(height: number): number {
+	return height / (DECK_EDGE_STRIPES_PER_REPEAT * STRIPE_WORLD_THICKNESS);
+}


### PR DESCRIPTION
Task: tableplace-41
Closes #41

## Problem
1. **Jagged card corners** — card/deck faces round their corners via ImageMaterial's `radius={0.1}` alpha cutout, but the paper-edge body underneath was a square `BoxGeometry`, so its sharp corners poked out past the arc as white nubs.
2. **Deck sides were a blank void** — a single flat unlit color, no depth cue.
3. Deck body height was fixed at 0.4 regardless of card count.

## Changes
- **Shared rounded body geometry** (`constants-cards.ts`): rounded-rect `THREE.Shape` → `ExtrudeGeometry`, built once and shared across all cards/decks (`dispose={false}` on the meshes so one unmount can't destroy it for everyone). Bodies stay inset under the printed face, with the corner radius shrunk by the same inset so the arc stays concentric inside the face's 0.1-radius cutout.
- **Stacked-card-edge deck sides** (`deck-edge-texture.ts`): procedural `CanvasTexture` of thin horizontal stripes with per-line lightness jitter around the paper base color, one shared canvas. ExtrudeGeometry's two material groups get `[lid, side]` unlit `MeshBasicMaterial`s — sides can never go black under the current lighting rig. Each deck clones the texture so `repeat.y` tracks that deck's height, keeping stripes ≈ one card thick.
- **Deck height tracks card count**: `0.01/card`, clamped to `0.1..0.5` (40 cards ≈ the old fixed 0.4 slab). Top image plane and drop-footprint reposition at `height/2 + ε`.

Untouched per ticket: flip/facedown visibility, drag/spring behavior, mesh-level `{#key}` conventions (threlte 8.5 material-swap bug), the zero-size preload plane, and the Billboard count label.

## Verification
- `bun run check`: 0 errors · `bun run test`: 63/63 pass · `bun run build`: succeeds (prerender exercises the SSR path — texture creation is `browser`-guarded)
- Script-verified against the actual geometry: side-wall UV `v` spans exactly 0..1 along the thickness axis (stripes wrap, don't smear), material groups are `[lids, sides]` in that order, card body bbox is the same 1.36 × 0.0368 × 1.96 envelope as the old box, and heights clamp 3→0.1 / 40→0.4 / 80→0.5.
- Pre-existing repo-wide prettier/eslint failures (26 files) are untouched; the 4 files in this diff pass both.
- Not done: in-browser visual pass (Chrome extension not connected in this session) — worth a quick look at the low-angle and close-up angles from the ticket screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8J1H5FDCxoimAfuT71F1M