### PR TITLE
tableplace-37: hidden state stops leaving the server

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -175,7 +175,37 @@ Discrete actions and continuous drags have opposite needs, so they ride the same
 | Persistence | Applied to canonical `GameDTO`, snapshotted | Never persisted |
 | Rate | Occasional | 20–30 Hz per held object |
 
-**Drag lifecycle:** `grab(objectId)` action → server grants a *hold lease* (`held_by`; concurrent grabs rejected — no two players fight over one card) → holder streams `move {objectId, seq, pos, rot}` → server stamps + fans out, drops stale seqs → `drop(objectId, finalTransform)` action ends the lease and persists the result. Leases auto-expire on disconnect (object stays at last streamed position via a server-synthesized drop).
+**Drag lifecycle:** `grab(objectId)` action → server grants a *hold lease* (`heldBy`; concurrent grabs rejected — no two players fight over one card) → holder streams `move {objectId, seq, pos, rot}` → server stamps + fans out, drops stale seqs → `drop(objectId, finalTransform)` action ends the lease and persists the result. Leases auto-expire on disconnect (object stays at last streamed position via a server-synthesized drop) and after a 60s TTL, so a wedged tab can't park a card out of reach. `heldBy` rides on the entity itself, so every client can render "someone else has this" and refuse to start its own drag.
+
+### 4e. Hidden information
+
+Facedown is a *data* boundary, not a render flag. The rule: **hidden state never leaves the server for a player not entitled to it**, so secrecy holds against devtools, not just against the UI.
+
+**The model.** Cards carry a visibility descriptor rather than having their secrecy inferred from rotation:
+
+```typescript
+type CardVisibility =
+  | { kind: 'public' }                        // face-up: anyone may see the face
+  | { kind: 'hidden'; seenBy?: string[] };    // only the listed players may
+```
+
+Facedown on the table = hidden to all. In a hand = hidden to everyone but its owner. Peeked = hidden, with the peeker in `seenBy`. State with no descriptor (a scenario file, an older client) falls back to orientation — facedown reads as hidden, which is the safe direction. Rendering keys off this, never off rotation: a card you peeked at lies facedown on the table but shows its face in the preview HUD.
+
+**Per-recipient views.** The server builds a filtered copy of the document for each player before sending, and diffs it against what that player was last sent — so every client receives a patch stream describing only the game it is allowed to know about:
+
+| | shipped to an entitled player | shipped to everyone else |
+|---|---|---|
+| card face | `faceImageUrl` | *omitted* — backs, transforms and the descriptor still ship, so the table renders identically |
+| hand (`players[x].tray`) | full contents, to `x` only | `handCount` only |
+| deck (`decks[d].cards`) | face-up pile: its top card | `cardCount` only — a facedown deck's order and faces never leave |
+
+**Two write paths.** `update` merge patches remain the cheap path for drag streams, layout, imports and scenario seeds, but are now *sanitized*: a client may not write another player's row, a hand, an existing deck's card list, an existing card's face, or the server-owned `visibility`/`heldBy` fields, and may not mutate any object somebody else holds. Refused subtrees are dropped rather than merged, and the sender is told — and corrected, since its next patch is diffed against "what we last sent you, plus what you just tried".
+
+Everything that moves hidden information is a validated **action** instead, because the requesting client usually cannot hold the data the move operates on: `draw` (server pops the deck and materializes a card under a client-supplied *opaque* id — `card:alice:main-AS` would announce the card it names), `placeOnDeck`, `shuffle`, `tray`/`untray`, `flip`, `claimSeat` (an unclaimed seat's pre-dealt hand is hidden from its claimer too), plus the deliberate reveals below.
+
+**Peeking is a move.** Looking at a hidden card is legitimate, so it is explicit and recorded rather than a side effect of hovering: `peek` entitles you to the face and writes you into `seenBy` where the whole table can see it, announced with a `log` message; `reveal` turns a card face-up for everyone. Flipping *back* down removes the face from everyone again, peekers included — "facedown" has no exceptions to reason about.
+
+With no backend (`local` mode, the /setup editor) there is nothing to hide and nobody to arbitrate: actions fall back to applying the move on the spot.
 
 **Client smoothing:** remote clients feed incoming samples into the existing spring interpolation (`Card.svelte`) — springs chasing the latest sample absorb jitter without snapshot-buffer machinery. The local holder renders its own drag directly (no round-trip lag on your own hand).
 

--- a/server/game/actions.go
+++ b/server/game/actions.go
@@ -1,0 +1,411 @@
+package game
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"math/rand/v2"
+	"slices"
+	"strings"
+)
+
+// Actions are the validated write path. Anything that moves hidden information
+// around — drawing, trays, flips, peeks, shuffles — happens here, on the
+// server, because the client that asks for it may not (and usually must not)
+// hold the data the action operates on.
+//
+// Every handler runs under g.mu and returns the entities it touched. Those refs
+// are force-included in the requesting client's next patch, so a rejected
+// action undoes whatever the client drew optimistically.
+
+type entityRef struct{ col, id string }
+
+type actionRequest struct {
+	Action string `json:"action"`
+	// ID addresses a card or a piece; `piece:` prefixed ids are pieces,
+	// everything else is a card (the same convention the client drags by).
+	ID       string    `json:"id,omitempty"`
+	DeckID   string    `json:"deckId,omitempty"`
+	Position []float64 `json:"position,omitempty"`
+	Rotation []float64 `json:"rotation,omitempty"`
+	Seat     *int      `json:"seat,omitempty"`
+}
+
+func (r actionRequest) collection() string {
+	if strings.HasPrefix(r.ID, "piece:") {
+		return colPieces
+	}
+	return colCards
+}
+
+var errNotFound = errors.New("not found")
+
+// applyAction validates and applies one action, then fans the result out.
+func (g *Game) applyAction(sender string, msg Message) {
+	var req actionRequest
+	if err := json.Unmarshal(msg.Value, &req); err != nil {
+		g.sendError(sender, "malformed action")
+		return
+	}
+
+	g.mu.Lock()
+	touched, extra, err := g.dispatch(sender, req)
+	if err == nil {
+		g.Updates++
+		g.touchActivity()
+	}
+	messages := g.buildFanout(sender, nil, touched)
+	g.mu.Unlock()
+
+	g.send(messages...)
+	g.send(extra...)
+	if err != nil {
+		g.sendError(sender, fmt.Sprintf("%s rejected: %v", req.Action, err))
+	}
+}
+
+// dispatch runs one action. The returned refs are reported even on failure —
+// that is what corrects a client that already drew the result locally.
+func (g *Game) dispatch(sender string, req actionRequest) ([]entityRef, []*PlayerMessage, error) {
+	switch req.Action {
+	case "grab":
+		return g.actionGrab(sender, req)
+	case "drop":
+		return g.actionDrop(sender, req)
+	case "flip":
+		return g.actionFlip(sender, req)
+	case "peek":
+		return g.actionPeek(sender, req)
+	case "reveal":
+		return g.actionReveal(sender, req)
+	case "tray":
+		return g.actionTray(sender, req)
+	case "untray":
+		return g.actionUntray(sender, req)
+	case "draw":
+		return g.actionDraw(sender, req)
+	case "placeOnDeck":
+		return g.actionPlaceOnDeck(sender, req)
+	case "shuffle":
+		return g.actionShuffle(req)
+	case "claimSeat":
+		return g.actionClaimSeat(sender, req)
+	default:
+		return nil, nil, fmt.Errorf("unknown action %q", req.Action)
+	}
+}
+
+func (g *Game) actionGrab(sender string, req actionRequest) ([]entityRef, []*PlayerMessage, error) {
+	col := req.collection()
+	refs := []entityRef{{col, req.ID}}
+	if entity(g.Data, col, req.ID) == nil {
+		return refs, nil, errNotFound
+	}
+	if !g.grab(col, req.ID, sender) {
+		return refs, nil, fmt.Errorf("held by %s", g.holder(col, req.ID))
+	}
+	return refs, nil, nil
+}
+
+func (g *Game) actionDrop(sender string, req actionRequest) ([]entityRef, []*PlayerMessage, error) {
+	col := req.collection()
+	refs := []entityRef{{col, req.ID}}
+	if !g.drop(col, req.ID, sender) {
+		return refs, nil, errors.New("not yours to drop")
+	}
+	return refs, nil, nil
+}
+
+// actionFlip turns a card over. Flipping face-up is what makes a face public;
+// flipping face-down takes it away from everyone again, including whoever just
+// looked at it — "facedown" means hidden, with no exceptions to reason about.
+func (g *Game) actionFlip(sender string, req actionRequest) ([]entityRef, []*PlayerMessage, error) {
+	refs := []entityRef{{colCards, req.ID}}
+	card := entity(g.Data, colCards, req.ID)
+	if card == nil {
+		return refs, nil, errNotFound
+	}
+	if !g.mutableBy(colCards, req.ID, sender) {
+		return refs, nil, fmt.Errorf("held by %s", g.holder(colCards, req.ID))
+	}
+	rot := floats(card[fieldRotation], 3)
+	if rot[0] == facedownRotationX {
+		rot[0] = 0
+		card[fieldVisibility] = publicVisibility()
+	} else {
+		rot[0] = facedownRotationX
+		card[fieldVisibility] = hiddenVisibility(nil)
+	}
+	card[fieldRotation] = anyFloats(rot)
+	return refs, nil, nil
+}
+
+// actionPeek is the sanctioned way to look at a hidden card: it entitles the
+// peeker to the face and puts their name in seenBy, where every other client
+// can see it. Looking at a card is a move, not a side effect of hovering.
+func (g *Game) actionPeek(sender string, req actionRequest) ([]entityRef, []*PlayerMessage, error) {
+	refs := []entityRef{{colCards, req.ID}}
+	card := entity(g.Data, colCards, req.ID)
+	if card == nil {
+		return refs, nil, errNotFound
+	}
+	kind, seenBy := cardVisibility(card)
+	if kind == visPublic {
+		return refs, nil, errors.New("card is already face up")
+	}
+	if !slices.Contains(seenBy, sender) {
+		seenBy = append(seenBy, sender)
+	}
+	card[fieldVisibility] = hiddenVisibility(seenBy)
+	return refs, []*PlayerMessage{g.logMessage("peek", sender, req.ID)}, nil
+}
+
+// actionReveal turns a hidden card face-up for the whole table at once.
+func (g *Game) actionReveal(sender string, req actionRequest) ([]entityRef, []*PlayerMessage, error) {
+	refs := []entityRef{{colCards, req.ID}}
+	card := entity(g.Data, colCards, req.ID)
+	if card == nil {
+		return refs, nil, errNotFound
+	}
+	if !g.mutableBy(colCards, req.ID, sender) {
+		return refs, nil, fmt.Errorf("held by %s", g.holder(colCards, req.ID))
+	}
+	rot := floats(card[fieldRotation], 3)
+	rot[0] = 0
+	card[fieldRotation] = anyFloats(rot)
+	card[fieldVisibility] = publicVisibility()
+	return refs, []*PlayerMessage{g.logMessage("reveal", sender, req.ID)}, nil
+}
+
+// actionTray moves a table card into the sender's own hand. The card leaves
+// `cards` entirely, so from here on it exists only in a collection no other
+// client is ever sent.
+func (g *Game) actionTray(sender string, req actionRequest) ([]entityRef, []*PlayerMessage, error) {
+	refs := []entityRef{{colCards, req.ID}, {colPlayers, sender}}
+	card := entity(g.Data, colCards, req.ID)
+	if card == nil {
+		return refs, nil, errNotFound
+	}
+	if !g.mutableBy(colCards, req.ID, sender) {
+		return refs, nil, fmt.Errorf("held by %s", g.holder(colCards, req.ID))
+	}
+	player := entity(g.Data, colPlayers, sender)
+	if player == nil {
+		return refs, nil, errors.New("no such player")
+	}
+	tray := collection(player, fieldTray, true)
+	tray[req.ID] = map[string]any{
+		fieldFace: card[fieldFace],
+		fieldBack: card[fieldBack],
+	}
+	g.release(colCards, req.ID)
+	delete(collection(g.Data, colCards, true), req.ID)
+	return refs, nil, nil
+}
+
+// actionUntray puts a card from the sender's hand back on the table, facedown
+// and already leased to them so the drag that follows is theirs.
+func (g *Game) actionUntray(sender string, req actionRequest) ([]entityRef, []*PlayerMessage, error) {
+	refs := []entityRef{{colCards, req.ID}, {colPlayers, sender}}
+	player := entity(g.Data, colPlayers, sender)
+	if player == nil {
+		return refs, nil, errors.New("no such player")
+	}
+	tray := collection(player, fieldTray, false)
+	if tray == nil {
+		return refs, nil, errNotFound
+	}
+	held, ok := tray[req.ID].(map[string]any)
+	if !ok {
+		return refs, nil, errNotFound
+	}
+	if entity(g.Data, colCards, req.ID) != nil {
+		return refs, nil, errors.New("already on the table")
+	}
+	delete(tray, req.ID)
+
+	card := map[string]any{
+		fieldFace:       held[fieldFace],
+		fieldBack:       held[fieldBack],
+		fieldPosition:   anyFloats(vec3(req.Position)),
+		fieldRotation:   anyFloats(facedown(req.Rotation)),
+		fieldVisibility: hiddenVisibility(nil),
+	}
+	collection(g.Data, colCards, true)[req.ID] = card
+	g.grab(colCards, req.ID, sender)
+	return refs, nil, nil
+}
+
+// actionDraw takes the top card off a deck and materializes it on the table.
+//
+// The client asks for this by id and never sees what it drew until the card
+// says it may: deck contents live on the server, so a draw is the only way a
+// face ever leaves it. The requested id must be namespaced to the sender, and
+// is expected to be opaque — an id like `card:alice:main-AS` would announce the
+// card it names.
+func (g *Game) actionDraw(sender string, req actionRequest) ([]entityRef, []*PlayerMessage, error) {
+	refs := []entityRef{{colCards, req.ID}, {colDecks, req.DeckID}}
+	if !strings.HasPrefix(req.ID, "card:"+sender+":") {
+		return refs, nil, errors.New("drawn card id must be namespaced to you")
+	}
+	if entity(g.Data, colCards, req.ID) != nil {
+		return refs, nil, errors.New("card id already in play")
+	}
+	deck := entity(g.Data, colDecks, req.DeckID)
+	if deck == nil {
+		return refs, nil, errNotFound
+	}
+	cards, _ := deck[fieldCards].([]any)
+	if len(cards) == 0 {
+		return refs, nil, errors.New("deck is empty")
+	}
+
+	faceUp := isFaceUp(deck)
+	var drawn any
+	if faceUp {
+		// a face-up pile is drawn from the top of the list (LIFO mirrored)
+		drawn, cards = cards[0], cards[1:]
+	} else {
+		drawn, cards = cards[len(cards)-1], cards[:len(cards)-1]
+	}
+	deck[fieldCards] = cards
+
+	entry, _ := drawn.(map[string]any)
+	back := entry[fieldBack]
+	if back == nil {
+		back = deck["deckBackImageUrl"]
+	}
+	rot := vec3(req.Rotation)
+	card := map[string]any{
+		fieldFace:     entry[fieldFace],
+		fieldBack:     back,
+		fieldPosition: anyFloats(vec3(req.Position)),
+	}
+	if faceUp {
+		rot[0] = 0
+		card[fieldVisibility] = publicVisibility()
+	} else {
+		rot[0] = facedownRotationX
+		card[fieldVisibility] = hiddenVisibility(nil)
+	}
+	card[fieldRotation] = anyFloats(rot)
+	collection(g.Data, colCards, true)[req.ID] = card
+	g.grab(colCards, req.ID, sender)
+	return refs, nil, nil
+}
+
+// actionPlaceOnDeck returns a table card to a deck. The card's face goes back
+// behind the server boundary in the same move.
+func (g *Game) actionPlaceOnDeck(sender string, req actionRequest) ([]entityRef, []*PlayerMessage, error) {
+	refs := []entityRef{{colCards, req.ID}, {colDecks, req.DeckID}}
+	card := entity(g.Data, colCards, req.ID)
+	if card == nil {
+		return refs, nil, errNotFound
+	}
+	if !g.mutableBy(colCards, req.ID, sender) {
+		return refs, nil, fmt.Errorf("held by %s", g.holder(colCards, req.ID))
+	}
+	deck := entity(g.Data, colDecks, req.DeckID)
+	if deck == nil {
+		return refs, nil, errNotFound
+	}
+	cards, _ := deck[fieldCards].([]any)
+	entry := map[string]any{
+		"id":      req.ID,
+		fieldFace: card[fieldFace],
+		fieldBack: card[fieldBack],
+	}
+	if isFaceUp(deck) {
+		cards = append([]any{entry}, cards...)
+	} else {
+		cards = append(cards, entry)
+	}
+	deck[fieldCards] = cards
+	g.release(colCards, req.ID)
+	delete(collection(g.Data, colCards, true), req.ID)
+	return refs, nil, nil
+}
+
+// actionShuffle reorders a deck server-side. Done on the client it would be
+// meaningless: the client has counts, not cards.
+func (g *Game) actionShuffle(req actionRequest) ([]entityRef, []*PlayerMessage, error) {
+	refs := []entityRef{{colDecks, req.DeckID}}
+	deck := entity(g.Data, colDecks, req.DeckID)
+	if deck == nil {
+		return refs, nil, errNotFound
+	}
+	cards, _ := deck[fieldCards].([]any)
+	if len(cards) < 2 {
+		return refs, nil, nil
+	}
+	shuffled := make([]any, len(cards))
+	copy(shuffled, cards)
+	rand.Shuffle(len(shuffled), func(i, j int) {
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	})
+	deck[fieldCards] = shuffled
+	return refs, nil, nil
+}
+
+// actionClaimSeat hands a scenario's placeholder seat to a real player: every
+// entity owned by `seatN` is renamed to them, and the seat's pre-dealt hand
+// moves across. This has to be a server action — the placeholder's tray is
+// hidden from everyone, so the claiming client cannot see what it is claiming.
+func (g *Game) actionClaimSeat(sender string, req actionRequest) ([]entityRef, []*PlayerMessage, error) {
+	if req.Seat == nil || *req.Seat < 0 || *req.Seat > 3 {
+		return nil, nil, errors.New("seat must be 0-3")
+	}
+	placeholder := fmt.Sprintf("seat%d", *req.Seat)
+	players := collection(g.Data, colPlayers, true)
+	ph, ok := players[placeholder].(map[string]any)
+	if !ok {
+		return nil, nil, errors.New("seat is not open")
+	}
+
+	refs := []entityRef{{colPlayers, placeholder}, {colPlayers, sender}}
+	segment := ":" + placeholder + ":"
+	for _, col := range []string{colCards, colDecks, colPieces} {
+		entities := collection(g.Data, col, false)
+		for id, value := range entities {
+			if !strings.Contains(id, segment) {
+				continue
+			}
+			newID := renameOwner(id, placeholder, sender)
+			if ent, ok := value.(map[string]any); ok {
+				if _, hasID := ent["id"]; hasID {
+					ent["id"] = newID
+				}
+			}
+			delete(entities, id)
+			entities[newID] = value
+			refs = append(refs, entityRef{col, id}, entityRef{col, newID})
+		}
+	}
+
+	me, ok := players[sender].(map[string]any)
+	if !ok {
+		me = map[string]any{"id": sender}
+		players[sender] = me
+	}
+	me["seat"] = float64(*req.Seat)
+	if tray, ok := ph[fieldTray].(map[string]any); ok && len(tray) > 0 {
+		maps.Copy(collection(me, fieldTray, true), tray)
+	}
+	delete(players, placeholder)
+	return refs, nil, nil
+}
+
+// vec3 normalizes a client-supplied position/rotation to three components.
+func vec3(values []float64) []float64 {
+	out := make([]float64, 3)
+	copy(out, values)
+	return out
+}
+
+func facedown(rotation []float64) []float64 {
+	rot := vec3(rotation)
+	rot[0] = facedownRotationX
+	return rot
+}
+

--- a/server/game/actions_test.go
+++ b/server/game/actions_test.go
@@ -1,0 +1,504 @@
+package game
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// table drives a Game the way a lobby does: real players, real messages, and a
+// drain of the outbound channel so tests can assert on what each client would
+// actually have received.
+type table struct {
+	t       *testing.T
+	game    *Game
+	out     <-chan *PlayerMessage
+	players map[string]*Player
+	// received is the state each client has after applying everything sent to
+	// it — the client-side store, reconstructed.
+	received map[string]map[string]any
+}
+
+func newTable(t *testing.T, playerIDs ...string) *table {
+	t.Helper()
+	g, out := NewGame()
+	tb := &table{
+		t:        t,
+		game:     g,
+		out:      out,
+		players:  map[string]*Player{},
+		received: map[string]map[string]any{},
+	}
+	for _, id := range playerIDs {
+		tb.players[id] = g.ConnectPlayer(id)
+		tb.received[id] = map[string]any{}
+	}
+	return tb
+}
+
+// seed installs canonical state directly, standing in for whatever put the
+// table together (a scenario seed, a pack spawn, an import).
+func (tb *table) seed(raw string) {
+	tb.t.Helper()
+	tb.game.mu.Lock()
+	tb.game.Data = doc(tb.t, raw)
+	tb.game.mu.Unlock()
+	for id := range tb.players {
+		tb.game.SyncPlayerState(id)
+	}
+	tb.drain()
+}
+
+func (tb *table) update(sender string, raw string) {
+	tb.t.Helper()
+	tb.game.HandleMessage(tb.players[sender], Message{
+		Type:      "update",
+		PlayerID:  sender,
+		Timestamp: time.Now().UnixMilli(),
+		Value:     json.RawMessage(raw),
+	})
+	tb.drain()
+}
+
+func (tb *table) action(sender string, raw string) {
+	tb.t.Helper()
+	tb.game.HandleMessage(tb.players[sender], Message{
+		Type:      "action",
+		PlayerID:  sender,
+		Timestamp: time.Now().UnixMilli(),
+		Value:     json.RawMessage(raw),
+	})
+	tb.drain()
+}
+
+// drain applies every pending outbound message to its recipients' reconstructed
+// state, and returns the raw messages for assertions about wire traffic.
+func (tb *table) drain() []Message {
+	tb.t.Helper()
+	var messages []Message
+	for {
+		select {
+		case pm := <-tb.out:
+			var msg Message
+			require.NoError(tb.t, json.Unmarshal(pm.Content, &msg))
+			messages = append(messages, msg)
+			for id := range tb.players {
+				if len(pm.To) > 0 && !containsID(pm.To, id) {
+					continue
+				}
+				if pm.Exclude == id {
+					continue
+				}
+				tb.apply(id, msg)
+			}
+		default:
+			return messages
+		}
+	}
+}
+
+// apply mirrors the client store: sync replaces, update merges, null deletes.
+func (tb *table) apply(id string, msg Message) {
+	if msg.Type != "sync" && msg.Type != "update" {
+		return
+	}
+	var value map[string]any
+	if err := json.Unmarshal(msg.Value, &value); err != nil {
+		return
+	}
+	if msg.Type == "sync" {
+		tb.received[id] = value
+		return
+	}
+	tb.received[id] = mergeWithDeletes(tb.received[id], value)
+}
+
+func mergeWithDeletes(dst, patch map[string]any) map[string]any {
+	if dst == nil {
+		dst = map[string]any{}
+	}
+	for k, v := range patch {
+		if v == nil {
+			delete(dst, k)
+			continue
+		}
+		if pm, ok := v.(map[string]any); ok {
+			if dm, ok := dst[k].(map[string]any); ok {
+				dst[k] = mergeWithDeletes(dm, pm)
+				continue
+			}
+			dst[k] = mergeWithDeletes(map[string]any{}, pm)
+			continue
+		}
+		dst[k] = v
+	}
+	return dst
+}
+
+func containsID(list []string, want string) bool {
+	for _, id := range list {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+func (tb *table) card(player, id string) map[string]any {
+	return entity(tb.received[player], colCards, id)
+}
+
+func (tb *table) canonicalCard(id string) map[string]any {
+	tb.game.mu.Lock()
+	defer tb.game.mu.Unlock()
+	return entity(tb.game.Data, colCards, id)
+}
+
+const twoPlayerTable = `{
+	"cards": {
+		"card:alice:1": {
+			"faceImageUrl": "secret.png",
+			"backImageUrl": "back.png",
+			"position": [1,0,1],
+			"rotation": [180,0,0],
+			"visibility": {"kind":"hidden"}
+		}
+	},
+	"players": {
+		"alice": {"id":"alice","seat":0,"tray":{}},
+		"bob":   {"id":"bob","seat":1,"tray":{}}
+	}
+}`
+
+func TestSyncSendsEachPlayerOnlyTheirOwnView(t *testing.T) {
+	tb := newTable(t, "alice", "bob")
+	tb.seed(twoPlayerTable)
+
+	for _, player := range []string{"alice", "bob"} {
+		assert.NotContains(t, tb.card(player, "card:alice:1"), fieldFace)
+	}
+}
+
+func TestGrabIsExclusive(t *testing.T) {
+	tb := newTable(t, "alice", "bob")
+	tb.seed(twoPlayerTable)
+
+	tb.action("alice", `{"action":"grab","id":"card:alice:1"}`)
+	assert.Equal(t, "alice", tb.canonicalCard("card:alice:1")[fieldHeldBy])
+	// the lease is public knowledge — that is how the other client knows not to
+	// start its own drag
+	assert.Equal(t, "alice", tb.card("bob", "card:alice:1")[fieldHeldBy])
+
+	tb.action("bob", `{"action":"grab","id":"card:alice:1"}`)
+	assert.Equal(t, "alice", tb.canonicalCard("card:alice:1")[fieldHeldBy], "a concurrent grab is rejected")
+
+	tb.action("alice", `{"action":"drop","id":"card:alice:1"}`)
+	assert.NotContains(t, tb.canonicalCard("card:alice:1"), fieldHeldBy)
+
+	tb.action("bob", `{"action":"grab","id":"card:alice:1"}`)
+	assert.Equal(t, "bob", tb.canonicalCard("card:alice:1")[fieldHeldBy], "a dropped card is free again")
+}
+
+func TestGrabOnHeldCardReportsAnError(t *testing.T) {
+	tb := newTable(t, "alice", "bob")
+	tb.seed(twoPlayerTable)
+
+	tb.action("alice", `{"action":"grab","id":"card:alice:1"}`)
+	tb.game.HandleMessage(tb.players["bob"], Message{
+		Type:  "action",
+		Value: json.RawMessage(`{"action":"grab","id":"card:alice:1"}`),
+	})
+	messages := tb.drain()
+
+	var sawError bool
+	for _, msg := range messages {
+		if msg.Type == "error" {
+			sawError = true
+		}
+	}
+	assert.True(t, sawError, "the refused grab is reported back to its sender")
+}
+
+func TestMoveOnAHeldCardIsRejected(t *testing.T) {
+	tb := newTable(t, "alice", "bob")
+	tb.seed(twoPlayerTable)
+	tb.action("alice", `{"action":"grab","id":"card:alice:1"}`)
+
+	tb.update("bob", `{"cards":{"card:alice:1":{"position":[9,9,9]}}}`)
+
+	assert.Equal(t, []any{1.0, 0.0, 1.0}, tb.canonicalCard("card:alice:1")[fieldPosition])
+	// and bob's optimistic move is walked back on his own client
+	assert.Equal(t, []any{1.0, 0.0, 1.0}, tb.card("bob", "card:alice:1")[fieldPosition])
+}
+
+func TestHolderCanMoveTheirOwnCard(t *testing.T) {
+	tb := newTable(t, "alice", "bob")
+	tb.seed(twoPlayerTable)
+	tb.action("alice", `{"action":"grab","id":"card:alice:1"}`)
+
+	tb.update("alice", `{"cards":{"card:alice:1":{"position":[4,0,4]}}}`)
+
+	assert.Equal(t, []any{4.0, 0.0, 4.0}, tb.canonicalCard("card:alice:1")[fieldPosition])
+	assert.Equal(t, []any{4.0, 0.0, 4.0}, tb.card("bob", "card:alice:1")[fieldPosition])
+}
+
+func TestDisconnectReleasesTheLease(t *testing.T) {
+	tb := newTable(t, "alice", "bob")
+	tb.seed(twoPlayerTable)
+	tb.action("alice", `{"action":"grab","id":"card:alice:1"}`)
+
+	tb.game.DisconnectPlayer(tb.players["alice"])
+	tb.drain()
+
+	assert.NotContains(t, tb.canonicalCard("card:alice:1"), fieldHeldBy)
+	assert.NotContains(t, tb.card("bob", "card:alice:1"), fieldHeldBy)
+	// the card stays exactly where the last streamed transform left it
+	assert.Equal(t, []any{1.0, 0.0, 1.0}, tb.canonicalCard("card:alice:1")[fieldPosition])
+
+	tb.players["alice"].Connected = true // reconnect
+	tb.action("bob", `{"action":"grab","id":"card:alice:1"}`)
+	assert.Equal(t, "bob", tb.canonicalCard("card:alice:1")[fieldHeldBy])
+}
+
+func TestExpiredLeaseIsStealable(t *testing.T) {
+	tb := newTable(t, "alice", "bob")
+	tb.seed(twoPlayerTable)
+	tb.action("alice", `{"action":"grab","id":"card:alice:1"}`)
+
+	tb.game.mu.Lock()
+	tb.game.holds[holdKey(colCards, "card:alice:1")] = time.Now().Add(-time.Minute)
+	tb.game.mu.Unlock()
+
+	tb.action("bob", `{"action":"grab","id":"card:alice:1"}`)
+	assert.Equal(t, "bob", tb.canonicalCard("card:alice:1")[fieldHeldBy])
+}
+
+func TestFlipRevealsAndRehides(t *testing.T) {
+	tb := newTable(t, "alice", "bob")
+	tb.seed(twoPlayerTable)
+
+	tb.action("alice", `{"action":"flip","id":"card:alice:1"}`)
+	for _, player := range []string{"alice", "bob"} {
+		assert.Equal(t, "secret.png", tb.card(player, "card:alice:1")[fieldFace],
+			"a face-up card is public to the whole table")
+	}
+
+	tb.action("alice", `{"action":"flip","id":"card:alice:1"}`)
+	for _, player := range []string{"alice", "bob"} {
+		assert.NotContains(t, tb.card(player, "card:alice:1"), fieldFace,
+			"flipping back down takes the face away again")
+	}
+}
+
+func TestFlipOnAHeldCardIsRejected(t *testing.T) {
+	tb := newTable(t, "alice", "bob")
+	tb.seed(twoPlayerTable)
+	tb.action("alice", `{"action":"grab","id":"card:alice:1"}`)
+
+	tb.action("bob", `{"action":"flip","id":"card:alice:1"}`)
+
+	assert.Equal(t, []any{180.0, 0.0, 0.0}, tb.canonicalCard("card:alice:1")[fieldRotation])
+	assert.NotContains(t, tb.card("bob", "card:alice:1"), fieldFace)
+}
+
+func TestPeekEntitlesOnlyThePeekerAndIsRecorded(t *testing.T) {
+	tb := newTable(t, "alice", "bob")
+	tb.seed(twoPlayerTable)
+
+	tb.game.HandleMessage(tb.players["bob"], Message{
+		Type:  "action",
+		Value: json.RawMessage(`{"action":"peek","id":"card:alice:1"}`),
+	})
+	messages := tb.drain()
+
+	assert.Equal(t, "secret.png", tb.card("bob", "card:alice:1")[fieldFace])
+	assert.NotContains(t, tb.card("alice", "card:alice:1"), fieldFace)
+
+	// who looked is on the card, for everyone
+	visibility, _ := tb.card("alice", "card:alice:1")[fieldVisibility].(map[string]any)
+	assert.Equal(t, []any{"bob"}, visibility[fieldSeenBy])
+
+	var logged *Message
+	for i, msg := range messages {
+		if msg.Type == "log" {
+			logged = &messages[i]
+		}
+	}
+	require.NotNil(t, logged, "a peek is announced to the table")
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(logged.Value, &payload))
+	assert.Equal(t, "peek", payload["kind"])
+	assert.Equal(t, "bob", payload["playerId"])
+	assert.Equal(t, "card:alice:1", payload["cardId"])
+}
+
+func TestRevealMakesACardPublic(t *testing.T) {
+	tb := newTable(t, "alice", "bob")
+	tb.seed(twoPlayerTable)
+
+	tb.action("alice", `{"action":"reveal","id":"card:alice:1"}`)
+
+	for _, player := range []string{"alice", "bob"} {
+		assert.Equal(t, "secret.png", tb.card(player, "card:alice:1")[fieldFace])
+		assert.Equal(t, []any{0.0, 0.0, 0.0}, tb.card(player, "card:alice:1")[fieldRotation])
+	}
+}
+
+func TestTrayAndUntrayKeepHandsPrivate(t *testing.T) {
+	tb := newTable(t, "alice", "bob")
+	tb.seed(twoPlayerTable)
+
+	tb.action("alice", `{"action":"tray","id":"card:alice:1"}`)
+
+	assert.Nil(t, tb.canonicalCard("card:alice:1"), "the card leaves the table")
+	mine := entity(tb.received["alice"], colPlayers, "alice")
+	tray, _ := mine[fieldTray].(map[string]any)
+	require.Len(t, tray, 1)
+	assert.Equal(t, "secret.png", tray["card:alice:1"].(map[string]any)[fieldFace])
+
+	theirs := entity(tb.received["bob"], colPlayers, "alice")
+	assert.NotContains(t, theirs, fieldTray)
+	assert.Equal(t, float64(1), theirs[fieldHandCount])
+
+	tb.action("alice", `{"action":"untray","id":"card:alice:1","position":[2,2.5,2],"rotation":[0,0,90]}`)
+
+	back := tb.canonicalCard("card:alice:1")
+	require.NotNil(t, back)
+	assert.Equal(t, []any{180.0, 0.0, 90.0}, back[fieldRotation], "cards leave the hand facedown")
+	assert.Equal(t, "alice", back[fieldHeldBy], "the card comes out already leased to its drawer")
+	assert.NotContains(t, tb.card("bob", "card:alice:1"), fieldFace)
+	assert.Equal(t, float64(0), entity(tb.received["bob"], colPlayers, "alice")[fieldHandCount])
+}
+
+func TestTrayingSomeoneElsesHeldCardIsRejected(t *testing.T) {
+	tb := newTable(t, "alice", "bob")
+	tb.seed(twoPlayerTable)
+	tb.action("alice", `{"action":"grab","id":"card:alice:1"}`)
+
+	tb.action("bob", `{"action":"tray","id":"card:alice:1"}`)
+
+	assert.NotNil(t, tb.canonicalCard("card:alice:1"))
+	assert.Empty(t, entity(tb.game.Data, colPlayers, "bob")[fieldTray])
+}
+
+const deckTable = `{
+	"decks": {
+		"deck:alice:main": {
+			"id": "deck:alice:main",
+			"isFaceUp": false,
+			"deckBackImageUrl": "back.png",
+			"position": [8,0.4,4],
+			"cards": [
+				{"id":"card:alice:main-2C","faceImageUrl":"two.png"},
+				{"id":"card:alice:main-AS","faceImageUrl":"ace.png"}
+			]
+		}
+	},
+	"players": {
+		"alice": {"id":"alice","seat":0,"tray":{}},
+		"bob":   {"id":"bob","seat":1,"tray":{}}
+	}
+}`
+
+func TestDrawTakesTheTopCardWithoutShippingTheDeck(t *testing.T) {
+	tb := newTable(t, "alice", "bob")
+	tb.seed(deckTable)
+
+	tb.action("alice", `{"action":"draw","deckId":"deck:alice:main","id":"card:alice:xyz789","position":[0,2.5,0],"rotation":[0,0,0]}`)
+
+	drawn := tb.canonicalCard("card:alice:xyz789")
+	require.NotNil(t, drawn)
+	assert.Equal(t, "ace.png", drawn[fieldFace], "the top of a facedown deck is its last entry")
+	assert.Equal(t, "back.png", drawn[fieldBack])
+	assert.Equal(t, []any{180.0, 0.0, 0.0}, drawn[fieldRotation])
+	assert.Equal(t, "alice", drawn[fieldHeldBy])
+
+	// nobody — not even the drawer — is shown a face they have not turned over
+	for _, player := range []string{"alice", "bob"} {
+		assert.NotContains(t, tb.card(player, "card:alice:xyz789"), fieldFace)
+		deck := entity(tb.received[player], colDecks, "deck:alice:main")
+		assert.NotContains(t, deck, fieldCards)
+		assert.Equal(t, float64(1), deck[fieldCardCount])
+	}
+}
+
+func TestDrawRequiresAnIdNamespacedToTheSender(t *testing.T) {
+	tb := newTable(t, "alice", "bob")
+	tb.seed(deckTable)
+
+	tb.action("bob", `{"action":"draw","deckId":"deck:alice:main","id":"card:alice:sneaky","position":[0,2.5,0]}`)
+
+	assert.Nil(t, tb.canonicalCard("card:alice:sneaky"))
+}
+
+// A client that drew optimistically must be walked back when the draw fails —
+// otherwise the ghost card it painted stays on its table forever.
+func TestRejectedDrawRemovesTheClientsGhostCard(t *testing.T) {
+	tb := newTable(t, "alice", "bob")
+	tb.seed(deckTable)
+
+	// alice paints the card she is about to drag, then the draw is refused
+	tb.received["alice"] = mergeWithDeletes(tb.received["alice"], doc(t,
+		`{"cards":{"card:alice:ghost":{"position":[0,2.5,0],"rotation":[180,0,0]}}}`))
+	tb.action("alice", `{"action":"draw","deckId":"deck:nope","id":"card:alice:ghost","position":[0,2.5,0]}`)
+
+	assert.Nil(t, tb.card("alice", "card:alice:ghost"))
+}
+
+func TestPlaceOnDeckPutsTheFaceBackBehindTheServer(t *testing.T) {
+	tb := newTable(t, "alice", "bob")
+	tb.seed(deckTable)
+	tb.action("alice", `{"action":"draw","deckId":"deck:alice:main","id":"card:alice:xyz789","position":[0,2.5,0]}`)
+	tb.action("alice", `{"action":"flip","id":"card:alice:xyz789"}`)
+	require.Equal(t, "ace.png", tb.card("alice", "card:alice:xyz789")[fieldFace])
+
+	tb.action("alice", `{"action":"placeOnDeck","deckId":"deck:alice:main","id":"card:alice:xyz789"}`)
+
+	assert.Nil(t, tb.canonicalCard("card:alice:xyz789"))
+	for _, player := range []string{"alice", "bob"} {
+		assert.Nil(t, tb.card(player, "card:alice:xyz789"))
+		assert.Equal(t, float64(2), entity(tb.received[player], colDecks, "deck:alice:main")[fieldCardCount])
+	}
+}
+
+func TestShuffleStaysOnTheServer(t *testing.T) {
+	tb := newTable(t, "alice", "bob")
+	tb.seed(deckTable)
+
+	tb.action("alice", `{"action":"shuffle","deckId":"deck:alice:main"}`)
+
+	tb.game.mu.Lock()
+	cards, _ := entity(tb.game.Data, colDecks, "deck:alice:main")[fieldCards].([]any)
+	tb.game.mu.Unlock()
+	assert.Len(t, cards, 2, "shuffling neither loses nor reveals cards")
+}
+
+func TestClaimSeatMovesTheHiddenHandServerSide(t *testing.T) {
+	tb := newTable(t, "alice")
+	tb.seed(`{
+		"cards": {"card:seat1:token": {"position":[0,0,0],"rotation":[0,0,0],"faceImageUrl":"public.png"}},
+		"decks": {"deck:seat1:main": {"id":"deck:seat1:main","cards":[{"id":"x","faceImageUrl":"a.png"}]}},
+		"players": {
+			"alice": {"id":"alice","seat":0,"tray":{}},
+			"seat1": {"id":"seat1","seat":1,"tray":{"dealt":{"faceImageUrl":"dealt.png"}}}
+		}
+	}`)
+	// the claiming client cannot see what it is about to claim
+	require.NotContains(t, entity(tb.received["alice"], colPlayers, "seat1"), fieldTray)
+
+	tb.action("alice", `{"action":"claimSeat","seat":1}`)
+
+	mine := entity(tb.received["alice"], colPlayers, "alice")
+	assert.Equal(t, float64(1), mine["seat"])
+	tray, _ := mine[fieldTray].(map[string]any)
+	require.Len(t, tray, 1, "the seat's pre-dealt hand arrives with the seat")
+	assert.Equal(t, "dealt.png", tray["dealt"].(map[string]any)[fieldFace])
+
+	assert.Nil(t, entity(tb.received["alice"], colPlayers, "seat1"))
+	assert.NotNil(t, entity(tb.received["alice"], colCards, "card:alice:token"))
+	assert.Nil(t, entity(tb.received["alice"], colCards, "card:seat1:token"))
+	assert.NotNil(t, entity(tb.received["alice"], colDecks, "deck:alice:main"))
+}

--- a/server/game/document.go
+++ b/server/game/document.go
@@ -1,0 +1,129 @@
+package game
+
+import "reflect"
+
+// Helpers for walking the decoded JSON document. Everything the server stores
+// comes out of encoding/json, so maps are map[string]any, arrays are []any and
+// numbers are float64.
+
+func deepCopy(value any) any {
+	switch v := value.(type) {
+	case map[string]any:
+		return deepCopyMap(v)
+	case []any:
+		out := make([]any, len(v))
+		for i, item := range v {
+			out[i] = deepCopy(item)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func deepCopyMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = deepCopy(v)
+	}
+	return out
+}
+
+// collection returns a collection map (cards/decks/players/…), creating it when
+// create is set. Returns nil when absent (or present but not an object).
+func collection(data map[string]any, name string, create bool) map[string]any {
+	if existing, ok := data[name].(map[string]any); ok {
+		return existing
+	}
+	if !create {
+		return nil
+	}
+	created := map[string]any{}
+	data[name] = created
+	return created
+}
+
+// entity returns one entity out of a collection, or nil when it does not exist.
+func entity(data map[string]any, col, id string) map[string]any {
+	c := collection(data, col, false)
+	if c == nil {
+		return nil
+	}
+	ent, _ := c[id].(map[string]any)
+	return ent
+}
+
+// floats reads a numeric array field, padding to n with zeroes so callers can
+// index without bounds checks.
+func floats(value any, n int) []float64 {
+	out := make([]float64, n)
+	arr, ok := value.([]any)
+	if !ok {
+		return out
+	}
+	for i := 0; i < n && i < len(arr); i++ {
+		if f, ok := arr[i].(float64); ok {
+			out[i] = f
+		}
+	}
+	return out
+}
+
+func anyFloats(values []float64) []any {
+	out := make([]any, len(values))
+	for i, v := range values {
+		out[i] = v
+	}
+	return out
+}
+
+func strSlice(value any) []string {
+	arr, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, item := range arr {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// diffMaps produces the JSON merge patch that turns old into new: changed keys
+// carry their new value, keys that vanished carry nil (a JSON null, which the
+// client store treats as a delete). Nested objects recurse; arrays and scalars
+// replace wholesale, matching MergeMaps on the way in.
+func diffMaps(old, new map[string]any) map[string]any {
+	patch := map[string]any{}
+	for key, nv := range new {
+		ov, present := old[key]
+		if !present {
+			patch[key] = nv
+			continue
+		}
+		if nm, ok := nv.(map[string]any); ok {
+			if om, ok := ov.(map[string]any); ok {
+				if sub := diffMaps(om, nm); len(sub) > 0 {
+					patch[key] = sub
+				}
+				continue
+			}
+			patch[key] = nv
+			continue
+		}
+		if !reflect.DeepEqual(ov, nv) {
+			patch[key] = nv
+		}
+	}
+	for key := range old {
+		if _, present := new[key]; !present {
+			patch[key] = nil
+		}
+	}
+	return patch
+}

--- a/server/game/game.go
+++ b/server/game/game.go
@@ -2,15 +2,19 @@ package game
 
 import (
 	"encoding/json"
+	"maps"
 	"time"
 
 	"github.com/jollygrin/tts-server/jsonmerge"
 	"github.com/rs/zerolog/log"
 )
 
-// HandleMessage handles incoming messages from players
-// If a message is returned, send it back to the caller.
-// TODO: Make this a channel and async go routine
+// HandleMessage handles incoming messages from players.
+//
+// Nothing is relayed verbatim any more: state changes are validated, applied to
+// the canonical document, and then fanned out as *per-recipient* patches built
+// from what each player is entitled to see (see buildFanout). Presence pings
+// carry no state and are still passed straight through.
 func (g *Game) HandleMessage(from *Player, msg Message) {
 	if msg.PlayerID == "" {
 		// This feels like a bug futher up and should not be fixed here.
@@ -20,26 +24,140 @@ func (g *Game) HandleMessage(from *Player, msg Message) {
 	switch msg.Type {
 	case "sync":
 		g.SyncPlayerState(from.ID)
-		return
 	case "update":
-		g.update(msg)
-	}
-
-	// For whatever reason, we broadcast every message.
-	// This feels.... wrong
-	data, _ := json.Marshal(msg)
-	g.out <- &PlayerMessage{ // TODO: Full channel problems
-		To:      []string{},
-		Exclude: from.ID,
-		Content: data,
+		g.applyUpdate(from.ID, msg)
+	case "action":
+		g.applyAction(from.ID, msg)
+	case "connect", "disconnect":
+		data, _ := json.Marshal(msg)
+		g.send(&PlayerMessage{To: []string{}, Exclude: from.ID, Content: data})
+	default:
+		log.Warn().Str("type", msg.Type).Msg("Unknown message type")
 	}
 }
 
+// applyUpdate is the merge-patch path: cheap, frequent, non-secret changes
+// (drag streams, layout, scenario seeds). The patch is filtered down to what
+// the sender is allowed to write before it touches the canonical document.
+func (g *Game) applyUpdate(sender string, msg Message) {
+	if msg.Value == nil {
+		log.Error().Msg("Invalid update message: missing value")
+		return
+	}
+
+	// decode outside the lock; only the merge itself needs exclusivity
+	var patch map[string]any
+	if err := json.Unmarshal(msg.Value, &patch); err != nil {
+		log.Err(err).Msg("Failed to decode update value")
+		return
+	}
+
+	g.mu.Lock()
+	accepted, refused := g.sanitizeUpdate(patch, sender)
+	g.Data = jsonmerge.MergeMaps(g.Data, accepted)
+	g.Updates++
+	g.touchActivity()
+	// the sender applied its own patch optimistically, so its believed state is
+	// the last view we sent plus that patch — diffing against it is what walks
+	// back the parts we refused
+	messages := g.buildFanout(sender, patch, nil)
+	g.mu.Unlock()
+
+	g.send(messages...)
+	if len(refused) > 0 {
+		log.Warn().Str("player", sender).Strs("refused", refused).Msg("Rejected parts of an update")
+		g.sendError(sender, "update rejected: "+refused[0])
+	}
+}
+
+// buildFanout produces one patch per connected player: their new entitled view
+// diffed against what we last sent them. Expects g.mu to be held; the returned
+// messages must be sent after releasing it.
+//
+// touched entities are force-included for the sender. An action the sender
+// mirrored locally (drawing a card, emptying a slot in its hand) leaves the
+// server with nothing to diff when it fails, so those refs are restated
+// explicitly — as the canonical entity, or as a null when it does not exist.
+func (g *Game) buildFanout(sender string, senderPatch map[string]any, touched []entityRef) []*PlayerMessage {
+	var messages []*PlayerMessage
+	now := time.Now().UnixMilli()
+
+	for id, player := range g.Players {
+		if !player.Connected {
+			delete(g.views, id)
+			continue
+		}
+
+		view := viewFor(g.Data, id)
+		believed := g.views[id]
+		if believed == nil {
+			believed = map[string]any{}
+		}
+		if id == sender && senderPatch != nil {
+			believed = jsonmerge.MergeMaps(deepCopyMap(believed), senderPatch)
+		}
+		patch := diffMaps(believed, view)
+		if id == sender {
+			for _, ref := range touched {
+				forceRef(patch, view, ref)
+			}
+		}
+		g.views[id] = view
+
+		if len(patch) == 0 {
+			continue
+		}
+		value, err := json.Marshal(patch)
+		if err != nil {
+			log.Err(err).Msg("Failed to marshal patch")
+			continue
+		}
+		content, err := json.Marshal(&Message{
+			Type:      "update",
+			PlayerID:  serverID,
+			Timestamp: now,
+			Value:     value,
+		})
+		if err != nil {
+			log.Err(err).Msg("Failed to marshal update message")
+			continue
+		}
+		messages = append(messages, &PlayerMessage{To: []string{id}, Content: content})
+	}
+	return messages
+}
+
+// forceRef restates one entity in a patch, whether or not it changed. It is a
+// union, not a replacement: the diff's own keys win, so a field the diff is
+// deleting (a face that just went back into hiding) keeps its explicit null
+// instead of being papered over by the restated entity.
+func forceRef(patch, view map[string]any, ref entityRef) {
+	target, ok := patch[ref.col].(map[string]any)
+	if !ok {
+		target = map[string]any{}
+		patch[ref.col] = target
+	}
+	ent := entity(view, ref.col, ref.id)
+	if ent == nil {
+		target[ref.id] = nil
+		return
+	}
+	forced := deepCopyMap(ent)
+	if diffed, ok := target[ref.id].(map[string]any); ok {
+		maps.Copy(forced, diffed)
+	}
+	target[ref.id] = forced
+}
+
+// SyncPlayerState sends a player their entire entitled view and resets our
+// record of what they hold, so subsequent patches diff from a known point.
 func (g *Game) SyncPlayerState(id string) {
 	// marshal under the lock, send after releasing it — sending to a possibly
 	// full channel while holding the state mutex can deadlock the lobby
 	g.mu.Lock()
-	data, err := json.Marshal(g.Data)
+	view := viewFor(g.Data, id)
+	g.views[id] = view
+	data, err := json.Marshal(view)
 	g.mu.Unlock()
 	if err != nil {
 		log.Err(err).Msg("Failed to marshal state for sync")
@@ -54,19 +172,68 @@ func (g *Game) SyncPlayerState(id string) {
 	}
 	payload, _ := json.Marshal(returnMsg)
 
-	g.out <- &PlayerMessage{
-		To:      []string{id},
-		Content: payload,
+	g.send(&PlayerMessage{To: []string{id}, Content: payload})
+}
+
+// send delivers already-built messages. Never call it while holding g.mu.
+func (g *Game) send(messages ...*PlayerMessage) {
+	for _, msg := range messages {
+		if msg == nil {
+			continue
+		}
+		g.out <- msg
 	}
 }
 
+func (g *Game) sendError(playerID, message string) {
+	value, _ := json.Marshal(message)
+	payload, err := json.Marshal(&Message{
+		Type:      "error",
+		PlayerID:  serverID,
+		Timestamp: time.Now().UnixMilli(),
+		Value:     value,
+	})
+	if err != nil {
+		return
+	}
+	g.send(&PlayerMessage{To: []string{playerID}, Content: payload})
+}
+
+// logMessage records a table event everyone should know happened — who peeked
+// at what, who revealed what. Looking at a hidden card is a move, so it leaves
+// a trace instead of being invisible.
+func (g *Game) logMessage(kind, playerID, cardID string) *PlayerMessage {
+	value, err := json.Marshal(map[string]any{
+		"kind":     kind,
+		"playerId": playerID,
+		"cardId":   cardID,
+	})
+	if err != nil {
+		return nil
+	}
+	payload, err := json.Marshal(&Message{
+		Type:      "log",
+		PlayerID:  serverID,
+		Timestamp: time.Now().UnixMilli(),
+		Value:     value,
+	})
+	if err != nil {
+		return nil
+	}
+	return &PlayerMessage{To: []string{}, Content: payload}
+}
+
+// DisconnectPlayer releases everything the player was holding — the
+// server-synthesized drop from SPEC.md §4c — and tells everyone else.
 func (g *Game) DisconnectPlayer(p *Player) {
 	g.mu.Lock()
-	defer g.mu.Unlock()
-
-	// TODO: channels?
 	p.Connected = false
-	// broadcastPlayerChange(c.Lobby, c.ID, "disconnect", time.Now().UnixMilli())
+	g.releaseHeldBy(p.ID)
+	delete(g.views, p.ID)
+	messages := g.buildFanout("", nil, nil)
+	g.mu.Unlock()
+
+	g.send(messages...)
 }
 
 func (g *Game) BroadcastPlayerChange(playerID, changeType string, timestamp int64) {
@@ -94,10 +261,7 @@ func (g *Game) BroadcastPlayerChange(playerID, changeType string, timestamp int6
 	}
 
 	// Broadcast to all clients in the lobby
-	g.out <- &PlayerMessage{
-		To:      []string{},
-		Content: payload,
-	}
+	g.send(&PlayerMessage{To: []string{}, Content: payload})
 }
 
 func (g *Game) ConnectPlayer(playerID string) *Player {
@@ -110,6 +274,8 @@ func (g *Game) ConnectPlayer(playerID string) *Player {
 		// TODO: What?! We should check if the player is still listening
 		// on another websocket and do something.
 		existing.Connected = true
+		// a reconnecting client starts from nothing until it syncs
+		delete(g.views, playerID)
 		return existing
 	}
 
@@ -123,22 +289,4 @@ func (g *Game) ConnectPlayer(playerID string) *Player {
 	return newPlayer
 }
 
-func (g *Game) update(msg Message) {
-	if msg.Value == nil {
-		log.Error().Msgf("Invalid update message: missing path or value")
-		return
-	}
-
-	// decode outside the lock; only the merge itself needs exclusivity
-	var patch map[string]any
-	if err := json.Unmarshal(msg.Value, &patch); err != nil {
-		log.Err(err).Msg("Failed to decode update value")
-		return
-	}
-
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	g.Data = jsonmerge.MergeMaps(g.Data, patch)
-	g.Updates++
-	g.LastActivity = time.Now()
-}
+func (g *Game) touchActivity() { g.LastActivity = time.Now() }

--- a/server/game/lease.go
+++ b/server/game/lease.go
@@ -1,0 +1,101 @@
+package game
+
+import "time"
+
+// Hold leases. `grab` claims an object, `drop` releases it, and while a lease
+// is out nobody else may move, flip, tray or otherwise mutate that object.
+// The holder is published on the entity (heldBy) so every client can render
+// "someone else has this"; the expiry is server-private.
+//
+// All functions here expect g.mu to be held.
+
+func holdKey(col, id string) string { return col + "/" + id }
+
+// holder returns the current owner of an object's lease, "" when free. A lease
+// past its TTL is treated as free: the holder's client is gone or wedged.
+func (g *Game) holder(col, id string) string {
+	ent := entity(g.Data, col, id)
+	if ent == nil {
+		return ""
+	}
+	held, _ := ent[fieldHeldBy].(string)
+	if held == "" {
+		return ""
+	}
+	if expiry, ok := g.holds[holdKey(col, id)]; ok && time.Now().After(expiry) {
+		return ""
+	}
+	return held
+}
+
+// mutableBy reports whether player may change this object. Objects that do not
+// exist yet are mutable (that is a create), and an object nobody holds is fair
+// game — contention is the thing leases exist to stop.
+func (g *Game) mutableBy(col, id, player string) bool {
+	held := g.holder(col, id)
+	return held == "" || held == player
+}
+
+// grab claims the lease, refreshing it if the caller already holds it.
+func (g *Game) grab(col, id, player string) bool {
+	ent := entity(g.Data, col, id)
+	if ent == nil {
+		return false
+	}
+	if !g.mutableBy(col, id, player) {
+		return false
+	}
+	ent[fieldHeldBy] = player
+	g.holds[holdKey(col, id)] = time.Now().Add(holdTTL)
+	return true
+}
+
+// drop ends the lease. The object keeps whatever transform was last streamed,
+// which is what makes a synthesized drop (disconnect, expiry) safe.
+func (g *Game) drop(col, id, player string) bool {
+	ent := entity(g.Data, col, id)
+	if ent == nil {
+		return false
+	}
+	if held, _ := ent[fieldHeldBy].(string); held != "" && held != player {
+		return false
+	}
+	g.release(col, id)
+	return true
+}
+
+func (g *Game) release(col, id string) {
+	if ent := entity(g.Data, col, id); ent != nil {
+		delete(ent, fieldHeldBy)
+	}
+	delete(g.holds, holdKey(col, id))
+}
+
+// touchHold keeps a live lease alive while its holder is still streaming.
+func (g *Game) touchHold(col, id, player string) {
+	if ent := entity(g.Data, col, id); ent != nil {
+		if held, _ := ent[fieldHeldBy].(string); held == player {
+			g.holds[holdKey(col, id)] = time.Now().Add(holdTTL)
+		}
+	}
+}
+
+// releaseHeldBy drops every lease a player owns — the synthesized drop that
+// runs when they disconnect. Objects stay exactly where they were last seen.
+func (g *Game) releaseHeldBy(player string) []entityRef {
+	var released []entityRef
+	for _, col := range []string{colCards, colPieces} {
+		entities := collection(g.Data, col, false)
+		for id, raw := range entities {
+			ent, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			if held, _ := ent[fieldHeldBy].(string); held == player {
+				g.release(col, id)
+				released = append(released, entityRef{col: col, id: id})
+			}
+		}
+	}
+	return released
+}

--- a/server/game/sanitize.go
+++ b/server/game/sanitize.go
@@ -1,0 +1,167 @@
+package game
+
+import "fmt"
+
+// sanitizeUpdate splits an incoming merge patch into the part the sender is
+// allowed to apply and a list of what was refused.
+//
+// `update` is still the write path for the cheap, non-secret half of the game —
+// streaming a drag, laying out a table, seeding a scenario, moving a deck. What
+// it may no longer do is touch anything that carries hidden information or
+// belongs to somebody else; those go through validated actions instead (see
+// actions.go). Anything refused is dropped from the patch, never merged, and
+// reported back so the sender can be corrected.
+//
+// Expects g.mu to be held. The returned patch shares no memory with the input.
+func (g *Game) sanitizeUpdate(patch map[string]any, sender string) (map[string]any, []string) {
+	accepted := make(map[string]any, len(patch))
+	var refused []string
+
+	for key, value := range patch {
+		switch key {
+		case colCards, colPieces:
+			kept, why := g.sanitizeObjects(key, value, sender)
+			accepted[key] = kept
+			refused = append(refused, why...)
+		case colDecks:
+			kept, why := g.sanitizeDecks(value)
+			accepted[key] = kept
+			refused = append(refused, why...)
+		case colPlayers:
+			kept, why := g.sanitizePlayers(value, sender)
+			accepted[key] = kept
+			refused = append(refused, why...)
+		default:
+			accepted[key] = deepCopy(value)
+		}
+	}
+
+	// drop collections that ended up empty so the merge stays a no-op
+	for key, value := range accepted {
+		if m, ok := value.(map[string]any); ok && len(m) == 0 {
+			delete(accepted, key)
+		}
+	}
+	return accepted, refused
+}
+
+// sanitizeObjects validates a cards/pieces patch: you may not touch an object
+// somebody else is holding, and you may never write the server-owned fields
+// (visibility, heldBy) or repaint the face of a card that already exists.
+func (g *Game) sanitizeObjects(col string, value any, sender string) (any, []string) {
+	entities, ok := value.(map[string]any)
+	if !ok {
+		return deepCopy(value), nil
+	}
+	kept := make(map[string]any, len(entities))
+	var refused []string
+
+	for id, raw := range entities {
+		if !g.mutableBy(col, id, sender) {
+			refused = append(refused, fmt.Sprintf("%s/%s is held by %s", col, id, g.holder(col, id)))
+			continue
+		}
+		if raw == nil { // delete
+			kept[id] = nil
+			continue
+		}
+		ent, ok := raw.(map[string]any)
+		if !ok {
+			kept[id] = deepCopy(raw)
+			continue
+		}
+		exists := entity(g.Data, col, id) != nil
+		copied := deepCopyMap(ent)
+		delete(copied, fieldVisibility)
+		delete(copied, fieldHeldBy)
+		if col == colCards && exists {
+			// The face of a card already on the table is the server's to
+			// hand out — see flip/peek/reveal. Letting a client re-declare it
+			// would let it launder a face it was never sent.
+			delete(copied, fieldFace)
+		}
+		kept[id] = copied
+		g.touchHold(col, id, sender)
+	}
+	return kept, refused
+}
+
+// sanitizeDecks refuses rewrites of an existing deck's card list. Creating or
+// replacing a deck wholesale (import, scenario seed, pack spawn) carries the
+// `id` field and is allowed; draw/shuffle/place send only `cards` and must go
+// through the actions that keep deck order server-side.
+func (g *Game) sanitizeDecks(value any) (any, []string) {
+	decks, ok := value.(map[string]any)
+	if !ok {
+		return deepCopy(value), nil
+	}
+	kept := make(map[string]any, len(decks))
+	var refused []string
+
+	for id, raw := range decks {
+		if raw == nil {
+			kept[id] = nil
+			continue
+		}
+		deck, ok := raw.(map[string]any)
+		if !ok {
+			kept[id] = deepCopy(raw)
+			continue
+		}
+		copied := deepCopyMap(deck)
+		delete(copied, fieldCardCount) // server-derived
+		if _, hasCards := copied[fieldCards]; hasCards {
+			_, isFullDefinition := copied["id"]
+			if entity(g.Data, colDecks, id) != nil && !isFullDefinition {
+				delete(copied, fieldCards)
+				refused = append(refused, fmt.Sprintf("decks/%s card list is server-owned (use draw/shuffle/place)", id))
+			}
+		}
+		kept[id] = copied
+	}
+	return kept, refused
+}
+
+// sanitizePlayers keeps players to their own row (plus the unclaimed seat
+// placeholders a scenario is built from) and keeps hands out of the merge path
+// entirely — a tray only ever changes via the tray/untray/claimSeat actions.
+func (g *Game) sanitizePlayers(value any, sender string) (any, []string) {
+	players, ok := value.(map[string]any)
+	if !ok {
+		return deepCopy(value), nil
+	}
+	kept := make(map[string]any, len(players))
+	var refused []string
+
+	for id, raw := range players {
+		if id != sender && !isSeatPlaceholder(id) {
+			refused = append(refused, fmt.Sprintf("players/%s is not yours to write", id))
+			continue
+		}
+		if raw == nil {
+			kept[id] = nil
+			continue
+		}
+		player, ok := raw.(map[string]any)
+		if !ok {
+			kept[id] = deepCopy(raw)
+			continue
+		}
+		copied := deepCopyMap(player)
+		delete(copied, fieldHandCount) // server-derived
+		if tray, present := copied[fieldTray]; present && !isSeatPlaceholder(id) {
+			// An empty tray is how a client introduces itself; anything with
+			// contents is a hand mutation and must be an action.
+			//
+			// Seeding an *unclaimed* seat's hand is the exception: a scenario
+			// lays those out wholesale, and nobody is entitled to a placeholder's
+			// tray anyway — it stays hidden from every client until claimed.
+			if m, ok := tray.(map[string]any); !ok || len(m) > 0 {
+				delete(copied, fieldTray)
+				refused = append(refused, fmt.Sprintf("players/%s tray is server-owned (use tray/untray)", id))
+			}
+		}
+		kept[id] = copied
+	}
+	return kept, refused
+}

--- a/server/game/sanitize_test.go
+++ b/server/game/sanitize_test.go
@@ -1,0 +1,121 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newSanitizeGame(t *testing.T, state string) *Game {
+	t.Helper()
+	g, _ := NewGame()
+	g.Data = doc(t, state)
+	return g
+}
+
+func TestUpdateCannotWriteAnotherPlayersRow(t *testing.T) {
+	g := newSanitizeGame(t, `{"players":{"alice":{"id":"alice","seat":0},"bob":{"id":"bob","seat":1}}}`)
+
+	accepted, refused := g.sanitizeUpdate(doc(t, `{"players":{
+		"bob":   {"seat": 3},
+		"alice": {"seat": 2}
+	}}`), "alice")
+
+	players, _ := accepted[colPlayers].(map[string]any)
+	assert.NotContains(t, players, "bob")
+	assert.Contains(t, players, "alice")
+	assert.Len(t, refused, 1)
+}
+
+func TestUpdateCannotWriteAHand(t *testing.T) {
+	g := newSanitizeGame(t, `{"players":{"alice":{"id":"alice","tray":{}}}}`)
+
+	accepted, refused := g.sanitizeUpdate(doc(t,
+		`{"players":{"alice":{"seat":1,"tray":{"c1":{"faceImageUrl":"a.png"}}}}}`), "alice")
+
+	alice, _ := accepted[colPlayers].(map[string]any)["alice"].(map[string]any)
+	assert.NotContains(t, alice, fieldTray)
+	assert.Equal(t, float64(1), alice["seat"], "the rest of the row still applies")
+	assert.Len(t, refused, 1)
+}
+
+// Introducing yourself carries an empty tray, and a scenario seeds the hands of
+// seats nobody is sitting in yet. Neither is a hand mutation.
+func TestUpdateAllowsEmptyTrayAndSeatSeeding(t *testing.T) {
+	g := newSanitizeGame(t, `{"players":{}}`)
+
+	accepted, refused := g.sanitizeUpdate(doc(t, `{"players":{
+		"alice": {"id":"alice","tray":{}},
+		"seat1": {"id":"seat1","seat":1,"tray":{"dealt":{"faceImageUrl":"a.png"}}}
+	}}`), "alice")
+
+	players, _ := accepted[colPlayers].(map[string]any)
+	assert.Contains(t, players["alice"], fieldTray)
+	assert.Contains(t, players["seat1"], fieldTray)
+	assert.Empty(t, refused)
+}
+
+func TestUpdateCannotDeclareVisibilityOrLeases(t *testing.T) {
+	g := newSanitizeGame(t, `{"cards":{"c1":{"rotation":[180,0,0],"faceImageUrl":"secret.png"}}}`)
+
+	accepted, _ := g.sanitizeUpdate(doc(t, `{"cards":{"c1":{
+		"visibility": {"kind":"public"},
+		"heldBy": "mallory",
+		"position": [1,1,1]
+	}}}`), "mallory")
+
+	card, _ := accepted[colCards].(map[string]any)["c1"].(map[string]any)
+	assert.NotContains(t, card, fieldVisibility)
+	assert.NotContains(t, card, fieldHeldBy)
+	assert.Contains(t, card, fieldPosition, "the honest part of the patch still applies")
+}
+
+func TestUpdateCannotRepaintAnExistingCardsFace(t *testing.T) {
+	g := newSanitizeGame(t, `{"cards":{"c1":{"rotation":[0,0,0],"faceImageUrl":"real.png"}}}`)
+
+	accepted, _ := g.sanitizeUpdate(doc(t,
+		`{"cards":{"c1":{"faceImageUrl":"forged.png"},"c2":{"faceImageUrl":"mine.png","rotation":[0,0,0]}}}`),
+		"alice")
+
+	cards, _ := accepted[colCards].(map[string]any)
+	existing, _ := cards["c1"].(map[string]any)
+	assert.NotContains(t, existing, fieldFace)
+	created, _ := cards["c2"].(map[string]any)
+	assert.Equal(t, "mine.png", created[fieldFace], "putting your own card on the table is fine")
+}
+
+func TestUpdateCannotRewriteAnExistingDecksCards(t *testing.T) {
+	g := newSanitizeGame(t, `{"decks":{"d1":{"id":"d1","cards":[{"id":"x","faceImageUrl":"a.png"}]}}}`)
+
+	accepted, refused := g.sanitizeUpdate(doc(t,
+		`{"decks":{"d1":{"cards":[],"position":[1,1,1]}}}`), "alice")
+
+	deck, _ := accepted[colDecks].(map[string]any)["d1"].(map[string]any)
+	assert.NotContains(t, deck, fieldCards, "draw/shuffle/place are actions, not patches")
+	assert.Contains(t, deck, fieldPosition, "moving the deck around is still fine")
+	assert.Len(t, refused, 1)
+}
+
+func TestUpdateAllowsWholesaleDeckDefinition(t *testing.T) {
+	g := newSanitizeGame(t, `{"decks":{}}`)
+
+	accepted, refused := g.sanitizeUpdate(doc(t,
+		`{"decks":{"d1":{"id":"d1","cards":[{"id":"x","faceImageUrl":"a.png"}]}}}`), "alice")
+
+	deck, _ := accepted[colDecks].(map[string]any)["d1"].(map[string]any)
+	require.NotNil(t, deck)
+	assert.Len(t, deck[fieldCards], 1, "imports and scenario seeds bring their own card lists")
+	assert.Empty(t, refused)
+}
+
+func TestSanitizeDoesNotAliasTheIncomingPatch(t *testing.T) {
+	g := newSanitizeGame(t, `{"cards":{}}`)
+	patch := doc(t, `{"cards":{"c1":{"position":[1,1,1],"rotation":[0,0,0]}}}`)
+
+	accepted, _ := g.sanitizeUpdate(patch, "alice")
+	entity(patch, colCards, "c1")[fieldPosition] = "tampered"
+
+	card, _ := accepted[colCards].(map[string]any)["c1"].(map[string]any)
+	assert.Equal(t, []any{1.0, 1.0, 1.0}, card[fieldPosition])
+}

--- a/server/game/state.go
+++ b/server/game/state.go
@@ -16,9 +16,26 @@ type Game struct {
 	LastActivity time.Time `json:"lastActivity"`
 	Updates      int64     `json:"updates"`
 
+	// views is what we believe each client's copy of the state looks like —
+	// the filtered document last sent to them. Outgoing patches are diffed
+	// against it, so a client is only ever told about the part of a change it
+	// is entitled to know about.
+	views map[string]map[string]any
+	// holds tracks when each hold lease goes stale, keyed by "<collection>/<id>".
+	// The lease itself lives on the entity (heldBy) so every client can see who
+	// is dragging what; only the expiry is server-private.
+	holds map[string]time.Time
+
 	out chan *PlayerMessage
 	mu  sync.Mutex
 }
+
+// holdTTL bounds a lease that was never dropped — a wedged tab or a lost
+// pointerup must not park a card out of everyone else's reach forever.
+const holdTTL = 60 * time.Second
+
+// serverID is the sender stamped on messages the server itself originates.
+const serverID = "server"
 
 type PlayerMessage struct {
 	// TODO: Probably a better way to add addressing
@@ -28,12 +45,16 @@ type PlayerMessage struct {
 }
 
 func NewGame() (*Game, <-chan *PlayerMessage) {
-	out := make(chan *PlayerMessage, 50)
+	// one buffered slot per message, and a fan-out now produces one message per
+	// connected player rather than one for the whole lobby
+	out := make(chan *PlayerMessage, 256)
 	now := time.Now()
 	return &Game{
 		Players:      make(map[string]*Player),
 		out:          out,
 		Data:         map[string]any{},
+		views:        make(map[string]map[string]any),
+		holds:        make(map[string]time.Time),
 		CreatedAt:    now,
 		LastActivity: now,
 	}, out

--- a/server/game/visibility.go
+++ b/server/game/visibility.go
@@ -1,0 +1,222 @@
+package game
+
+import (
+	"regexp"
+	"slices"
+	"strings"
+)
+
+// Collections inside the synced GameDTO document.
+const (
+	colCards    = "cards"
+	colDecks    = "decks"
+	colPlayers  = "players"
+	colPieces   = "pieces"
+	colOverlays = "overlays"
+)
+
+// Fields the server owns. A client may never write these — they are the
+// secrecy model itself, so a hand-crafted socket message must not be able to
+// declare a card public or hand itself a hold lease.
+const (
+	fieldVisibility = "visibility"
+	fieldHeldBy     = "heldBy"
+	fieldFace       = "faceImageUrl"
+	fieldBack       = "backImageUrl"
+	fieldTray       = "tray"
+	fieldHandCount  = "handCount"
+	fieldCards      = "cards"
+	fieldCardCount  = "cardCount"
+	fieldIsFaceUp   = "isFaceUp"
+	fieldRotation   = "rotation"
+	fieldPosition   = "position"
+	fieldSeenBy     = "seenBy"
+	fieldKind       = "kind"
+)
+
+const (
+	visPublic = "public"
+	visHidden = "hidden"
+)
+
+// facedownRotationX is the flip convention shared with the client: 180° on the
+// x axis means the back of the card is what the table sees.
+const facedownRotationX = 180.0
+
+// seatPlaceholder matches the `seat0`–`seat3` stand-in players a scenario is
+// authored against. They are not real players, so nobody is entitled to their
+// hand until a player claims the seat (see claimSeat).
+var seatPlaceholder = regexp.MustCompile(`^seat[0-3]$`)
+
+func isSeatPlaceholder(id string) bool { return seatPlaceholder.MatchString(id) }
+
+// isFacedown reports whether a card's rotation puts its back up.
+func isFacedown(card map[string]any) bool {
+	rot := floats(card[fieldRotation], 3)
+	return rot[0] == facedownRotationX
+}
+
+// cardVisibility resolves a card's visibility descriptor.
+//
+// A missing descriptor falls back to orientation: a facedown card is hidden
+// from everyone. That default is deliberately the *safe* one — state seeded by
+// an older client or a scenario file has no descriptor, and inferring "public"
+// there would leak exactly what this model exists to protect.
+func cardVisibility(card map[string]any) (kind string, seenBy []string) {
+	if v, ok := card[fieldVisibility].(map[string]any); ok {
+		switch k, _ := v[fieldKind].(string); k {
+		case visPublic:
+			return visPublic, nil
+		case visHidden:
+			return visHidden, strSlice(v[fieldSeenBy])
+		}
+	}
+	if isFacedown(card) {
+		return visHidden, nil
+	}
+	return visPublic, nil
+}
+
+// canSeeCard reports whether playerID is entitled to a card's face.
+func canSeeCard(card map[string]any, playerID string) bool {
+	kind, seenBy := cardVisibility(card)
+	if kind == visPublic {
+		return true
+	}
+	return slices.Contains(seenBy, playerID)
+}
+
+func hiddenVisibility(seenBy []string) map[string]any {
+	v := map[string]any{fieldKind: visHidden}
+	if len(seenBy) > 0 {
+		list := make([]any, len(seenBy))
+		for i, id := range seenBy {
+			list[i] = id
+		}
+		v[fieldSeenBy] = list
+	}
+	return v
+}
+
+func publicVisibility() map[string]any {
+	return map[string]any{fieldKind: visPublic}
+}
+
+// viewFor builds the copy of the game document that playerID is entitled to
+// receive. Everything a player may not see is removed here, on the way out of
+// the server — this is the one place the secrecy property is enforced for
+// reads, so nothing downstream needs to be trusted with hidden data.
+//
+// The rules:
+//   - a card whose face this player may not see ships without faceImageUrl
+//     (backs, transforms and the visibility descriptor still ship, so the table
+//     renders identically and the client knows *that* it is hidden)
+//   - a deck ships as a count; a face-up deck additionally ships its top card,
+//     which is the only card anyone can actually see
+//   - another player's tray ships as a count with no contents at all
+func viewFor(data map[string]any, playerID string) map[string]any {
+	out := make(map[string]any, len(data))
+	for key, value := range data {
+		switch key {
+		case colCards:
+			out[key] = filterCards(value, playerID)
+		case colDecks:
+			out[key] = filterDecks(value)
+		case colPlayers:
+			out[key] = filterPlayers(value, playerID)
+		default:
+			out[key] = deepCopy(value)
+		}
+	}
+	return out
+}
+
+func filterCards(value any, playerID string) any {
+	cards, ok := value.(map[string]any)
+	if !ok {
+		return deepCopy(value)
+	}
+	out := make(map[string]any, len(cards))
+	for id, raw := range cards {
+		card, ok := raw.(map[string]any)
+		if !ok {
+			out[id] = deepCopy(raw)
+			continue
+		}
+		copied := deepCopyMap(card)
+		if !canSeeCard(card, playerID) {
+			delete(copied, fieldFace)
+		}
+		out[id] = copied
+	}
+	return out
+}
+
+func filterDecks(value any) any {
+	decks, ok := value.(map[string]any)
+	if !ok {
+		return deepCopy(value)
+	}
+	out := make(map[string]any, len(decks))
+	for id, raw := range decks {
+		deck, ok := raw.(map[string]any)
+		if !ok {
+			out[id] = deepCopy(raw)
+			continue
+		}
+		copied := deepCopyMap(deck)
+		if cards, ok := deck[fieldCards].([]any); ok {
+			copied[fieldCardCount] = float64(len(cards))
+			// A face-up pile shows exactly one card to the table: its top.
+			// Everything under it — and every card in a facedown deck — stays
+			// on the server.
+			if isFaceUp(deck) && len(cards) > 0 {
+				copied[fieldCards] = []any{deepCopy(cards[0])}
+			} else {
+				delete(copied, fieldCards)
+			}
+		}
+		out[id] = copied
+	}
+	return out
+}
+
+func filterPlayers(value any, playerID string) any {
+	players, ok := value.(map[string]any)
+	if !ok {
+		return deepCopy(value)
+	}
+	out := make(map[string]any, len(players))
+	for id, raw := range players {
+		player, ok := raw.(map[string]any)
+		if !ok {
+			out[id] = deepCopy(raw)
+			continue
+		}
+		copied := deepCopyMap(player)
+		if tray, ok := player[fieldTray].(map[string]any); ok {
+			copied[fieldHandCount] = float64(len(tray))
+			if id != playerID {
+				delete(copied, fieldTray)
+			}
+		}
+		out[id] = copied
+	}
+	return out
+}
+
+func isFaceUp(deck map[string]any) bool {
+	up, _ := deck[fieldIsFaceUp].(bool)
+	return up
+}
+
+// renameOwner swaps the owner segment of a `kind:owner:slug` entity id.
+func renameOwner(id, from, to string) string {
+	parts := strings.Split(id, ":")
+	for i, part := range parts {
+		if part == from {
+			parts[i] = to
+		}
+	}
+	return strings.Join(parts, ":")
+}

--- a/server/game/visibility_test.go
+++ b/server/game/visibility_test.go
@@ -1,0 +1,198 @@
+package game
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// doc decodes a JSON literal into the same shape the server holds state in, so
+// tests exercise the real float64/[]any/map[string]any world.
+func doc(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(raw), &out))
+	return out
+}
+
+func TestViewStripsFacesOfHiddenCards(t *testing.T) {
+	state := doc(t, `{
+		"cards": {
+			"card:alice:1": {
+				"faceImageUrl": "ace-of-spades.png",
+				"backImageUrl": "back.png",
+				"position": [1,0,1],
+				"rotation": [180,0,0],
+				"visibility": {"kind": "hidden"}
+			},
+			"card:alice:2": {
+				"faceImageUrl": "two-of-clubs.png",
+				"rotation": [0,0,0],
+				"visibility": {"kind": "public"}
+			}
+		}
+	}`)
+
+	for _, player := range []string{"alice", "bob"} {
+		view := viewFor(state, player)
+		hidden := entity(view, colCards, "card:alice:1")
+		assert.NotContains(t, hidden, fieldFace, "%s must not receive a hidden face", player)
+		// everything needed to render the card is still there
+		assert.Equal(t, "back.png", hidden[fieldBack])
+		assert.NotNil(t, hidden[fieldPosition])
+		assert.NotNil(t, hidden[fieldVisibility])
+
+		public := entity(view, colCards, "card:alice:2")
+		assert.Equal(t, "two-of-clubs.png", public[fieldFace])
+	}
+}
+
+func TestViewShipsFaceOnlyToPeeker(t *testing.T) {
+	state := doc(t, `{
+		"cards": {
+			"c1": {
+				"faceImageUrl": "secret.png",
+				"rotation": [180,0,0],
+				"visibility": {"kind": "hidden", "seenBy": ["alice"]}
+			}
+		}
+	}`)
+
+	assert.Equal(t, "secret.png", entity(viewFor(state, "alice"), colCards, "c1")[fieldFace])
+	assert.NotContains(t, entity(viewFor(state, "bob"), colCards, "c1"), fieldFace)
+}
+
+// A card with no visibility descriptor — seeded by a scenario file or an older
+// client — must fall back to the safe reading, not the convenient one.
+func TestVisibilityDefaultsToOrientation(t *testing.T) {
+	state := doc(t, `{
+		"cards": {
+			"down": {"faceImageUrl": "secret.png", "rotation": [180,0,0]},
+			"up":   {"faceImageUrl": "shown.png",  "rotation": [0,0,0]},
+			"bare": {"faceImageUrl": "shown.png"}
+		}
+	}`)
+	view := viewFor(state, "alice")
+
+	assert.NotContains(t, entity(view, colCards, "down"), fieldFace)
+	assert.Equal(t, "shown.png", entity(view, colCards, "up")[fieldFace])
+	assert.Equal(t, "shown.png", entity(view, colCards, "bare")[fieldFace])
+}
+
+func TestViewShipsOtherPlayersTrayAsACount(t *testing.T) {
+	state := doc(t, `{
+		"players": {
+			"alice": {"id":"alice","seat":0,"tray":{"c1":{"faceImageUrl":"a.png"},"c2":{"faceImageUrl":"b.png"}}},
+			"bob":   {"id":"bob","seat":1,"tray":{"c3":{"faceImageUrl":"c.png"}}},
+			"seat2": {"id":"seat2","seat":2,"tray":{"c4":{"faceImageUrl":"d.png"}}}
+		}
+	}`)
+
+	view := viewFor(state, "alice")
+
+	mine := entity(view, colPlayers, "alice")
+	assert.Len(t, mine[fieldTray], 2, "my own hand comes through in full")
+	assert.Equal(t, float64(2), mine[fieldHandCount])
+
+	theirs := entity(view, colPlayers, "bob")
+	assert.NotContains(t, theirs, fieldTray)
+	assert.Equal(t, float64(1), theirs[fieldHandCount])
+
+	// an unclaimed seat's pre-dealt hand belongs to nobody yet
+	placeholder := entity(view, colPlayers, "seat2")
+	assert.NotContains(t, placeholder, fieldTray)
+	assert.Equal(t, float64(1), placeholder[fieldHandCount])
+
+	// the belt-and-braces check the ticket asks for: inspect the payload
+	payload, err := json.Marshal(view)
+	require.NoError(t, err)
+	assert.NotContains(t, string(payload), "c.png")
+	assert.NotContains(t, string(payload), "d.png")
+	assert.Contains(t, string(payload), "a.png")
+}
+
+func TestViewShipsDeckAsACount(t *testing.T) {
+	state := doc(t, `{
+		"decks": {
+			"deck:alice:main": {
+				"id": "deck:alice:main",
+				"isFaceUp": false,
+				"deckBackImageUrl": "back.png",
+				"cards": [
+					{"id":"card:alice:main-AS","faceImageUrl":"ace.png"},
+					{"id":"card:alice:main-KH","faceImageUrl":"king.png"}
+				]
+			},
+			"deck:alice:discard": {
+				"id": "deck:alice:discard",
+				"isFaceUp": true,
+				"cards": [
+					{"id":"top","faceImageUrl":"top.png"},
+					{"id":"buried","faceImageUrl":"buried.png"}
+				]
+			}
+		}
+	}`)
+
+	view := viewFor(state, "alice")
+
+	facedown := entity(view, colDecks, "deck:alice:main")
+	assert.NotContains(t, facedown, fieldCards, "a facedown deck is a count, not a card list")
+	assert.Equal(t, float64(2), facedown[fieldCardCount])
+
+	discard := entity(view, colDecks, "deck:alice:discard")
+	assert.Len(t, discard[fieldCards], 1, "a face-up pile shows exactly its top card")
+	assert.Equal(t, float64(2), discard[fieldCardCount])
+
+	payload, err := json.Marshal(view)
+	require.NoError(t, err)
+	for _, secret := range []string{"ace.png", "king.png", "buried.png", "main-AS"} {
+		assert.NotContains(t, string(payload), secret)
+	}
+	assert.Contains(t, string(payload), "top.png")
+}
+
+func TestViewLeavesNonSecretCollectionsAlone(t *testing.T) {
+	state := doc(t, `{
+		"pieces": {"piece:1": {"kind":"token","position":[0,0,0]}},
+		"overlays": {"o1": {"imageUrl":"map.png"}}
+	}`)
+	view := viewFor(state, "alice")
+	assert.Equal(t, state[colPieces], view[colPieces])
+	assert.Equal(t, state[colOverlays], view[colOverlays])
+}
+
+// The view is a copy: mutating canonical state afterwards must not silently
+// rewrite what we believe a client already holds (which would break diffing).
+func TestViewIsADeepCopy(t *testing.T) {
+	state := doc(t, `{"cards":{"c1":{"faceImageUrl":"a.png","rotation":[0,0,0]}}}`)
+	view := viewFor(state, "alice")
+	entity(state, colCards, "c1")[fieldFace] = "changed.png"
+	assert.Equal(t, "a.png", entity(view, colCards, "c1")[fieldFace])
+}
+
+func TestDiffMapsProducesMergePatch(t *testing.T) {
+	old := doc(t, `{"cards":{"a":{"position":[0,0,0],"faceImageUrl":"x.png"},"b":{"position":[1,1,1]}}}`)
+	next := doc(t, `{"cards":{"a":{"position":[2,0,0]},"c":{"position":[3,3,3]}}}`)
+
+	patch := diffMaps(old, next)
+	cards, _ := patch[colCards].(map[string]any)
+	require.NotNil(t, cards)
+
+	changed, _ := cards["a"].(map[string]any)
+	assert.Equal(t, []any{2.0, 0.0, 0.0}, changed[fieldPosition])
+	assert.Contains(t, changed, fieldFace)
+	assert.Nil(t, changed[fieldFace], "a key that vanished becomes an explicit null")
+	assert.Nil(t, cards["b"], "a removed entity becomes an explicit null")
+	assert.NotNil(t, cards["c"])
+
+	// nothing changed → nothing to send
+	assert.Empty(t, diffMaps(old, old))
+
+	raw, err := json.Marshal(patch)
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(string(raw), `"b":null`))
+}

--- a/server/lobby/lobby.go
+++ b/server/lobby/lobby.go
@@ -174,8 +174,12 @@ func (l *Lobby) clientWrite(ctx context.Context, c *Client) {
 // unsubscribe will only close the connection once
 func (l *Lobby) unsubscribe(c *Client) {
 	c.close.Do(func() {
-		l.mu.Lock()
+		// outside l.mu: this releases the player's hold leases and fans the
+		// synthesized drop out through the game's channel, which run() drains
+		// under this same lock
 		l.state.DisconnectPlayer(c.Player)
+
+		l.mu.Lock()
 		_ = c.Conn.Close(websocket.StatusInternalError, "unsubscribing")
 		delete(l.clients, c)
 		// safe: run() only sends to clients still in the map, under this same

--- a/src/lib/Card.svelte
+++ b/src/lib/Card.svelte
@@ -11,9 +11,12 @@
 	import { gameActions } from './store/game/actions';
 	import { CARD_WIDTH, CARD_HEIGHT, CARD_THICKNESS, CARD_REST_Y } from '$lib/utils/constants-cards';
 	import { resolveCardImage, sheetRefCache } from '$lib/packs';
+	import { canSeeFace, isHeldByOther } from './store/game/visibility';
+	import toast from 'svelte-french-toast';
 	type Vec3Array = [number, number, number];
 
 	let { id }: { id: string } = $props();
+	const myPlayerId = gameActions.getMyId() ?? '';
 
 	let card: THREE.Mesh | undefined = $state();
 	const initCardState: GameDTO['cards'][string] = {
@@ -25,7 +28,13 @@
 
 	const isDragging = $derived($dragStore.isDragging === id);
 	const cardState = $derived($gameStore?.cards?.[id] ?? initCardState);
-	const faceImageUrl = $derived(resolveCardImage(cardState?.faceImageUrl, $sheetRefCache));
+	// Entitlement, not orientation: a card we may not see arrives with no face
+	// at all, and the visibility descriptor says so explicitly.
+	const canSee = $derived(canSeeFace(cardState, myPlayerId));
+	const heldByOther = $derived(isHeldByOther(cardState, myPlayerId));
+	const faceImageUrl = $derived(
+		canSee ? resolveCardImage(cardState?.faceImageUrl, $sheetRefCache) : ''
+	);
 	const backImageUrl = $derived(resolveCardImage(cardState?.backImageUrl, $sheetRefCache));
 	let isHovered = $state(false);
 	let emissiveIntensity = $state(0);
@@ -108,7 +117,15 @@
 		rotationTap.target = baseRotation[2];
 	});
 
+	// Starting a drag is a request for the hold lease, not a fait accompli: the
+	// server rejects a grab on a card somebody else already has, and corrects us
+	// if we started moving it anyway.
 	function handleDragStart() {
+		if (heldByOther) {
+			toast(`${cardState.heldBy} is holding that card`);
+			return;
+		}
+		gameActions.grabObject(id);
 		dragStart(id, position[1]); // Pass current height
 
 		// Animate to raised height with some extra bounce
@@ -141,28 +158,35 @@
 		<T.BoxGeometry args={[CARD_WIDTH - 0.04, CARD_THICKNESS * 0.92, CARD_HEIGHT - 0.04]} />
 		<T.MeshBasicMaterial color="#d9d6c9" />
 	</T.Mesh>
-	<!-- key the MESH, not the material: threlte 8.5 material swaps on a live
+	<!-- No face plane at all for a card we are not entitled to: there is no url
+	     to load, so nothing to peek at in devtools or in a drag ghost. When we
+	     do hold the face, the plane stays mounted (hidden while facedown) so the
+	     texture survives a flip.
+
+	     key the MESH, not the material: threlte 8.5 material swaps on a live
 	     mesh detach without reattaching (same bug as the felt table), leaving
 	     the default white material. Mesh recreation attaches cleanly. -->
-	{#key faceImageUrl}
-		<T.Mesh
-			castShadow
-			receiveShadow
-			bind:ref={card}
-			visible={!isFacedown}
-			rotation.x={-Math.PI / 2}
-			position.y={CARD_THICKNESS / 2}
-		>
-			<T.PlaneGeometry args={[CARD_WIDTH, CARD_HEIGHT]} />
-			<ImageMaterial
-				url={faceImageUrl ?? ''}
-				side={0}
-				radius={0.1}
-				monochromeColor={'#fff'}
-				monochromeStrength={emissiveIntensity}
-			/>
-		</T.Mesh>
-	{/key}
+	{#if faceImageUrl}
+		{#key faceImageUrl}
+			<T.Mesh
+				castShadow
+				receiveShadow
+				bind:ref={card}
+				visible={!isFacedown}
+				rotation.x={-Math.PI / 2}
+				position.y={CARD_THICKNESS / 2}
+			>
+				<T.PlaneGeometry args={[CARD_WIDTH, CARD_HEIGHT]} />
+				<ImageMaterial
+					url={faceImageUrl}
+					side={0}
+					radius={0.1}
+					monochromeColor={'#fff'}
+					monochromeStrength={emissiveIntensity}
+				/>
+			</T.Mesh>
+		{/key}
+	{/if}
 
 	{#if backImageUrl}
 		<!-- rotation.z compensates the width-axis flip so directional backs read upright -->

--- a/src/lib/Deck.svelte
+++ b/src/lib/Deck.svelte
@@ -8,6 +8,7 @@
 	import { gameStore } from './store/game/gameStore.svelte';
 	import { gameActions } from './store/game/actions';
 	import { resolveCardImage, sheetRefCache, CARD_BACK_DEFAULT } from '$lib/packs';
+	import { nanoid } from 'nanoid';
 
 	interactivity();
 
@@ -16,38 +17,56 @@
 	const deck = $derived($gameStore?.decks?.[id] ?? {});
 	const deckBackImage = $derived($gameStore?.decks?.[id].deckBackImageUrl ?? CARD_BACK_DEFAULT);
 
+	// A facedown deck arrives as a count with no card list — its order and its
+	// faces stay on the server. A face-up pile ships only the one card the table
+	// can actually see.
 	const cards = $derived($gameStore?.decks?.[id]?.cards ?? []);
+	const cardCount = $derived(deck.cardCount ?? cards.length);
 	const position: [number, number, number] = $derived(deck.position ?? [0, 0, 0]);
 	const rotation: [number, number, number] = $derived(deck.rotation ?? [0, 0, 0]);
 	const isFaceUp = $derived(deck.isFaceUp ?? false); // true = cards[0] is top, false = cards[cards.length - 1] is top
-	const lastCardImage = $derived(cards?.[0].faceImageUrl ?? '');
+	const lastCardImage = $derived(cards?.[0]?.faceImageUrl ?? '');
 	const displayedImage = $derived(
 		resolveCardImage(isFaceUp ? lastCardImage : deckBackImage, $sheetRefCache)
 	);
 
 	const isHovered = $derived(id === $dragStore.isDeckHovered);
 
+	// Drawing is a request: the client asks for a card under an id it makes up,
+	// and the server fills that id in with whatever was on top. The id is opaque
+	// on purpose — `card:alice:main-AS` would announce the card it names.
 	function handleDragStart(e: PointerEvent) {
 		e.stopPropagation();
 		const { x = 0, z = 0 } = $dragStore.intersectionPoint as THREE.Vector3;
-		const card = gameActions.drawFromTop(id);
-		if (!card) return console.warn('No card drawn');
+		const myPlayerId = gameActions.getMyId();
+		if (!myPlayerId) return console.warn('No player id — cannot draw');
 
 		const rotX = isFaceUp ? 0 : 180;
 		const rotY = 0;
 		const rotZ = -degrees[gameActions?.getMySeat()] / DEG2RAD;
-		gameStore.updateState({
+		const placement = {
+			cardId: `card:${myPlayerId}:${nanoid(10)}`,
+			position: [x, 2.5, z] as [number, number, number],
+			rotation: [rotX, rotY, rotZ] as [number, number, number]
+		};
+
+		const cardId = gameActions.drawFromTop(id, placement);
+		if (!cardId) return console.warn('No card drawn');
+
+		// paint the card being dragged straight away; the face (if we are even
+		// entitled to it) arrives with the server's confirmation
+		gameStore.updateStateSilently({
 			cards: {
-				[card.id]: {
-					...card,
-					position: [x, 2.5, z],
-					rotation: [rotX, rotY, rotZ],
-					backImageUrl: card.backImageUrl ?? deckBackImage
+				[cardId]: {
+					position: placement.position,
+					rotation: placement.rotation,
+					backImageUrl: deckBackImage,
+					visibility: isFaceUp ? { kind: 'public' } : { kind: 'hidden' }
 				}
 			}
 		});
 
-		dragStart(card.id, 2.5);
+		dragStart(cardId, 2.5);
 	}
 </script>
 
@@ -59,14 +78,9 @@
 	onpointerleave={() => setDeckHover(null)}
 >
 	<Billboard>
-		<Text
-			fontSize={0.5}
-			text={(cards ?? [])?.length?.toString() ?? '0'}
-			position={[0, 1.75, 0]}
-			anchorX="center"
-		/>
+		<Text fontSize={0.5} text={cardCount.toString()} position={[0, 1.75, 0]} anchorX="center" />
 	</Billboard>
-	{#if cards?.length > 0}
+	{#if cardCount > 0}
 		{#key displayedImage}
 			<T.Mesh castShadow receiveShadow rotation.x={-Math.PI / 2} position.y={0.21}>
 				<T.PlaneGeometry args={[1.4, 2]} />
@@ -75,7 +89,8 @@
 		{/key}
 	{/if}
 
-	<!-- PRELOAD THE NEXT DISCARD IMAGE -->
+	<!-- PRELOAD THE NEXT DISCARD IMAGE (offline only: online a pile ships just
+	     its top card, so there is no next image to warm) -->
 	{#if isFaceUp && cards.length > 1}
 		{@const preloadUrl = resolveCardImage(cards[1]?.faceImageUrl, $sheetRefCache)}
 		{#key preloadUrl}

--- a/src/lib/HUDPreview/PreviewCard.svelte
+++ b/src/lib/HUDPreview/PreviewCard.svelte
@@ -4,18 +4,24 @@
 	import { T } from '@threlte/core';
 	import { ImageMaterial, interactivity } from '@threlte/extras';
 	import { resolveCardImage, sheetRefCache } from '$lib/packs';
+	import { canSeeFace } from '$lib/store/game/visibility';
+	import { gameActions } from '$lib/store/game/actions';
 
 	interactivity();
 	let { id }: { id: string } = $props();
+	const myPlayerId = gameActions.getMyId() ?? '';
 	const card = $derived($gameStore?.cards?.[id] as NonNullable<GameDTO['cards'][string]>);
-	const isFlipped = $derived((card?.rotation ?? [0])[0] === 180);
+	// The preview is where a peeked card pays off: it shows the face you are
+	// entitled to even while the card lies facedown on the table. A card you may
+	// not see previews as its back — there is no face here to leak.
+	const canSee = $derived(canSeeFace(card, myPlayerId));
 
 	const cardSize = [1.4 * 1.4, 2 * 1.4];
 </script>
 
 {#if !!card}
 	{@const previewUrl = resolveCardImage(
-		isFlipped ? card.backImageUrl : card.faceImageUrl,
+		canSee ? card.faceImageUrl : card.backImageUrl,
 		$sheetRefCache
 	)}
 	{#key previewUrl}

--- a/src/lib/HUDTray/TrayCard.svelte
+++ b/src/lib/HUDTray/TrayCard.svelte
@@ -73,19 +73,11 @@
 	}
 	function handleDragStart() {
 		const { x = 0, z = 0 } = $dragStore.intersectionPoint as THREE.Vector3;
-
-		const movedCard = gameActions.moveCardOutOfTray(id, myPlayerId);
-		gameStore?.updateState({
-			cards: {
-				[id]: {
-					...movedCard,
-					position: [x, 2.5, z],
-					// 180 on x = facedown (matches flipCard convention) — cards leave the hand hidden
-					rotation: [180, 0, -degrees[gameActions?.getMySeat()] / DEG2RAD],
-					faceImageUrl: movedCard?.faceImageUrl ?? card?.faceImageUrl,
-					backImageUrl: movedCard?.backImageUrl ?? card.backImageUrl ?? CARD_BACK_DEFAULT // TODO: update this with its actual cardback
-				}
-			}
+		gameActions.moveCardOutOfTray(id, myPlayerId, {
+			position: [x, 2.5, z],
+			// 180 on x = facedown (matches flipCard convention) — cards leave the hand hidden
+			rotation: [180, 0, -degrees[gameActions?.getMySeat()] / DEG2RAD],
+			backImageUrl: card.backImageUrl ?? CARD_BACK_DEFAULT // TODO: update this with its actual cardback
 		});
 		dragStart(id, 2.5);
 	}

--- a/src/lib/Intersection.svelte
+++ b/src/lib/Intersection.svelte
@@ -4,7 +4,10 @@
 	import { ImageMaterial } from '@threlte/extras';
 	import { DEG2RAD } from 'three/src/math/MathUtils.js';
 	import { gameStore } from './store/game/gameStore.svelte';
+	import { faceFor } from './store/game/visibility';
+	import { gameActions } from './store/game/actions';
 
+	const myPlayerId = gameActions.getMyId() ?? '';
 	const intersectionPoint = $derived($dragStore.intersectionPoint);
 </script>
 
@@ -13,10 +16,12 @@
 		{#if $dragStore.isDragging}
 			{@const card = $gameStore?.cards?.[$dragStore.isDragging]}
 			{@const rotation = card?.rotation ?? [0, 0, 0]}
+			<!-- the drop ghost can only ever show a face this client is entitled
+			     to: a hidden card has no faceImageUrl to render -->
 			<T.Mesh position.y={0.01} rotation.x={-Math.PI / 2} rotation.z={-rotation[2] * DEG2RAD}>
 				<T.PlaneGeometry args={[1.4, 2]} />
 				<ImageMaterial
-					url={card?.faceImageUrl ?? ''}
+					url={faceFor(card, myPlayerId) ?? ''}
 					side={0}
 					radius={0.1}
 					transparent={true}

--- a/src/lib/Piece.svelte
+++ b/src/lib/Piece.svelte
@@ -6,10 +6,14 @@
 	import { gameStore } from './store/game/gameStore.svelte';
 	import { gameActions } from './store/game/actions';
 	import { resolveCardImage, sheetRefCache } from '$lib/packs';
+	import { isHeldByOther } from './store/game/visibility';
+	import toast from 'svelte-french-toast';
 
 	let { id }: { id: string } = $props();
+	const myPlayerId = gameActions.getMyId() ?? '';
 
 	const piece = $derived($gameStore?.pieces?.[id]);
+	const heldByOther = $derived(isHeldByOther(piece, myPlayerId));
 	const kind = $derived(piece?.kind ?? 'token');
 	const radius = $derived(piece?.radius ?? 0.75);
 	const color = $derived(piece?.color ?? '#c8c4b8');
@@ -57,6 +61,11 @@
 			gameActions.incrementCounter(id, -1);
 			return;
 		}
+		if (heldByOther) {
+			toast(`${piece?.heldBy} is holding that piece`);
+			return;
+		}
+		gameActions.grabObject(id);
 		dragStart(id, position[1]);
 		height.target = 1.2;
 	}

--- a/src/lib/Table.svelte
+++ b/src/lib/Table.svelte
@@ -25,30 +25,36 @@
 			if (px !== undefined && pz !== undefined) {
 				gameStore.updateState({ pieces: { [id]: { position: [px, PIECE_REST_Y, pz] } } });
 			}
+			gameActions.dropObject(id);
 			dragEnd();
 			return;
 		}
 
-		const { faceImageUrl } = gameActions.getCardState($dragStore.isDragging) ?? {};
-
 		if ($dragStore.isTrayHovered) {
-			console.log('Storing in hand:', id, faceImageUrl);
+			// tray/placeOnDeck end the lease themselves — the card is leaving the
+			// table, so there is nothing left to hold
 			gameActions.moveCardToTray(id, gameActions?.getMe()?.id as string);
+			dragEnd();
+			return;
 		}
 
 		if (!!$dragStore.isDeckHovered) {
 			const deckIdHovered = $dragStore.isDeckHovered;
-			console.log('Storing in deck', deckIdHovered);
 			gameActions.placeOnTopOfDeck(deckIdHovered, id);
+			dragEnd();
+			return;
 		}
 
 		const card = gameActions.getCardState(id);
-		const [x, y, z] = card?.position ?? [];
+		const [x, , z] = card?.position ?? [];
 		if (x && z) {
 			const restY = resolveStackHeight($gameStore?.cards, id, x, z);
 			gameStore.updateState({ cards: { [id]: { position: [x, restY, z] } } });
 		}
 
+		// releasing the lease is the last thing that happens: the settle above
+		// still needs it (sendGameAction flushes the queued drag frame first)
+		gameActions.dropObject(id);
 		dragEnd();
 	}
 

--- a/src/lib/hud/__tests__/players.test.ts
+++ b/src/lib/hud/__tests__/players.test.ts
@@ -72,6 +72,23 @@ describe('derivePlayerRows', () => {
 		expect(rows.find((r) => r.id === 'seat2')?.handCount).toBe(0);
 	});
 
+	// Online there is nothing to count: another player's tray and a facedown
+	// deck's card list never reach this client, only the server's numbers do.
+	it('uses the server counts when the contents are withheld', () => {
+		const rows = derivePlayerRows({
+			players: {
+				me: { id: 'me', seat: 0, joinTimestamp: 1, tray: { c1: card }, handCount: 1, metadata: {} },
+				them: { id: 'them', seat: 1, joinTimestamp: 2, handCount: 4, metadata: {} } as never
+			},
+			decks: {
+				'deck:them:main': { id: 'deck:them:main', cardCount: 37 }
+			}
+		});
+		expect(rows.find((r) => r.id === 'me')?.handCount).toBe(1);
+		expect(rows.find((r) => r.id === 'them')?.handCount).toBe(4);
+		expect(rows.find((r) => r.id === 'them')?.decks).toEqual([{ slot: 'main', count: 37 }]);
+	});
+
 	it('groups decks by owner from the deck id, sorted by slot', () => {
 		const rows = derivePlayerRows(state);
 		expect(rows.find((r) => r.id === 'alice')?.decks).toEqual([

--- a/src/lib/hud/players.ts
+++ b/src/lib/hud/players.ts
@@ -7,8 +7,10 @@
  * `card:<playerId>:…`), so an opponent's hand size and deck counts are
  * derivable without any new wire messages.
  *
- * Only counts are exposed for other players. Card faces/ids of somebody
- * else's tray must never leave this module.
+ * Counts are all there is to work with: another player's tray and a facedown
+ * deck's card list never reach this client at all, so `handCount`/`cardCount`
+ * (server-derived) are the numbers, with the local lengths as the offline
+ * fallback for the /setup editor.
  */
 
 import { isSeatPlaceholder } from '$lib/scenario/scenario';
@@ -82,7 +84,10 @@ export function derivePlayerRows(
 	for (const [deckId, deck] of Object.entries(state?.decks ?? {})) {
 		const owner = ownerOf(deckId);
 		if (!owner || !deck) continue;
-		(decksByOwner[owner] ??= []).push({ slot: slotOf(deckId), count: deck.cards?.length ?? 0 });
+		(decksByOwner[owner] ??= []).push({
+			slot: slotOf(deckId),
+			count: deck.cardCount ?? deck.cards?.length ?? 0
+		});
 	}
 	for (const decks of Object.values(decksByOwner))
 		decks.sort((a, b) => a.slot.localeCompare(b.slot));
@@ -100,7 +105,7 @@ export function derivePlayerRows(
 				joinTimestamp: player?.joinTimestamp ?? 0,
 				isMe: !!myId && id === myId,
 				isOpenSeat: isSeatPlaceholder(id),
-				handCount: Object.keys(player?.tray ?? {}).length,
+				handCount: player?.handCount ?? Object.keys(player?.tray ?? {}).length,
 				decks: decksByOwner[id] ?? [],
 				tableCount: tableByOwner[id] ?? 0
 			};

--- a/src/lib/scenario/scenario.ts
+++ b/src/lib/scenario/scenario.ts
@@ -14,6 +14,7 @@ import { get } from 'svelte/store';
 import { gameStore } from '$lib/store/game/gameStore.svelte';
 import { gameActions } from '$lib/store/game/actions';
 import { prewarmGameState } from '$lib/packs/prewarm-state';
+import { sendGameAction } from '$lib/store/game/actions/net';
 import type { GameDTO } from '$lib/store/game/types';
 
 const STORAGE_KEY = 'scenarios:v1';
@@ -145,6 +146,10 @@ function renameOwner(key: string, from: string, to: string): string {
  * Claim a placeholder seat as the local player: the seat index + tray move
  * onto my player, and every entity owned by the placeholder is renamed to my
  * id so ownership-based UI (deck panes) follows. No-op if already claimed.
+ *
+ * Online this has to be a server action. An unclaimed seat's pre-dealt hand is
+ * hidden from everybody — including whoever is about to sit down — so the
+ * claiming client cannot see what it is claiming, let alone move it.
  */
 export function claimSeat(seat: SeatIndex): boolean {
 	const myId = gameActions.getMyId();
@@ -153,6 +158,8 @@ export function claimSeat(seat: SeatIndex): boolean {
 	const s = get(gameStore);
 	const ph = s?.players?.[placeholder];
 	if (!ph) return false;
+
+	if (sendGameAction('claimSeat', { seat })) return true;
 
 	// decks first, one message each — full card lists must stay under the
 	// server's websocket read limit

--- a/src/lib/store/game/__tests__/actions.test.ts
+++ b/src/lib/store/game/__tests__/actions.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+const sent: any[] = [];
+let connected = true;
+
+vi.mock('$lib/websocket/connection', () => ({
+	isWebSocketConnected: () => connected,
+	sendMessage: (message: any) => {
+		sent.push(message);
+		return true;
+	}
+}));
+vi.mock('$lib/websocket/storeIntegration', () => ({ flushPendingUpdate: () => {} }));
+
+const { gameStore } = await import('../gameStore.svelte');
+const { gameActions } = await import('../actions');
+
+const facedownCard = {
+	position: [0, 0, 0] as [number, number, number],
+	rotation: [180, 0, 0] as [number, number, number],
+	faceImageUrl: 'ace.png',
+	visibility: { kind: 'hidden' as const }
+};
+
+const actionsSent = () => sent.filter((m) => m.type === 'action').map((m) => m.value);
+
+beforeEach(() => {
+	sent.length = 0;
+	connected = true;
+	localStorage.setItem('myPlayerId', 'me');
+	gameStore.set({
+		cards: { c1: { ...facedownCard } },
+		players: { me: { id: 'me', seat: 0, joinTimestamp: 0, tray: {}, metadata: {} } },
+		decks: {
+			'deck:me:main': {
+				id: 'deck:me:main',
+				cards: [{ id: 'x', faceImageUrl: 'two.png' }],
+				cardCount: 9
+			}
+		}
+	});
+});
+
+describe('with a server to arbitrate', () => {
+	it('asks to flip rather than flipping', () => {
+		gameActions.flipCard('c1');
+		expect(actionsSent()).toEqual([{ action: 'flip', id: 'c1' }]);
+		// the card does not turn over until the server says so — it is holding
+		// the face until then
+		expect(get(gameStore).cards?.c1?.rotation).toEqual([180, 0, 0]);
+	});
+
+	it('asks to peek, and does not invent an entitlement', () => {
+		gameActions.peekCard('c1');
+		expect(actionsSent()).toEqual([{ action: 'peek', id: 'c1' }]);
+		expect(get(gameStore).cards?.c1?.visibility).toEqual({ kind: 'hidden' });
+	});
+
+	it('grabs before dragging and drops after', () => {
+		gameActions.grabObject('c1');
+		gameActions.dropObject('c1');
+		expect(actionsSent()).toEqual([
+			{ action: 'grab', id: 'c1' },
+			{ action: 'drop', id: 'c1' }
+		]);
+	});
+
+	it('moves a card into the hand without writing the hand', () => {
+		gameActions.moveCardToTray('c1', 'me');
+		expect(actionsSent()).toEqual([{ action: 'tray', id: 'c1' }]);
+		const state = get(gameStore);
+		expect(state.cards?.c1).toBeUndefined(); // gone from the table immediately
+		expect(state.players?.me?.tray).toEqual({}); // the hand comes from the server
+	});
+
+	it('takes a card out of the hand facedown, leaving its face behind', () => {
+		gameStore.set({
+			...get(gameStore),
+			players: {
+				me: {
+					id: 'me',
+					seat: 0,
+					joinTimestamp: 0,
+					tray: { c9: { faceImageUrl: 'king.png', backImageUrl: 'back.png' } },
+					metadata: {}
+				}
+			}
+		});
+
+		gameActions.moveCardOutOfTray('c9', 'me', {
+			position: [1, 2.5, 1],
+			rotation: [180, 0, 0]
+		});
+
+		expect(actionsSent()).toEqual([
+			{ action: 'untray', id: 'c9', position: [1, 2.5, 1], rotation: [180, 0, 0] }
+		]);
+		const card = get(gameStore).cards?.c9;
+		expect(card?.faceImageUrl).toBeUndefined();
+		expect(card?.backImageUrl).toBe('back.png');
+		expect(card?.visibility).toEqual({ kind: 'hidden' });
+	});
+
+	it('draws by id and never touches the deck itself', () => {
+		const id = gameActions.drawFromTop('deck:me:main', {
+			cardId: 'card:me:opaque',
+			position: [0, 2.5, 0],
+			rotation: [180, 0, 0]
+		});
+		expect(id).toBe('card:me:opaque');
+		expect(actionsSent()).toEqual([
+			{
+				action: 'draw',
+				deckId: 'deck:me:main',
+				id: 'card:me:opaque',
+				position: [0, 2.5, 0],
+				rotation: [180, 0, 0]
+			}
+		]);
+		expect(get(gameStore).decks?.['deck:me:main']?.cards).toHaveLength(1);
+	});
+
+	it('counts a deck by what the server said, not by what it was sent', () => {
+		expect(gameActions.getDeckLength('deck:me:main')).toBe(9);
+	});
+
+	it('shuffles server-side', () => {
+		gameActions.shuffleDeck('deck:me:main');
+		expect(actionsSent()).toEqual([{ action: 'shuffle', deckId: 'deck:me:main' }]);
+	});
+});
+
+describe('with no server (the offline scenario editor)', () => {
+	beforeEach(() => {
+		connected = false;
+	});
+
+	it('flips locally and keeps the visibility model consistent', () => {
+		gameActions.flipCard('c1');
+		expect(actionsSent()).toEqual([]);
+		expect(get(gameStore).cards?.c1?.rotation).toEqual([0, 0, 0]);
+		expect(get(gameStore).cards?.c1?.visibility).toEqual({ kind: 'public' });
+	});
+
+	it('moves the card into the hand itself', () => {
+		gameActions.moveCardToTray('c1', 'me');
+		const state = get(gameStore);
+		expect(state.cards?.c1).toBeUndefined();
+		expect(state.players?.me?.tray?.c1?.faceImageUrl).toBe('ace.png');
+	});
+
+	it('carries the face across when taking a card out of the hand', () => {
+		gameActions.moveCardToTray('c1', 'me');
+		gameActions.moveCardOutOfTray('c1', 'me', {
+			position: [1, 2.5, 1],
+			rotation: [180, 0, 0]
+		});
+		expect(get(gameStore).cards?.c1?.faceImageUrl).toBe('ace.png');
+	});
+
+	it('draws off the local deck', () => {
+		const id = gameActions.drawFromTop('deck:me:main', {
+			cardId: 'card:me:local',
+			position: [0, 2.5, 0],
+			rotation: [180, 0, 0]
+		});
+		expect(id).toBe('card:me:local');
+		expect(get(gameStore).cards?.['card:me:local']?.faceImageUrl).toBe('two.png');
+		expect(get(gameStore).decks?.['deck:me:main']?.cards).toHaveLength(0);
+	});
+});

--- a/src/lib/store/game/__tests__/visibility.test.ts
+++ b/src/lib/store/game/__tests__/visibility.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { canSeeFace, faceFor, isHeldByOther, visibilityOf } from '../visibility';
+
+describe('visibilityOf', () => {
+	it('reads an explicit descriptor', () => {
+		expect(visibilityOf({ visibility: { kind: 'public' } })).toEqual({ kind: 'public' });
+		expect(visibilityOf({ visibility: { kind: 'hidden', seenBy: ['a'] } })).toEqual({
+			kind: 'hidden',
+			seenBy: ['a']
+		});
+	});
+
+	it('falls back to orientation, hiding anything facedown', () => {
+		expect(visibilityOf({ rotation: [180, 0, 0] })).toEqual({ kind: 'hidden' });
+		expect(visibilityOf({ rotation: [0, 0, 0] })).toEqual({ kind: 'public' });
+		expect(visibilityOf(undefined)).toEqual({ kind: 'public' });
+	});
+
+	it('trusts the descriptor over the rotation', () => {
+		// a peeked card lies facedown on the table but is not hidden from you
+		const peeked = {
+			rotation: [180, 0, 0] as [number, number, number],
+			visibility: { kind: 'hidden' as const, seenBy: ['me'] }
+		};
+		expect(canSeeFace(peeked, 'me')).toBe(true);
+		expect(canSeeFace(peeked, 'them')).toBe(false);
+
+		// and a face-up card is public whatever its rotation says
+		expect(canSeeFace({ rotation: [180, 0, 0], visibility: { kind: 'public' } }, 'them')).toBe(
+			true
+		);
+	});
+});
+
+describe('faceFor', () => {
+	it('returns nothing for a card this player may not see', () => {
+		const hidden = { faceImageUrl: 'leftover.png', visibility: { kind: 'hidden' as const } };
+		expect(faceFor(hidden, 'me')).toBeUndefined();
+	});
+
+	it('returns the face once you are entitled to it', () => {
+		expect(faceFor({ faceImageUrl: 'ace.png', visibility: { kind: 'public' } }, 'me')).toBe(
+			'ace.png'
+		);
+		expect(
+			faceFor({ faceImageUrl: 'ace.png', visibility: { kind: 'hidden', seenBy: ['me'] } }, 'me')
+		).toBe('ace.png');
+	});
+
+	it('has nothing to return when the server withheld the url', () => {
+		expect(faceFor({ visibility: { kind: 'hidden' } }, 'me')).toBeUndefined();
+	});
+});
+
+describe('isHeldByOther', () => {
+	it('is true only while somebody else holds the lease', () => {
+		expect(isHeldByOther({ heldBy: 'them' }, 'me')).toBe(true);
+		expect(isHeldByOther({ heldBy: 'me' }, 'me')).toBe(false);
+		expect(isHeldByOther({}, 'me')).toBe(false);
+	});
+});

--- a/src/lib/store/game/actions/card.ts
+++ b/src/lib/store/game/actions/card.ts
@@ -2,6 +2,8 @@ import { get } from 'svelte/store';
 import { gameStore } from '../gameStore.svelte';
 import { dragStore } from '$lib/store/dragStore.svelte';
 import { CARD_REST_Y } from '$lib/utils/constants-cards';
+import { FACEDOWN_ROTATION_X } from '../visibility';
+import { sendGameAction } from './net';
 
 function getCardState(cardId: string) {
 	return get(gameStore)?.cards?.[cardId];
@@ -11,29 +13,97 @@ function removeCard(cardId: string) {
 	return gameStore.updateState({ cards: { [cardId]: null } });
 }
 
+/** The card a keyboard action applies to: whatever is hovered or being dragged. */
+function targetCardId(cardId?: string) {
+	const { isHovered, isDragging } = get(dragStore);
+	return cardId ?? isDragging ?? isHovered ?? undefined;
+}
+
 /**
- * Flips a card over
- * If no cardId provided, uses the id of the hovered card
+ * Flips a card over.
+ * If no cardId provided, uses the id of the hovered card.
+ *
+ * Online this is a request: turning a card face-up is what makes its face
+ * public, so only the server can complete it — it is holding the face until
+ * then. Offline (the /setup editor) there is nothing to hide, so we flip
+ * locally.
  * */
 function flipCard(cardId?: string) {
-	const { isHovered, isDragging } = get(dragStore);
-	const hoveredId = isHovered || isDragging;
-	let id = cardId ?? hoveredId;
+	const id = targetCardId(cardId);
 	if (!id) return console.error('No cardId provided to flip');
+	if (sendGameAction('flip', { id })) return;
 
 	const card = get(gameStore)?.cards?.[id];
-	const [_x = 0, y = 0, z = 0] = card?.rotation ?? [];
-	const isFlipped = card?.rotation?.[0] === 180; // 180 = backFace of card is visible
-	const x = isFlipped ? 0 : 180;
+	const [, y = 0, z = 0] = card?.rotation ?? [];
+	const isFlipped = card?.rotation?.[0] === FACEDOWN_ROTATION_X; // 180 = backFace of card is visible
+	const x = isFlipped ? 0 : FACEDOWN_ROTATION_X;
 	return gameStore.updateState({
-		cards: { [id as string]: { rotation: [x, y, z] } }
+		cards: {
+			[id]: {
+				rotation: [x, y, z],
+				visibility: isFlipped ? { kind: 'public' } : { kind: 'hidden' }
+			}
+		}
 	});
 }
 
+/**
+ * Look at a hidden card without turning it over.
+ *
+ * Deliberately a first-class move rather than a side effect of hovering: the
+ * server hands you the face *and* writes you into the card's `seenBy`, so the
+ * rest of the table can see that you looked.
+ * */
+function peekCard(cardId?: string) {
+	const id = targetCardId(cardId);
+	if (!id) return console.error('No cardId provided to peek');
+	if (sendGameAction('peek', { id })) return;
+
+	// offline: nothing is hidden from the only player there is
+	const visibility = get(gameStore)?.cards?.[id]?.visibility;
+	const seenBy = visibility?.kind === 'hidden' ? (visibility.seenBy ?? []) : [];
+	const me = localPlayerId() ?? 'local';
+	return gameStore.updateState({
+		cards: { [id]: { visibility: { kind: 'hidden', seenBy: [...seenBy, me] } } }
+	});
+}
+
+/** Turn a hidden card face-up for the whole table. */
+function revealCard(cardId?: string) {
+	const id = targetCardId(cardId);
+	if (!id) return console.error('No cardId provided to reveal');
+	if (sendGameAction('reveal', { id })) return;
+
+	const [, y = 0, z = 0] = get(gameStore)?.cards?.[id]?.rotation ?? [];
+	return gameStore.updateState({
+		cards: { [id]: { rotation: [0, y, z], visibility: { kind: 'public' } } }
+	});
+}
+
+function localPlayerId() {
+	try {
+		return localStorage.getItem('myPlayerId');
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Claim the hold lease on an object before dragging it. Rejected server-side
+ * when somebody else already holds it — which is what stops two players
+ * fighting over one card.
+ * */
+function grabObject(id: string) {
+	return sendGameAction('grab', { id });
+}
+
+/** Release the lease. The object keeps whatever transform was last streamed. */
+function dropObject(id: string) {
+	return sendGameAction('drop', { id });
+}
+
 function tapCard(isReverse?: boolean, cardId?: string) {
-	const { isHovered, isDragging } = get(dragStore);
-	const hoveredId = isHovered || isDragging;
-	let id = cardId ?? hoveredId;
+	const id = targetCardId(cardId);
 	if (!id) return console.error('No cardId provided to flip');
 
 	const card = get(gameStore)?.cards?.[id]; // grab card on table
@@ -41,14 +111,12 @@ function tapCard(isReverse?: boolean, cardId?: string) {
 	const isClockwise = isReverse ? -1 : 1; // isReverse reverses the rotation
 	const z = _z + 90 * isClockwise; // rotate 90 degrees counter/clockwise
 	gameStore.updateState({
-		cards: { [id as string]: { rotation: [x, y, z] } }
+		cards: { [id]: { rotation: [x, y, z] } }
 	});
 }
 
 function incrementHeight(increment: number, cardId?: string) {
-	const { isHovered, isDragging } = get(dragStore);
-	const hoveredId = isHovered || isDragging;
-	let id = cardId ?? hoveredId;
+	const id = targetCardId(cardId);
 	if (!id) return console.error('No cardId provided to increment');
 
 	const card = get(gameStore)?.cards?.[id]; // grab card on table
@@ -57,15 +125,9 @@ function incrementHeight(increment: number, cardId?: string) {
 	const ceiling = Math.min(0.5, y);
 	const _y = ceiling === 0.5 ? CARD_REST_Y : ceiling;
 	const mod = Math.max(CARD_REST_Y, _y + increment);
-	console.table({
-		debug: true,
-		y,
-		increment,
-		min: Math.min(0.5, y)
-	});
 	gameStore.updateState({
 		cards: {
-			[id as string]: { position: [x, mod, z] }
+			[id]: { position: [x, mod, z] }
 		}
 	});
 }
@@ -74,6 +136,10 @@ export const cardActions = {
 	getCardState,
 	removeCard,
 	flipCard,
+	peekCard,
+	revealCard,
+	grabObject,
+	dropObject,
 	tapCard,
 	incrementHeight
 };

--- a/src/lib/store/game/actions/deck.ts
+++ b/src/lib/store/game/actions/deck.ts
@@ -3,6 +3,7 @@ import { gameActions } from '.';
 import { gameStore } from '../gameStore.svelte';
 import { get } from 'svelte/store';
 import type { GameDTO } from '../types';
+import { sendGameAction } from './net';
 
 function getMyDecks() {
 	const myPlayerId = gameActions.getMe()?.id;
@@ -52,50 +53,101 @@ function addDeck(
 }
 
 /**
- * Draws from the top of the deck
- * Follows LIFO (Last In First Out)
- * When facedown (like a deck of cards), the top card = cards.length - 1
- * When faceup (like a visible discard pile), the top card = cards[0]
+ * Draws from the top of the deck onto the table.
  *
- * returns the card drawn.
+ * Deck order and deck faces live on the server — a client holds a count, not a
+ * card list — so drawing is a request for a specific new card id, which the
+ * server materializes (leased to you, facedown unless the pile is face-up).
+ * The caller can start dragging that id immediately.
+ *
+ * Follows LIFO (Last In First Out): when facedown (like a deck of cards) the
+ * top card is the last entry; when faceup (like a visible discard pile) it is
+ * the first.
+ *
+ * Returns the id of the card being drawn, or undefined when there is nothing
+ * to draw.
  * */
-function drawFromTop(id: string) {
-	const { cards, isFaceUp } = get(gameStore)?.decks?.[id] ?? {};
-	if (!cards || cards.length === 0)
-		return console.error('Cannot draw from an empty deck');
+function drawFromTop(
+	deckId: string,
+	placement: {
+		cardId: string;
+		position: [number, number, number];
+		rotation: [number, number, number];
+	}
+): string | undefined {
+	if (getDeckLength(deckId) === 0) {
+		console.error('Cannot draw from an empty deck');
+		return undefined;
+	}
 
-	const card = isFaceUp ? cards.shift() : cards.pop();
+	const { cardId, position, rotation } = placement;
+	if (sendGameAction('draw', { deckId, id: cardId, position, rotation })) {
+		return cardId;
+	}
+
+	// offline: we are the authority and hold the whole deck
+	const { cards, isFaceUp } = get(gameStore)?.decks?.[deckId] ?? {};
+	if (!cards || cards.length === 0) {
+		console.error('Cannot draw from an empty deck');
+		return undefined;
+	}
+	const drawn = isFaceUp ? cards.shift() : cards.pop();
+	if (!drawn) return undefined;
 	gameStore.updateState({
-		decks: { [id]: { cards } }
+		decks: { [deckId]: { cards } },
+		cards: {
+			[cardId]: {
+				faceImageUrl: drawn.faceImageUrl,
+				backImageUrl: drawn.backImageUrl,
+				position,
+				rotation,
+				visibility: isFaceUp ? { kind: 'public' } : { kind: 'hidden' }
+			}
+		}
 	});
-	return card; // returns card to hoist into cards for dragging
+	return cardId;
 }
 
-type Card = NonNullable<GameDTO['decks'][string]['cards']>[number];
+/** Put a table card back on a deck. The face goes back behind the server. */
 function placeOnTopOfDeck(deckId: string, cardId: string) {
-	const _card = get(gameStore)?.cards?.[cardId]; // grab card from table
-	if (!_card) return console.error('Card not found');
+	if (sendGameAction('placeOnDeck', { deckId, id: cardId })) {
+		return gameStore.updateStateSilently({ cards: { [cardId]: null } });
+	}
 
-	const { position, rotation, ...card } = { ..._card, id: cardId };
-	card.id = cardId;
+	const card = get(gameStore)?.cards?.[cardId]; // grab card from table
+	if (!card) return console.error('Card not found');
 	if (!card.faceImageUrl) return console.error('No card faceImageUrl found');
+
+	// only the identity travels back into the deck — transform and lease are
+	// table state, not card state
+	const entry = {
+		id: cardId,
+		faceImageUrl: card.faceImageUrl,
+		backImageUrl: card.backImageUrl
+	};
 
 	// get current deck
 	const { cards, isFaceUp } = get(gameStore)?.decks?.[deckId] ?? {};
 	if (!cards) return console.error('No cards found in deck');
 
-	isFaceUp ? cards.unshift(card as Card) : cards.push(card as Card);
+	isFaceUp ? cards.unshift(entry as Card) : cards.push(entry as Card);
 	return gameStore.updateState({
 		cards: { [cardId]: null },
 		decks: { [deckId]: { cards } }
 	});
 }
 
+type Card = NonNullable<GameDTO['decks'][string]['cards']>[number];
+
 /**
- * How many cards are in the deck
+ * How many cards are in the deck.
+ *
+ * `cardCount` is the server's number and covers the cards you cannot see;
+ * `cards.length` is the offline/local-authority fallback.
  * */
 function getDeckLength(id: string) {
-	return get(gameStore)?.decks?.[id]?.cards?.length ?? 0;
+	const deck = get(gameStore)?.decks?.[id];
+	return deck?.cardCount ?? deck?.cards?.length ?? 0;
 }
 
 function shuffleCards(cards: any[]) {
@@ -107,10 +159,13 @@ function shuffleCards(cards: any[]) {
 	return cards;
 }
 
-//   /**
-//    * Shuffle deck using the Fisher-Yates shuffle
-//    */
+/**
+ * Shuffle deck using the Fisher-Yates shuffle. Online the server does it —
+ * shuffling a list of counts would be theatre.
+ */
 export function shuffleDeck(deckId: string) {
+	if (sendGameAction('shuffle', { deckId })) return;
+
 	const deck = get(gameStore)?.decks?.[deckId];
 	const cards = deck?.cards;
 	if (!cards || cards.length === 0) return console.error('No cards to shuffle');

--- a/src/lib/store/game/actions/net.ts
+++ b/src/lib/store/game/actions/net.ts
@@ -1,0 +1,65 @@
+/**
+ * The action channel: gameplay moves that the server has to arbitrate.
+ *
+ * Anything that touches hidden information (draw, tray, flip, peek, shuffle) or
+ * that two players can fight over (grab, drop) is a *request*, not a fait
+ * accompli — the client says what it wants, the server decides, and the
+ * resulting state comes back through the normal patch stream.
+ *
+ * With no server (the /setup editor runs deliberately offline) there is nothing
+ * to arbitrate and nothing to hide: `sendGameAction` returns false and callers
+ * fall back to applying the move locally.
+ */
+
+import { isWebSocketConnected, sendMessage } from '$lib/websocket/connection';
+import { flushPendingUpdate } from '$lib/websocket/storeIntegration';
+import { gameActions } from '.';
+
+export type GameActionName =
+	| 'grab'
+	| 'drop'
+	| 'flip'
+	| 'peek'
+	| 'reveal'
+	| 'tray'
+	| 'untray'
+	| 'draw'
+	| 'placeOnDeck'
+	| 'shuffle'
+	| 'claimSeat';
+
+export type GameActionPayload = {
+	/** card or piece id; `piece:`-prefixed ids address a piece */
+	id?: string;
+	deckId?: string;
+	position?: [number, number, number];
+	rotation?: [number, number, number];
+	seat?: number;
+};
+
+/** True when the server is the authority — i.e. actions are worth sending. */
+export function isServerAuthoritative(): boolean {
+	return isWebSocketConnected();
+}
+
+/**
+ * Send one action. Returns false when there is no server, which callers read as
+ * "you are the authority, apply it yourself".
+ */
+export function sendGameAction(action: GameActionName, payload: GameActionPayload = {}): boolean {
+	if (!isWebSocketConnected()) return false;
+	const playerId = gameActions.getMyId();
+	if (!playerId) return false;
+
+	// A queued drag frame must not overtake the action that ends the drag: the
+	// throttle can be holding a trailing position update, and a move that lands
+	// after its `drop` no longer has a lease to ride on.
+	flushPendingUpdate();
+
+	return sendMessage({
+		type: 'action',
+		playerId,
+		timestamp: Date.now(),
+		value: { action, ...payload }
+	});
+}

--- a/src/lib/store/game/actions/tray.ts
+++ b/src/lib/store/game/actions/tray.ts
@@ -1,8 +1,23 @@
 import { get } from 'svelte/store';
 import { gameStore } from '../gameStore.svelte';
 import type { GameDTO } from '../types';
+import { sendGameAction } from './net';
 
+/**
+ * Put a table card into a player's hand.
+ *
+ * Online this is a server action, for two reasons: the card may be one you
+ * cannot see (so the client has no contents to move), and a hand is the one
+ * collection that is never sent to anybody else — the move has to happen on the
+ * side of the boundary that still holds the card.
+ * */
 function moveCardToTray(cardId: string, playerId: string) {
+	if (sendGameAction('tray', { id: cardId })) {
+		// mirror the visible half so the card leaves the table immediately; the
+		// hand itself comes back from the server
+		return gameStore.updateStateSilently({ cards: { [cardId]: null } });
+	}
+
 	const card = get(gameStore)?.cards?.[cardId] as NonNullable<
 		GameDTO['cards'][string]
 	>;
@@ -12,12 +27,51 @@ function moveCardToTray(cardId: string, playerId: string) {
 	});
 }
 
-function moveCardOutOfTray(cardId: string, playerId: string) {
+/**
+ * Take a card back out of your hand and onto the table, facedown.
+ *
+ * With a `placement` the card is materialized on the table too, ready to drag.
+ * Online that is the server's job — the card lands hidden from everyone, this
+ * player included, so only its back is painted locally and the face stays
+ * behind rather than lingering in the store. Offline we are the authority and
+ * carry the face across ourselves.
+ *
+ * Returns what the client knew about the card.
+ * */
+function moveCardOutOfTray(
+	cardId: string,
+	playerId: string,
+	placement?: {
+		position: [number, number, number];
+		rotation: [number, number, number];
+		backImageUrl?: string;
+	}
+) {
 	const card = get(gameStore)?.players?.[playerId]?.tray?.[cardId];
+	const emptySlot = { players: { [playerId]: { tray: { [cardId]: null } } } };
+
+	if (!placement) {
+		gameStore.updateState(emptySlot);
+		return card; // returns card to hoist into cards for dragging
+	}
+
+	const { backImageUrl, ...transform } = placement;
+	const onTable = {
+		...transform,
+		visibility: { kind: 'hidden' as const },
+		backImageUrl: card?.backImageUrl ?? backImageUrl
+	};
+
+	if (sendGameAction('untray', { id: cardId, ...transform })) {
+		gameStore.updateStateSilently({ ...emptySlot, cards: { [cardId]: onTable } });
+		return card;
+	}
+
 	gameStore.updateState({
-		players: { [playerId]: { tray: { [cardId]: null } } }
+		...emptySlot,
+		cards: { [cardId]: { ...onTable, faceImageUrl: card?.faceImageUrl } }
 	});
-	return card; // returns card to hoist into cards for dragging
+	return card;
 }
 
 export const trayActions = {

--- a/src/lib/store/game/types.ts
+++ b/src/lib/store/game/types.ts
@@ -1,11 +1,30 @@
 /**
+ * Who is entitled to a card's face.
+ *
+ * `public` — anyone at the table may see it (a face-up card).
+ * `hidden` — nobody may, except the players listed in `seenBy` (peekers, and
+ * the owner of the hand it sits in).
+ *
+ * This is the secrecy boundary, not a render flag: the server strips
+ * `faceImageUrl` on the way out for anyone this descriptor excludes, so a
+ * hidden card's face never reaches their client at all. The field is
+ * server-owned — clients read it, and change it only through the flip / peek /
+ * reveal actions.
+ */
+export type CardVisibility = { kind: 'public' } | { kind: 'hidden'; seenBy?: string[] };
+
+/**
  * Cards on the Table
  * */
 type CardDTO = {
 	position: [number, number, number];
 	rotation: [number, number, number];
+	/** absent when you are not entitled to see this card — see CardVisibility */
 	faceImageUrl: string;
 	backImageUrl?: string;
+	visibility?: CardVisibility;
+	/** server-granted hold lease: the player currently dragging this card */
+	heldBy?: string;
 };
 
 type CardInDeck = Omit<CardDTO, 'position' | 'rotation'> & { id: string };
@@ -23,9 +42,16 @@ type DeckDTO = {
 	position: [number, number, number];
 	rotation: [number, number, number];
 	/**
-	 * Cards in deck are an array instead of record
+	 * Cards in deck are an array instead of record.
+	 *
+	 * Only ever populated for what you may see: a facedown deck arrives with no
+	 * `cards` at all, a face-up pile with just its top card. Use `cardCount` for
+	 * the size, and the draw / shuffle / placeOnDeck actions to change it — deck
+	 * order lives on the server.
 	 * */
 	cards: CardInDeck[];
+	/** server-derived size of the deck, including the cards you cannot see */
+	cardCount?: number;
 };
 
 interface SeatState {
@@ -39,7 +65,13 @@ interface SeatState {
 type PlayerDTO = SeatState & {
 	id: string;
 	joinTimestamp: number;
+	/**
+	 * This player's hand. Only ever present for yourself — another player's
+	 * tray arrives as `handCount` and nothing else.
+	 * */
 	tray: Record<string, Partial<CardDTO | null>>;
+	/** server-derived hand size, present for every player including you */
+	handCount?: number;
 	/**
 	 * extend for future use with life/resources
 	 * */
@@ -64,6 +96,8 @@ type PieceDTO = {
 	/** counter state */
 	value?: number;
 	maxValue?: number;
+	/** server-granted hold lease: the player currently dragging this piece */
+	heldBy?: string;
 };
 
 type OverlayDTO = {

--- a/src/lib/store/game/visibility.ts
+++ b/src/lib/store/game/visibility.ts
@@ -1,0 +1,63 @@
+/**
+ * Client-side reading of the visibility model (see `CardVisibility` in
+ * types.ts). The server is what actually enforces secrecy — it never sends a
+ * face you are not entitled to — so these helpers exist to render the right
+ * thing, not to protect anything.
+ *
+ * Rendering keys off *this*, never off rotation: a facedown card you peeked at
+ * and a facedown card you have never seen look identical on the table but read
+ * differently in the preview HUD.
+ */
+
+import type { CardVisibility, GameDTO } from './types';
+
+type Card = Partial<GameDTO['cards'][string]> | null | undefined;
+
+/** 180° on the x axis = the table is looking at the card's back. */
+export const FACEDOWN_ROTATION_X = 180;
+
+export function isFacedown(card: Card): boolean {
+	return card?.rotation?.[0] === FACEDOWN_ROTATION_X;
+}
+
+/**
+ * Resolve a card's visibility, falling back to orientation when the descriptor
+ * is missing (local scenario editing, state authored before the field existed).
+ * The fallback is deliberately the cautious one — unlabelled and facedown means
+ * hidden.
+ */
+export function visibilityOf(card: Card): CardVisibility {
+	if (card?.visibility?.kind === 'public') return { kind: 'public' };
+	if (card?.visibility?.kind === 'hidden') return card.visibility;
+	return isFacedown(card) ? { kind: 'hidden' } : { kind: 'public' };
+}
+
+/** Is this player entitled to the card's face? */
+export function canSeeFace(card: Card, playerId?: string | null): boolean {
+	const visibility = visibilityOf(card);
+	if (visibility.kind === 'public') return true;
+	return !!playerId && !!visibility.seenBy?.includes(playerId);
+}
+
+/** Hidden from this player — the face is (and must stay) unavailable. */
+export function isHiddenFrom(card: Card, playerId?: string | null): boolean {
+	return !canSeeFace(card, playerId);
+}
+
+/**
+ * The face url to render, or undefined when there is nothing you may show.
+ * A card you may not see has no `faceImageUrl` in the first place; the
+ * visibility check is the belt to that braces.
+ */
+export function faceFor(card: Card, playerId?: string | null): string | undefined {
+	if (!canSeeFace(card, playerId)) return undefined;
+	return card?.faceImageUrl || undefined;
+}
+
+/** Someone else is dragging this object — hands off. */
+export function isHeldByOther(
+	object: { heldBy?: string } | null | undefined,
+	playerId?: string | null
+): boolean {
+	return !!object?.heldBy && object.heldBy !== playerId;
+}

--- a/src/lib/websocket/connection.ts
+++ b/src/lib/websocket/connection.ts
@@ -7,7 +7,17 @@ export type ConnectedPlayer = {
 };
 
 export type WebSocketMessage = {
-	type: 'connect' | 'sync' | 'update' | 'error' | 'disconnect' | 'playerList';
+	type:
+		| 'connect'
+		| 'sync'
+		| 'update'
+		| 'error'
+		| 'disconnect'
+		| 'playerList'
+		/** a gameplay move for the server to arbitrate — see actions/net.ts */
+		| 'action'
+		/** something the table should know happened, e.g. a peek */
+		| 'log';
 	path?: string[];
 	value?: any;
 	playerId: string;

--- a/src/lib/websocket/index.ts
+++ b/src/lib/websocket/index.ts
@@ -108,9 +108,19 @@ function setupMessageHandlers(): void {
 				prewarmGameState(message.value, () => gameStore.updateStateSilently({}));
 				break;
 
+			case 'log': {
+				// table events worth announcing: looking at a hidden card is a
+				// move, so everyone gets told who looked at what
+				const { kind, playerId, cardId } = message.value ?? {};
+				const verb = kind === 'peek' ? 'peeked at' : 'revealed';
+				console.log(`[log] ${playerId} ${verb} ${cardId}`);
+				if (playerId !== gameActions.getMyId()) toast(`${playerId} ${verb} a card`);
+				break;
+			}
+
 			case 'error':
 				console.error('Received error message:', message.value);
-				toast('Connection Error:', message.value);
+				toast(`Rejected: ${message.value}`);
 				break;
 
 			default:

--- a/src/lib/websocket/storeIntegration.ts
+++ b/src/lib/websocket/storeIntegration.ts
@@ -112,10 +112,32 @@ function mergePendingValue(pending: any, incoming: any) {
 	return merged;
 }
 
+/**
+ * Send whatever the position throttle is sitting on, right now.
+ *
+ * Actions bypass the throttle, so a queued drag frame would otherwise land
+ * *after* the `drop` that ended the drag — and be rejected, because by then the
+ * sender no longer holds the lease. Flushing first keeps the stream ordered.
+ * A no-op before `initWrappers` (the offline /setup editor).
+ */
+export let flushPendingUpdate: () => void = () => {};
+
 export function wsWrapperUpdateGameState(fn: Function) {
 	let lastSentTime = 0; // track the last time a message was sent
 	let positionTimeout: ReturnType<typeof setTimeout> | null = null;
 	let pendingPayload: any = null;
+
+	flushPendingUpdate = () => {
+		if (positionTimeout) {
+			clearTimeout(positionTimeout);
+			positionTimeout = null;
+		}
+		if (!pendingPayload) return;
+		lastSentTime = Date.now();
+		sendMessage(pendingPayload);
+		pendingPayload = null;
+	};
+
 	return function passArgs(...args: any[]) {
 		console.log('ws update gamestate: spread args', ...args);
 		const metadata = createWsMetaData();

--- a/src/routes/play/+page.svelte
+++ b/src/routes/play/+page.svelte
@@ -21,6 +21,11 @@
 		if (event.code === 'KeyC') cameraTransforms.resetView();
 		if (event.code === 'KeyT') gameActions.tapCard();
 		if (event.code === 'KeyR') gameActions.tapCard(true);
+		// P peeks (hold space to see it in the preview), shift+P reveals to all
+		if (event.code === 'KeyP') {
+			if (event.shiftKey) gameActions.revealCard();
+			else gameActions.peekCard();
+		}
 		if (event.code === 'ArrowUp') gameActions.incrementHeight(0.01);
 		if (event.code === 'ArrowDown') gameActions.incrementHeight(-0.01);
 	}

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -14,6 +14,10 @@
 		if (event.code === 'KeyC') cameraTransforms.resetView();
 		if (event.code === 'KeyT') gameActions.tapCard();
 		if (event.code === 'KeyR') gameActions.tapCard(true);
+		if (event.code === 'KeyP') {
+			if (event.shiftKey) gameActions.revealCard();
+			else gameActions.peekCard();
+		}
 		if (event.code === 'ArrowUp') gameActions.incrementHeight(0.01);
 		if (event.code === 'ArrowDown') gameActions.incrementHeight(-0.01);
 	}


### PR DESCRIPTION
Task: tableplace-37

Closes #37

Hidden information was not hidden: every client held every facedown card's face and every opponent's hand, and the server merged whatever patch arrived. Facedown was a render flag, not a data boundary.

## The model

Cards carry a visibility descriptor instead of having secrecy inferred from rotation:

```ts
type CardVisibility =
  | { kind: 'public' }
  | { kind: 'hidden'; seenBy?: string[] };
```

Missing descriptors (scenario files, older state) fall back to orientation — facedown reads as hidden, the safe direction. Rendering keys off this, not rotation.

## Per-recipient views

The server builds a filtered copy of the document for each player and diffs it against what that player was last sent, so each client receives a patch stream describing only the game it is allowed to know about.

| | entitled player | everyone else |
|---|---|---|
| card face | `faceImageUrl` | omitted — backs, transforms, descriptor still ship |
| hand | full contents, to its owner | `handCount` |
| deck | face-up pile: its top card | `cardCount` — a facedown deck's order and faces never leave |

## Two write paths

`update` merge patches stay for drag streams, layout, imports and scenario seeds, but are sanitized: no writing another player's row, a hand, an existing deck's card list, an existing card's face, the server-owned `visibility`/`heldBy`, or anything somebody else holds. Refused subtrees are dropped and the sender is corrected — its next patch is diffed against "what we last sent you, plus what you just tried", so an optimistic change that was refused gets walked back.

Everything that moves hidden information is a validated action instead, because the requesting client usually cannot hold the data the move operates on: `draw` (server pops the deck and materializes the card under a client-supplied *opaque* id — `card:alice:main-AS` would announce the card it names), `placeOnDeck`, `shuffle`, `tray`/`untray`, `flip`, `claimSeat`.

## Leases and deliberate reveals

`grab`/`drop` per SPEC §4c: concurrent grabs rejected, `heldBy` published on the entity so clients can refuse their own drag, released on disconnect at the last streamed transform (plus a 60s TTL for wedged tabs).

`peek` entitles you to a face *and* writes you into `seenBy` with a `log` message to the table — looking at a hidden card is a move, not a side effect of hovering. `reveal` turns a card face-up for everyone. Flipping back down withdraws the face from everyone, peekers included. This also makes the drag-ghost peek in #30 moot: the client has no face to render.

Offline (the /setup editor) there is nothing to hide and nobody to arbitrate, so actions fall back to applying the move locally.

## Verification

- `go test ./...`, `go vet ./...`, `go test -race ./...` — new coverage for per-recipient filtering, patch sanitization, lease contention, disconnect release, draw/tray/peek/claimSeat
- `bun run test` (66 passing) — client action layer online *and* offline, visibility helpers, HUD counts
- `bun run check` — 0 errors
- End-to-end over a real websocket, asserting on raw socket payloads: two clients, a deck, a draw, a contested move, flip/peek, tray, and a mid-drag disconnect. No deck or hand face ever reaches a client not entitled to it.

`bun run lint` still fails, as it does on `main` (29 prettier files, 59 eslint errors before this branch). This branch adds none of its own — new/changed files are prettier-clean and eslint is down to 52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019h4nygN4fauTDWqmVDz1Tx