### PR TITLE
tableplace-33: Presence — broadcast connected/disconnected for live HUD dots

### DIFF
--- a/server/game/game.go
+++ b/server/game/game.go
@@ -21,6 +21,10 @@ func (g *Game) HandleMessage(from *Player, msg Message) {
 	case "sync":
 		g.SyncPlayerState(from.ID)
 		return
+	case "connect":
+		// join handshake — presence is broadcast from ConnectPlayer, so there
+		// is nothing to relay and no client handles this type anymore
+		return
 	case "update":
 		g.update(msg)
 	}
@@ -60,67 +64,127 @@ func (g *Game) SyncPlayerState(id string) {
 	}
 }
 
+// DisconnectPlayer marks the player's socket as gone. The offline broadcast is
+// deferred by the grace period: a page refresh or brief network blip reconnects
+// the same player id within seconds, and the other clients should never see a
+// flicker. Only if the player is still gone when the timer fires does the
+// lobby learn about it.
+//
+// Called from lobby.unsubscribe while holding the lobby mutex — nothing here
+// may send on g.out (the lobby's run loop needs that same mutex to drain it).
 func (g *Game) DisconnectPlayer(p *Player) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	// TODO: channels?
-	p.Connected = false
-	// broadcastPlayerChange(c.Lobby, c.ID, "disconnect", time.Now().UnixMilli())
-}
-
-func (g *Game) BroadcastPlayerChange(playerID, changeType string, timestamp int64) {
-	// Create connect/disconnect message with path to update
-	msg := Message{
-		Type:      "update",
-		PlayerID:  playerID,
-		Timestamp: timestamp,
-	}
-
-	// Set value based on connection type
-	var valueJSON []byte
-	if changeType == "connect" {
-		valueJSON = []byte("true")
-	} else {
-		valueJSON = []byte("false")
-	}
-	msg.Value = json.RawMessage(valueJSON)
-
-	// Marshal message
-	payload, err := json.Marshal(msg)
-	if err != nil {
-		log.Err(err).Msg("Failed to marshal player change message")
+	p.conns--
+	if p.conns > 0 {
+		// another live socket for the same player id (overlapping reconnect) —
+		// the player is still connected, nothing to schedule
 		return
 	}
+	p.conns = 0
+	p.Connected = false
 
-	// Broadcast to all clients in the lobby
-	g.out <- &PlayerMessage{
-		To:      []string{},
-		Content: payload,
+	id := p.ID
+	if t, ok := g.offlineTimers[id]; ok {
+		t.Stop()
 	}
+	g.offlineTimers[id] = time.AfterFunc(g.offlineGrace, func() {
+		g.broadcastOffline(id)
+	})
+}
+
+// broadcastOffline runs when a disconnect grace period expires. If the player
+// reconnected in the meantime, it does nothing.
+func (g *Game) broadcastOffline(id string) {
+	g.mu.Lock()
+	delete(g.offlineTimers, id)
+	p, ok := g.Players[id]
+	if !ok || p.Connected {
+		g.mu.Unlock()
+		return
+	}
+	payload := g.mergePresenceLocked(id, false)
+	g.mu.Unlock()
+	g.sendPresence(payload)
 }
 
 func (g *Game) ConnectPlayer(playerID string) *Player {
 	g.mu.Lock()
-	defer g.mu.Unlock()
 	g.LastActivity = time.Now()
 
-	existing, ok := g.Players[playerID]
-	if ok {
-		// TODO: What?! We should check if the player is still listening
-		// on another websocket and do something.
-		existing.Connected = true
-		return existing
+	// reconnect inside the grace period: the offline patch was never sent, so
+	// cancel it and nobody ever learns the player was gone
+	if t, ok := g.offlineTimers[playerID]; ok {
+		t.Stop()
+		delete(g.offlineTimers, playerID)
 	}
 
-	newPlayer := &Player{
-		ID:            playerID,
-		JoinTimestamp: time.Now().UnixMilli(),
-		Connected:     true,
-		Seat:          0,
+	player, ok := g.Players[playerID]
+	if !ok {
+		player = &Player{
+			ID:            playerID,
+			JoinTimestamp: time.Now().UnixMilli(),
+			Seat:          0,
+		}
+		g.Players[playerID] = player
 	}
-	g.Players[playerID] = newPlayer
-	return newPlayer
+	player.conns++
+	player.Connected = true
+
+	payload := g.mergePresenceLocked(playerID, true)
+	g.mu.Unlock()
+
+	// send outside the lock — a full channel while holding g.mu can deadlock
+	g.sendPresence(payload)
+	return player
+}
+
+// mergePresenceLocked merges {"players": {id: {"connected": v}}} into g.Data
+// and returns the marshaled update message to broadcast. Caller must hold g.mu.
+//
+// The patch may create a partial row for an id not yet in g.Data.players (the
+// socket attaches before the client sends any player data); the HUD skips rows
+// without a joinTimestamp, so such rows are never rendered.
+func (g *Game) mergePresenceLocked(playerID string, connected bool) []byte {
+	patch := map[string]any{
+		"players": map[string]any{playerID: map[string]any{"connected": connected}},
+	}
+	g.Data = jsonmerge.MergeMaps(g.Data, patch)
+	g.Updates++
+
+	value, err := json.Marshal(patch)
+	if err != nil {
+		log.Err(err).Msg("Failed to marshal presence patch")
+		return nil
+	}
+	msg := Message{
+		Type:      "update",
+		PlayerID:  playerID,
+		Timestamp: time.Now().UnixMilli(),
+		Value:     value,
+	}
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		log.Err(err).Msg("Failed to marshal presence message")
+		return nil
+	}
+	return payload
+}
+
+// sendPresence broadcasts a presence update to the whole lobby without ever
+// blocking: DisconnectPlayer's timer can fire after the lobby stopped draining
+// g.out, and a stuck send there would leak the goroutine. Dropping a presence
+// patch on a full channel is harmless — the next sync carries the same state.
+func (g *Game) sendPresence(payload []byte) {
+	if payload == nil {
+		return
+	}
+	select {
+	case g.out <- &PlayerMessage{To: []string{}, Content: payload}:
+	default:
+		log.Warn().Msg("game out channel full, dropping presence update")
+	}
 }
 
 func (g *Game) update(msg Message) {

--- a/server/game/presence_test.go
+++ b/server/game/presence_test.go
@@ -1,0 +1,144 @@
+package game
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// drain empties the out channel and returns the decoded presence patches, in
+// order. Non-update messages fail the test — presence must ride the ordinary
+// update channel.
+func drainPresence(t *testing.T, out <-chan *PlayerMessage) []map[string]any {
+	t.Helper()
+	var patches []map[string]any
+	for {
+		select {
+		case msg := <-out:
+			var m Message
+			require.NoError(t, json.Unmarshal(msg.Content, &m))
+			require.Equal(t, "update", m.Type)
+			var patch map[string]any
+			require.NoError(t, json.Unmarshal(m.Value, &patch))
+			patches = append(patches, patch)
+		default:
+			return patches
+		}
+	}
+}
+
+func connectedValue(t *testing.T, patch map[string]any, id string) any {
+	t.Helper()
+	players, ok := patch["players"].(map[string]any)
+	require.True(t, ok, "patch has no players object: %v", patch)
+	row, ok := players[id].(map[string]any)
+	require.True(t, ok, "patch has no row for %s: %v", id, patch)
+	return row["connected"]
+}
+
+func TestConnectBroadcastsPresencePatch(t *testing.T) {
+	g, out := NewGame()
+
+	g.ConnectPlayer("alice")
+
+	patches := drainPresence(t, out)
+	require.Len(t, patches, 1)
+	require.Equal(t, true, connectedValue(t, patches[0], "alice"))
+
+	// the patch also landed in g.Data, so late joiners get it via sync
+	players := g.Data["players"].(map[string]any)
+	require.Equal(t, true, players["alice"].(map[string]any)["connected"])
+}
+
+func TestPresenceMergeKeepsExistingPlayerState(t *testing.T) {
+	g, out := NewGame()
+	g.offlineGrace = 20 * time.Millisecond
+	// state a client would have written: seat, tray, joinTimestamp
+	g.Data = map[string]any{
+		"players": map[string]any{
+			"alice": map[string]any{"id": "alice", "seat": 2, "joinTimestamp": float64(10), "tray": map[string]any{"c1": map[string]any{}}},
+		},
+	}
+
+	p := g.ConnectPlayer("alice")
+	g.DisconnectPlayer(p)
+	// wait for the offline broadcast to land in g.Data
+	require.Eventually(t, func() bool {
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		row := g.Data["players"].(map[string]any)["alice"].(map[string]any)
+		return row["connected"] == false
+	}, time.Second, 5*time.Millisecond)
+
+	g.mu.Lock()
+	row := g.Data["players"].(map[string]any)["alice"].(map[string]any)
+	g.mu.Unlock()
+	require.Equal(t, 2, row["seat"])
+	require.Equal(t, float64(10), row["joinTimestamp"])
+	require.Contains(t, row["tray"], "c1")
+	drainPresence(t, out)
+}
+
+func TestReconnectInsideGraceNeverBroadcastsOffline(t *testing.T) {
+	g, out := NewGame()
+	g.offlineGrace = 50 * time.Millisecond
+
+	p := g.ConnectPlayer("alice")
+	g.DisconnectPlayer(p)
+	// reconnect well inside the grace period — same id, as a page refresh does
+	g.ConnectPlayer("alice")
+
+	// wait past the (cancelled) grace period, then assert nobody was ever told
+	// alice went offline
+	time.Sleep(150 * time.Millisecond)
+	for _, patch := range drainPresence(t, out) {
+		require.Equal(t, true, connectedValue(t, patch, "alice"),
+			"offline patch leaked despite reconnect inside grace")
+	}
+
+	players := g.Data["players"].(map[string]any)
+	require.Equal(t, true, players["alice"].(map[string]any)["connected"])
+	require.True(t, g.Players["alice"].Connected)
+}
+
+func TestDisconnectPastGraceBroadcastsOffline(t *testing.T) {
+	g, out := NewGame()
+	g.offlineGrace = 20 * time.Millisecond
+
+	p := g.ConnectPlayer("alice")
+	drainPresence(t, out) // discard the connect patch
+
+	g.DisconnectPlayer(p)
+
+	// nothing may be sent before the grace period expires
+	require.Empty(t, drainPresence(t, out))
+
+	require.Eventually(t, func() bool {
+		patches := drainPresence(t, out)
+		return len(patches) == 1 && connectedValue(t, patches[0], "alice") == false
+	}, time.Second, 5*time.Millisecond)
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	players := g.Data["players"].(map[string]any)
+	require.Equal(t, false, players["alice"].(map[string]any)["connected"])
+}
+
+// A reconnect can attach the new socket before the old one's close is
+// noticed. The stale disconnect must not mark the player offline.
+func TestStaleDisconnectAfterReconnectKeepsPlayerOnline(t *testing.T) {
+	g, out := NewGame()
+	g.offlineGrace = 20 * time.Millisecond
+
+	p := g.ConnectPlayer("alice") // original socket
+	g.ConnectPlayer("alice")      // new socket attaches first…
+	g.DisconnectPlayer(p)         // …then the old socket's close lands
+
+	time.Sleep(100 * time.Millisecond)
+	for _, patch := range drainPresence(t, out) {
+		require.Equal(t, true, connectedValue(t, patch, "alice"))
+	}
+	require.True(t, g.Players["alice"].Connected)
+}

--- a/server/game/state.go
+++ b/server/game/state.go
@@ -18,7 +18,17 @@ type Game struct {
 
 	out chan *PlayerMessage
 	mu  sync.Mutex
+
+	// pending offline broadcasts, keyed by player id — armed on disconnect,
+	// cancelled when the same id reconnects inside the grace period
+	offlineTimers map[string]*time.Timer
+	offlineGrace  time.Duration
 }
+
+// offlineGraceDefault is how long a disconnected player has to reconnect
+// before the lobby is told they went offline. Covers page refreshes and brief
+// network blips without the other clients ever seeing a flicker.
+const offlineGraceDefault = 5 * time.Second
 
 type PlayerMessage struct {
 	// TODO: Probably a better way to add addressing
@@ -31,11 +41,13 @@ func NewGame() (*Game, <-chan *PlayerMessage) {
 	out := make(chan *PlayerMessage, 50)
 	now := time.Now()
 	return &Game{
-		Players:      make(map[string]*Player),
-		out:          out,
-		Data:         map[string]any{},
-		CreatedAt:    now,
-		LastActivity: now,
+		Players:       make(map[string]*Player),
+		out:           out,
+		Data:          map[string]any{},
+		CreatedAt:     now,
+		LastActivity:  now,
+		offlineTimers: make(map[string]*time.Timer),
+		offlineGrace:  offlineGraceDefault,
 	}, out
 }
 
@@ -46,6 +58,11 @@ type Player struct {
 	JoinTimestamp int64  `json:"joinTimestamp"`
 	Connected     bool   `json:"connected"`
 	Seat          int    `json:"seat,omitempty"`
+
+	// live socket count for this player id — a reconnect can attach the new
+	// socket before the old one's close is noticed, and the player is only
+	// offline when the last socket is gone
+	conns int
 }
 
 // PlayerStat is a lock-free copy of a player's status for admin views.

--- a/src/lib/hud/PlayerHud.svelte
+++ b/src/lib/hud/PlayerHud.svelte
@@ -91,6 +91,16 @@
 								<span class="block italic">Seat {row.seat} — open</span>
 							{:else}
 								<span class="flex items-baseline gap-1">
+									<!-- presence dot: green = connected; hollow = offline or unknown
+									     (a client that never got a presence patch must not show green) -->
+									<span
+										class={[
+											'h-2 w-2 shrink-0 self-center rounded-full',
+											row.connected ? 'bg-emerald-400' : 'border border-white/40 opacity-60'
+										]}
+										data-connected={row.connected}
+										title={row.connected ? 'online' : 'offline'}
+									></span>
 									<span class="truncate font-medium" title={row.id}>{row.id}</span>
 									{#if row.isMe}
 										<span class="shrink-0 text-[0.6rem] text-emerald-300 uppercase">you</span>

--- a/src/lib/hud/__tests__/PlayerHud.test.ts
+++ b/src/lib/hud/__tests__/PlayerHud.test.ts
@@ -131,6 +131,30 @@ describe('PlayerHud', () => {
 		expect(container.textContent).toContain('2 players · 1 open');
 	});
 
+	it('reveals a peer once their join re-publish lands', async () => {
+		const { container } = render(PlayerHud);
+		// what a peer's client holds before the re-publish: seat/tray/presence
+		// patches only — the join row itself was dropped pre-connect
+		gameStore.set({
+			players: {
+				me: state.players!.me,
+				peer: { seat: 1, tray: {}, connected: true }
+			}
+		} as Partial<GameDTO>);
+		await Promise.resolve();
+		expect(container.textContent).not.toContain('peer');
+
+		// the re-publish arrives as an ordinary update merge patch
+		gameStore.updateStateSilently({ players: { peer: { id: 'peer', joinTimestamp: 123 } } });
+		await Promise.resolve();
+		expect(container.textContent).toContain('peer');
+		// the presence that arrived before the row completed still shows
+		const dot = container
+			.querySelector('[title="peer"]')
+			?.parentElement?.querySelector('[data-connected]');
+		expect(dot?.getAttribute('data-connected')).toBe('true');
+	});
+
 	it('lets pointer events through everywhere but the HUD box', () => {
 		const { container } = render(PlayerHud);
 		const wrapper = container.querySelector('div');

--- a/src/lib/hud/__tests__/PlayerHud.test.ts
+++ b/src/lib/hud/__tests__/PlayerHud.test.ts
@@ -88,6 +88,49 @@ describe('PlayerHud', () => {
 		expect(reloaded.container.textContent).not.toContain('Seat 2 — open');
 	});
 
+	it('renders every dot as offline when no presence patch ever arrived', () => {
+		const { container } = render(PlayerHud);
+		// fixture state has no `connected` anywhere — offline-unknown, never green
+		const dots = container.querySelectorAll('[data-connected]');
+		expect(dots.length).toBe(2); // me + them; open seats get no dot
+		dots.forEach((dot) => expect(dot.getAttribute('data-connected')).toBe('false'));
+	});
+
+	it('flips a dot live when a presence patch lands', async () => {
+		const { container } = render(PlayerHud);
+		const dotFor = (id: string) =>
+			container
+				.querySelector(`[title="${id}"]`)
+				?.parentElement?.querySelector('[data-connected]')
+				?.getAttribute('data-connected');
+
+		gameStore.set({
+			...state,
+			players: { ...state.players, them: { ...state.players!.them, connected: true } }
+		} as Partial<GameDTO>);
+		await Promise.resolve();
+		expect(dotFor('them')).toBe('true');
+		expect(dotFor('me')).toBe('false');
+
+		gameStore.set({
+			...state,
+			players: { ...state.players, them: { ...state.players!.them, connected: false } }
+		} as Partial<GameDTO>);
+		await Promise.resolve();
+		expect(dotFor('them')).toBe('false');
+	});
+
+	it('never renders a presence-only ghost row', async () => {
+		const { container } = render(PlayerHud);
+		gameStore.set({
+			...state,
+			players: { ...state.players, ghost: { connected: true } }
+		} as Partial<GameDTO>);
+		await Promise.resolve();
+		expect(container.textContent).not.toContain('ghost');
+		expect(container.textContent).toContain('2 players · 1 open');
+	});
+
 	it('lets pointer events through everywhere but the HUD box', () => {
 		const { container } = render(PlayerHud);
 		const wrapper = container.querySelector('div');

--- a/src/lib/hud/__tests__/players.test.ts
+++ b/src/lib/hud/__tests__/players.test.ts
@@ -119,20 +119,50 @@ describe('derivePlayerRows', () => {
 	it('handles empty and missing state', () => {
 		expect(derivePlayerRows(undefined)).toEqual([]);
 		expect(derivePlayerRows({})).toEqual([]);
-		const sparse = derivePlayerRows({ players: { solo: { id: 'solo' } } });
+		const sparse = derivePlayerRows({
+			players: { solo: { id: 'solo', joinTimestamp: 5 } }
+		});
 		expect(sparse).toEqual([
 			{
 				id: 'solo',
 				seat: 0,
 				rotationDeg: 0,
-				joinTimestamp: 0,
+				joinTimestamp: 5,
 				isMe: false,
 				isOpenSeat: false,
+				connected: false,
 				handCount: 0,
 				decks: [],
 				tableCount: 0
 			}
 		]);
+	});
+
+	it('skips presence-only ghost rows (no joinTimestamp yet)', () => {
+		// the server merges players[id].connected on socket attach, before the
+		// client has sent seat/tray/joinTimestamp — such rows are not players yet
+		const rows = derivePlayerRows({
+			...state,
+			players: { ...state.players, ghost: { connected: true } }
+		});
+		expect(rows.map((r) => r.id)).not.toContain('ghost');
+	});
+
+	it('treats missing presence as offline-unknown, never connected', () => {
+		const rows = derivePlayerRows(state);
+		// nobody in this fixture has ever received a presence patch
+		expect(rows.every((r) => r.connected === false)).toBe(true);
+	});
+
+	it('maps presence strictly from connected === true', () => {
+		const rows = derivePlayerRows({
+			players: {
+				on: { id: 'on', seat: 0, joinTimestamp: 1, tray: {}, metadata: {}, connected: true },
+				off: { id: 'off', seat: 1, joinTimestamp: 2, tray: {}, metadata: {}, connected: false }
+			}
+		});
+		expect(rows.find((r) => r.id === 'on')?.connected).toBe(true);
+		expect(rows.find((r) => r.id === 'off')?.connected).toBe(false);
 	});
 });
 

--- a/src/lib/hud/players.ts
+++ b/src/lib/hud/players.ts
@@ -38,6 +38,12 @@ export type PlayerHudRow = {
 	isMe: boolean;
 	/** a `seat0`–`seat3` placeholder — nobody is sitting here yet */
 	isOpenSeat: boolean;
+	/**
+	 * live presence from the server (`players[id].connected` merge patches).
+	 * Strictly `=== true` — a client that never received a presence patch
+	 * must render offline-unknown, never connected.
+	 */
+	connected: boolean;
 	/** number of cards in the tray (hand); counts only, never the cards */
 	handCount: number;
 	/** decks owned by this player, sorted by slot */
@@ -89,23 +95,30 @@ export function derivePlayerRows(
 
 	const tableByOwner = countOwnedBy(Object.keys(state?.cards ?? {}));
 
-	return Object.entries(players)
-		.filter(([, player]) => !!player)
-		.map(([id, player]) => {
-			const seat = player?.seat ?? 0;
-			return {
-				id,
-				seat,
-				rotationDeg: SEAT_ROTATION_DEG[seat] ?? 0,
-				joinTimestamp: player?.joinTimestamp ?? 0,
-				isMe: !!myId && id === myId,
-				isOpenSeat: isSeatPlaceholder(id),
-				handCount: Object.keys(player?.tray ?? {}).length,
-				decks: decksByOwner[id] ?? [],
-				tableCount: tableByOwner[id] ?? 0
-			};
-		})
-		.sort((a, b) => a.seat - b.seat || a.joinTimestamp - b.joinTimestamp);
+	return (
+		Object.entries(players)
+			.filter(([, player]) => !!player)
+			// ghost-row guard: the server merges `connected` on socket attach,
+			// before the client has sent any player data — a row that is presence
+			// only (no joinTimestamp) is not a player yet and must not render
+			.filter(([, player]) => typeof player?.joinTimestamp === 'number')
+			.map(([id, player]) => {
+				const seat = player?.seat ?? 0;
+				return {
+					id,
+					seat,
+					rotationDeg: SEAT_ROTATION_DEG[seat] ?? 0,
+					joinTimestamp: player?.joinTimestamp ?? 0,
+					isMe: !!myId && id === myId,
+					isOpenSeat: isSeatPlaceholder(id),
+					connected: player?.connected === true,
+					handCount: Object.keys(player?.tray ?? {}).length,
+					decks: decksByOwner[id] ?? [],
+					tableCount: tableByOwner[id] ?? 0
+				};
+			})
+			.sort((a, b) => a.seat - b.seat || a.joinTimestamp - b.joinTimestamp)
+	);
 }
 
 /** `3 players` / `1 player` — the collapsed header summary. */

--- a/src/lib/store/game/types.ts
+++ b/src/lib/store/game/types.ts
@@ -41,6 +41,12 @@ type PlayerDTO = SeatState & {
 	joinTimestamp: number;
 	tray: Record<string, Partial<CardDTO | null>>;
 	/**
+	 * server-owned presence: merged into the lobby state on socket
+	 * connect/disconnect. Absent until the server has said anything —
+	 * treat undefined as offline-unknown, never as connected.
+	 * */
+	connected?: boolean;
+	/**
 	 * extend for future use with life/resources
 	 * */
 	metadata: any;

--- a/src/lib/websocket/__tests__/index.test.ts
+++ b/src/lib/websocket/__tests__/index.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Regression guard for the join re-publish: addPlayer() runs before connect(),
+ * so its full-row patch is dropped (sendMessage has no queue). initWebsocket
+ * must re-publish {id, joinTimestamp} once the socket is open, or peers only
+ * ever see seat/tray/connected patches and the HUD ghost-row guard hides the
+ * player forever.
+ *
+ * The connection mock mirrors the real gating: sends are dropped until
+ * connect() has run.
+ */
+const mockConnection = vi.hoisted(() => {
+	let socketOpen = false;
+	const delivered: any[] = [];
+	return {
+		delivered,
+		reset() {
+			socketOpen = false;
+			delivered.length = 0;
+		},
+		connect: vi.fn(async () => {
+			socketOpen = true;
+			return true;
+		}),
+		joinLobby: vi.fn(async () => socketOpen),
+		sendMessage: vi.fn((msg: any) => {
+			// same rule as the real sendMessage: not connected → dropped
+			if (!socketOpen) return false;
+			delivered.push(msg);
+			return true;
+		}),
+		onMessage: vi.fn()
+	};
+});
+
+vi.mock('../connection', () => ({
+	connect: mockConnection.connect,
+	joinLobby: mockConnection.joinLobby,
+	sendMessage: mockConnection.sendMessage,
+	onMessage: mockConnection.onMessage
+}));
+vi.mock('svelte-french-toast', () => ({
+	default: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() })
+}));
+vi.mock('$lib/packs/prewarm-state', () => ({ prewarmGameState: vi.fn() }));
+
+import { initWebsocket } from '..';
+import { initWrappers } from '../storeIntegration';
+import { gameStore } from '$lib/store/game/gameStore.svelte';
+
+describe('initWebsocket join re-publish', () => {
+	beforeEach(() => {
+		mockConnection.reset();
+		vi.clearAllMocks();
+		localStorage.clear();
+		localStorage.setItem('myPlayerId', 'tester');
+		gameStore.set({ players: {}, decks: {}, cards: {} });
+		// /play installs the ws wrapper before initWebsocket — same order here,
+		// so updateState calls actually reach (the mocked) sendMessage
+		initWrappers();
+	});
+
+	it('delivers my joinTimestamp to the lobby after the socket opens', async () => {
+		const ok = await initWebsocket('test-lobby');
+		expect(ok).toBe(true);
+
+		// the addPlayer() patch fired pre-connect and was dropped, so the only
+		// way a players patch with joinTimestamp gets delivered is the
+		// re-publish after joinLobby succeeds
+		const patch = mockConnection.delivered.find((m) => m?.value?.players?.tester);
+		expect(patch).toBeTruthy();
+		expect(typeof patch.value.players.tester.joinTimestamp).toBe('number');
+	});
+
+	it('re-publishes only id + joinTimestamp — never a seat that could clobber a reconnect', async () => {
+		await initWebsocket('test-lobby');
+		const patch = mockConnection.delivered.find((m) => m?.value?.players?.tester);
+		expect(patch.value.players.tester.seat).toBeUndefined();
+		expect(patch.value.players.tester.tray).toBeUndefined();
+	});
+});

--- a/src/lib/websocket/connection.ts
+++ b/src/lib/websocket/connection.ts
@@ -1,18 +1,15 @@
 import { gameActions } from '$lib/store/game/actions';
 import toast from 'svelte-french-toast';
 
-export type ConnectedPlayer = {
-	id: string;
-	joinTimestamp: number;
-};
-
 export type WebSocketMessage = {
-	type: 'connect' | 'sync' | 'update' | 'error' | 'disconnect' | 'playerList';
+	// 'connect' is outbound-only: the join handshake sent by joinLobby().
+	// Inbound traffic is 'sync' | 'update' | 'error' — presence arrives as an
+	// ordinary 'update' merge patch on players[id].connected.
+	type: 'connect' | 'sync' | 'update' | 'error';
 	path?: string[];
 	value?: any;
 	playerId: string;
 	timestamp: number;
-	players?: ConnectedPlayer[];
 };
 
 // Config

--- a/src/lib/websocket/index.ts
+++ b/src/lib/websocket/index.ts
@@ -1,11 +1,4 @@
-import {
-	connect,
-	joinLobby,
-	onMessage,
-	sendMessage,
-	type WebSocketMessage,
-	type ConnectedPlayer
-} from './connection';
+import { connect, joinLobby, onMessage, sendMessage, type WebSocketMessage } from './connection';
 import { gameActions } from '$lib/store/game/actions';
 import { gameStore } from '$lib/store/game/gameStore.svelte';
 import { prewarmGameState } from '$lib/packs/prewarm-state';
@@ -58,34 +51,6 @@ export async function initWebsocket(lobbyId: string, serverUrl?: string): Promis
 function setupMessageHandlers(): void {
 	onMessage((message: WebSocketMessage) => {
 		switch (message.type) {
-			case 'connect':
-				console.log(`Player ${message.playerId} connected`);
-				toast(`Player ${message.playerId} connected`);
-				break;
-
-			case 'disconnect':
-				console.log(`Player ${message.playerId} disconnected`);
-				// We keep the player in the store to preserve their data
-				// but could mark them as offline if needed
-				break;
-
-			case 'playerList':
-				console.log('Received player list:', message.players);
-				if (message.players && message.players.length > 0) {
-					// Update all players in the store
-					message.players.forEach((player: ConnectedPlayer) => {
-						gameStore?.updateStateSilently({
-							players: {
-								[player.id]: {
-									id: player.id,
-									joinTimestamp: player.joinTimestamp
-								}
-							}
-						});
-					});
-				}
-				break;
-
 			case 'sync':
 				console.log('Received sync message, updating local state', message);
 				gameStore.updateStateSilently(message.value);

--- a/src/lib/websocket/index.ts
+++ b/src/lib/websocket/index.ts
@@ -38,11 +38,33 @@ export async function initWebsocket(lobbyId: string, serverUrl?: string): Promis
 		// Set up event listeners for incoming messages
 		setupMessageHandlers();
 
+		// Re-publish my player row now that the socket is open. addPlayer()
+		// above ran before connect(), so its patch was dropped (sendMessage has
+		// no queue) — without this, peers only ever receive seat/tray/connected
+		// patches for this player, and the HUD's ghost-row guard (rows without
+		// a joinTimestamp are not players yet) would hide the row forever.
+		// Only id + joinTimestamp: re-sending the fresh local row's seat would
+		// clobber the seat a reconnecting player already holds in lobby state.
+		publishMyPlayerRow();
+
 		return true;
 	} catch (error) {
 		console.error('Error initializing websocket:', error);
 		return false;
 	}
+}
+
+/**
+ * Broadcast the minimal row that marks the local player as a real player in
+ * the lobby state. Goes through gameStore.updateState, which storeIntegration
+ * wraps to send over the (now open) websocket.
+ */
+function publishMyPlayerRow(): void {
+	const me = gameActions.getMe();
+	if (!me?.id) return;
+	gameStore.updateState({
+		players: { [me.id]: { id: me.id, joinTimestamp: me.joinTimestamp ?? Date.now() } }
+	});
 }
 
 /**


### PR DESCRIPTION
Task: tableplace-33
Closes #33

## What

Presence now reaches clients by riding the existing merge-patch `update` channel — no new message type, no client protocol change.

**Server** (`server/game/`):
- `ConnectPlayer` merges `{"players":{"<id>":{"connected":true}}}` into `g.Data` through `jsonmerge` and broadcasts it as an ordinary `update` to the lobby. Late joiners get presence for free via the normal sync.
- `DisconnectPlayer` arms a **5s grace timer** instead of broadcasting immediately. If the same id reconnects inside the grace period, the timer is cancelled and the offline patch is *never sent* — a hard refresh or brief network blip produces no visible flicker on other clients.
- A per-player socket count (`conns`) handles the overlapping-reconnect race where the new socket attaches before the old socket's close is noticed: the stale disconnect can't mark a live player offline.
- The offline timer's broadcast uses a non-blocking send, so a timer firing after the lobby stopped draining can't leak a goroutine.
- Deleted the broken, caller-less `BroadcastPlayerChange`; the join `connect` handshake is no longer relayed to other clients (it carried no information and no handler exists for it anymore).

**Client** (`src/lib/`):
- `PlayerDTO` gains `connected?: boolean`.
- Dead inbound `connect` / `disconnect` / `playerList` branches and the `ConnectedPlayer` type are gone. Per the correction on #33, **`'connect'` stays in the `WebSocketMessage` union** — it is the live outbound join message sent by `joinLobby()`. `'error'` also stays: the server's fall-through relay can still deliver it.
- HUD dot on each player row: green when `connected === true`, hollow/dim otherwise. `undefined` (client never received a presence patch) renders identically to offline — never as connected.

## Ghost rows: handled HUD-side

The ticket offered two options; I picked **the HUD skips rows lacking `joinTimestamp`**. Reason: the server's presence patch fires on socket attach, before the client has sent any player data — and the client's own `addPlayer` patch is currently emitted *before* the socket opens (so it's dropped), meaning the server-side "only write ids already in `g.Data.players`" guard would leave a fresh player permanently offline. With the HUD guard, the presence-only partial row stays invisible until real player data (seat/tray/joinTimestamp) merges in, at which point it renders already-green. Seat placeholders (`joinTimestamp: 0`) still render — the guard checks for the field's presence, not truthiness.

## Scenarios

`saveScenario` only keeps `seat0`–`seat3` placeholder rows, and placeholders never receive presence patches (they are not websocket ids), so no stale `connected` value can ride into a preset.

## Verification

- `go vet ./...`, `go test ./...` and `go test -race ./game/` pass. New `presence_test.go` covers: connect broadcast lands in `g.Data` + the out channel, presence merge preserving seat/tray/joinTimestamp, **connect → disconnect → reconnect-inside-grace never broadcasting offline**, disconnect past grace broadcasting offline, and the stale-disconnect-after-reconnect race.
- `bun run check` (0 errors) and `bun run test` (91/91) pass. New tests: ghost-row filtering, strict `connected === true` mapping, offline-unknown default, live dot flip, no dot on open seats.
- `bun run lint` fails on 26 files that already fail on `main` (pre-existing prettier drift, mostly markdown/json); every file this PR touches is prettier-clean — verified by diffing lint output with the branch stashed vs. applied.

Note: #37 also touches `server/game/`, `server/lobby/` and the websocket files; presence here is a broadcast-to-all patch and doesn't touch the per-recipient fan-out #37 builds, so the overlap should rebase mechanically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJDZazLTPFgQoMPkZuLupC