### PR TITLE
tableplace-47: card face overhangs body (muffin-top lip)

### DIFF
--- a/src/lib/utils/constants-cards.ts
+++ b/src/lib/utils/constants-cards.ts
@@ -7,7 +7,7 @@ import * as THREE from 'three';
  */
 export const CARD_WIDTH = 1.4;
 export const CARD_HEIGHT = 2;
-export const CARD_THICKNESS = 0.04;
+export const CARD_THICKNESS = 0.03;
 
 /** Corner radius of the printed face (ImageMaterial radius prop) */
 export const CARD_CORNER_RADIUS = 0.1;
@@ -51,16 +51,17 @@ function roundedSlabGeometry(
 }
 
 /**
- * Shared body geometry for every card: inset under the printed face so the
- * face always overhangs the paper edge, with the corner radius shrunk by the
- * same inset so the arc stays concentric inside the face's rounded corner.
- * Static — build once, share across all card instances.
+ * Shared body geometry for every card: same footprint and corner radius as
+ * the printed face, so the two share one silhouette with no overhanging lip.
+ * The body is thinner than CARD_THICKNESS (see roundedSlabGeometry call
+ * below) so its flat lids sit just under the face planes — that vertical gap
+ * avoids z-fighting between the white lid and the printed face; it's not a
+ * lateral inset. Static — build once, share across all card instances.
  */
-const CARD_BODY_INSET = 0.02; // per side
 export const cardBodyGeometry = roundedSlabGeometry(
-	CARD_WIDTH - CARD_BODY_INSET * 2,
-	CARD_HEIGHT - CARD_BODY_INSET * 2,
-	CARD_CORNER_RADIUS - CARD_BODY_INSET,
+	CARD_WIDTH,
+	CARD_HEIGHT,
+	CARD_CORNER_RADIUS,
 	CARD_THICKNESS * 0.92
 );
 
@@ -68,14 +69,9 @@ export const cardBodyGeometry = roundedSlabGeometry(
  * Shared deck body geometry, unit height (scale the mesh's Y to the deck's
  * actual height). Side-wall v spans exactly 0..1 over the unit thickness, so
  * texture.repeat.y = number of stripe-texture repeats across the full height.
+ * Same footprint/radius as the card face — no lateral inset (see cardBodyGeometry).
  */
-const DECK_BODY_INSET = 0.01; // per side
-export const deckBodyGeometry = roundedSlabGeometry(
-	CARD_WIDTH - DECK_BODY_INSET * 2,
-	CARD_HEIGHT - DECK_BODY_INSET * 2,
-	CARD_CORNER_RADIUS - DECK_BODY_INSET,
-	1
-);
+export const deckBodyGeometry = roundedSlabGeometry(CARD_WIDTH, CARD_HEIGHT, CARD_CORNER_RADIUS, 1);
 
 /**
  * Deck body height per card, clamped so a huge deck doesn't tower and an


### PR DESCRIPTION
## Summary
- Removed the lateral body inset (`CARD_BODY_INSET` / `DECK_BODY_INSET`) so the card/deck body geometry shares the exact same footprint and corner radius as the printed face — no more overhanging "muffin-top" lip at grazing camera angles. The 0.92x-thickness lid gap (vertical, prevents z-fighting) is unchanged.
- Reduced `CARD_THICKNESS` 0.04 → 0.03 (25% thinner). All face/back plane offsets (`±CARD_THICKNESS / 2`) and stack-height math (`resolveStackHeight`) derive from the constant, so they scale automatically.

## Verification
- `bun run test` — 85/85 tests pass, including stack-height tests that assert against `CARD_THICKNESS`.
- `bun run check` — 0 errors (pre-existing unrelated warnings only).
- `bun run lint` — no new issues (pre-existing formatting warnings in unrelated files only).
- `bun run build` — succeeds.
- Confirmed no other file references the removed `CARD_BODY_INSET`/`DECK_BODY_INSET` constants.
- **Not verified**: visual check in a live browser — the Chrome browser-automation extension wasn't connected in this environment, so I could not screenshot the running app at a grazing camera angle to confirm the flush edge / no z-fighting / no corner nubs by eye. The geometry math (shared width/height/radius between body and face, thickness-relative offsets) is correct by inspection and the existing corner-rounding logic (from #43) is untouched, but a human should do a quick visual pass before merge.

Task: tableplace-47
Closes #47