### PR TITLE
tableplace-52: landing page — make table.place's front door sell the product

### DIFF
--- a/src/lib/websocket/connection.ts
+++ b/src/lib/websocket/connection.ts
@@ -23,7 +23,11 @@ function normalizeServerHost(url: string): string {
 		.replace(/^(https?|wss?):\/\//, '')
 		.replace(/\/+$/, '');
 }
-const CACHE_SERVER_URL = normalizeServerHost(localStorage.getItem('serverurl') ?? 'localhost:8080');
+// Default to the public server so a first-time visitor gets real multiplayer;
+// a non-empty localStorage.serverurl (set in Settings) always wins. `||` (not ??)
+// because connectionStore writes '' to localStorage before a server is ever set.
+const CACHE_SERVER_URL =
+	normalizeServerHost(localStorage.getItem('serverurl') ?? '') || 'api.table.place';
 const SECURITY = CACHE_SERVER_URL.includes('localhost') ? 'ws' : 'wss';
 const WS_SERVER_URL = `${SECURITY}://${CACHE_SERVER_URL}/ws`;
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,44 +11,395 @@
 		lobby = randomLobbyName();
 		goto(`/play?lobby=${lobby}`);
 	}
+
+	const HAND = [
+		{ index: 'A', suit: '♠', red: false },
+		{ index: 'K', suit: '♥', red: true },
+		{ index: 'Q', suit: '♣', red: false },
+		{ index: 'J', suit: '♦', red: true },
+		{ index: '10', suit: '♠', red: false }
+	];
 </script>
 
 <svelte:head>
-	<title>table place</title>
-	<meta name="description" content="A tabletop simulator in the browser" />
+	<title>table.place — board games in your browser</title>
+	<meta
+		name="description"
+		content="Board games in your browser. No installs, no accounts — a table is just a link. Open a table, share the URL, and play."
+	/>
+	<meta property="og:title" content="table.place — board games in your browser" />
+	<meta
+		property="og:description"
+		content="No installs, no accounts — a table is just a link. Open a table, share the URL, and play."
+	/>
+	<link rel="preconnect" href="https://fonts.googleapis.com" />
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+	<link
+		href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400..700&display=swap"
+		rel="stylesheet"
+	/>
 </svelte:head>
 
-<div class="grid h-screen w-screen place-items-center bg-emerald-50">
-	<div class="max-w-lg rounded bg-white p-6 shadow">
-		<h1 class="mb-4 text-3xl font-bold">Welcome to table.place</h1>
-		<p class="mb-2">A browser-based tabletop simulator</p>
-		<a href="https://github.com/JollyGrin/three-tts" class="underline"> github </a>
-		<h2 class="mt-4 mb-2 text-xl font-semibold">Getting Started</h2>
-		<ol class="mb-4 list-inside list-decimal">
-			<li>Run the backend: <code>cd server && ./run.sh</code></li>
-			<li>(Optional) Expose with ngrok: <code>ngrok http 8080</code></li>
-			<li>Click <strong>Open Table</strong> and spawn a deck of cards</li>
-		</ol>
-		<p class="mb-4">
-			In the Settings pane (⚙️), set the Server to <code>localhost:8080</code> or your ngrok URL.
-		</p>
-		<a
-			href="/play?lobby={lobby}"
-			onclick={openTable}
-			class="block rounded bg-emerald-400 py-2 text-center font-medium text-white">Open Table</a
+<div class="page">
+	<!-- ============ hero: the table ============ -->
+	<header class="felt relative overflow-hidden">
+		<nav class="relative z-10 mx-auto flex max-w-5xl items-center gap-3 px-6 pt-6">
+			<span class="wordmark text-xl text-emerald-50">table.place</span>
+			<span class="alpha-badge">alpha</span>
+			<a
+				href="https://github.com/JollyGrin/tableplace"
+				class="ml-auto text-sm text-emerald-100/80 underline decoration-emerald-100/40 underline-offset-4 hover:text-white"
+			>
+				GitHub
+			</a>
+		</nav>
+
+		<div
+			class="relative z-10 mx-auto flex max-w-5xl flex-col items-center px-6 pt-10 pb-20 text-center sm:pt-16"
 		>
-		<p class="mt-2 text-sm text-gray-500">
-			Every table gets its own name — the table's URL is your invite link, so share it with whoever
-			you want to play with.
-		</p>
-		<a
-			href="/setup"
-			class="mt-2 block rounded border border-emerald-400 py-2 text-center font-medium text-emerald-600"
-			>Scenario Setup</a
+			<div class="fan" aria-hidden="true">
+				{#each HAND as card, i (card.index + card.suit)}
+					<div class="card" class:red={card.red} style="--i: {i}; --r: {(i - 2) * 12}deg">
+						<span class="corner">{card.index}<br />{card.suit}</span>
+						<span class="pip">{card.suit}</span>
+						<span class="corner corner-bottom">{card.index}<br />{card.suit}</span>
+					</div>
+				{/each}
+			</div>
+
+			<h1 class="wordmark mt-10 max-w-2xl text-4xl leading-tight text-emerald-50 sm:text-6xl">
+				Board games in your browser.
+			</h1>
+			<p class="mt-4 max-w-xl text-lg text-emerald-100/90">
+				No installs, no accounts — a table is just a link.
+			</p>
+
+			<a href="/play?lobby={lobby}" onclick={openTable} class="cta mt-8">Open a table</a>
+			<p class="mt-3 text-sm text-emerald-100/70">
+				Yours will be called <code class="rounded bg-emerald-950/40 px-1.5 py-0.5">{lobby}</code> — the
+				URL is the invite.
+			</p>
+		</div>
+	</header>
+
+	<!-- ============ how to play ============ -->
+	<section class="paper px-6 py-16 sm:py-20">
+		<div class="mx-auto max-w-5xl">
+			<h2 class="wordmark text-3xl text-emerald-950 sm:text-4xl">How to play</h2>
+			<div class="mt-8 grid gap-4 sm:grid-cols-3">
+				<div class="step">
+					<span class="step-index">1<br />♠</span>
+					<h3>Open a table</h3>
+					<p>
+						One click and a fresh table is yours, with a name like <code>swift-otter</code>. No
+						sign-up, nothing to download.
+					</p>
+				</div>
+				<div class="step">
+					<span class="step-index red">2<br />♥</span>
+					<h3>Share the URL</h3>
+					<p>
+						The address bar <em>is</em> the invite link. Send it to your friends and they pull up a chair
+						at the same table.
+					</p>
+				</div>
+				<div class="step">
+					<span class="step-index">3<br />♣</span>
+					<h3>Spawn a deck and play</h3>
+					<p>
+						Deal, drag, flip, stack. The table doesn't enforce rules — you play the way you would at
+						a real one.
+					</p>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- ============ create scenarios ============ -->
+	<section class="felt-deep px-6 py-16 text-emerald-50 sm:py-20">
+		<div class="mx-auto max-w-5xl">
+			<h2 class="wordmark text-3xl sm:text-4xl">Bring your own game</h2>
+			<div class="mt-6 grid gap-10 sm:grid-cols-2">
+				<div class="space-y-4 text-emerald-100/90">
+					<p>
+						A standard 52-card deck is built in, but any deck can join the table: import cards by
+						image URL, or load Tabletop Simulator–format JSON — like the fan-made decks from
+						<a href="https://the-unmatched.club" class="link-light">the-unmatched.club</a>.
+					</p>
+					<p>
+						Build a full setup in the <a href="/setup" class="link-light">scenario editor</a> — decks
+						for each seat, a map in the middle — then seed any lobby with it from the table's Settings&nbsp;→&nbsp;Scenarios.
+					</p>
+					<p class="text-sm text-emerald-100/60">
+						Fan-made content stays fan-made: creators host their own assets, and table.place hosts
+						none of them.
+					</p>
+				</div>
+				<div class="flex items-start justify-center sm:justify-end">
+					<a href="/setup" class="cta-ghost">Build a scenario</a>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- ============ where this is going ============ -->
+	<section class="paper px-6 py-16 sm:py-20">
+		<div class="mx-auto max-w-5xl">
+			<h2 class="wordmark text-3xl text-emerald-950 sm:text-4xl">Where this is going</h2>
+			<p class="mt-6 max-w-2xl text-lg text-emerald-950/80">
+				The goal: any tabletop game, loadable from a file. Easier creator tools — turn a spreadsheet
+				into a deck. Communities offering “play online” right from their own sites, with a table
+				that's just a link away.
+			</p>
+			<p class="mt-4 max-w-2xl text-emerald-950/60">
+				table.place is in alpha and free — no accounts, no tiers. Expect rough edges, and say hi on
+				<a
+					href="https://github.com/JollyGrin/tableplace"
+					class="underline decoration-emerald-700/40 underline-offset-4 hover:text-emerald-950"
+					>GitHub</a
+				> if you hit one.
+			</p>
+		</div>
+	</section>
+
+	<footer class="felt-deep px-6 py-8">
+		<div
+			class="mx-auto flex max-w-5xl flex-wrap items-center gap-x-4 gap-y-2 text-sm text-emerald-100/70"
 		>
-		<p class="mt-2 text-sm text-gray-500">
-			Build a reusable game setup locally — import decks for both seats, place the map, then seed a
-			lobby with it from the table's Settings → Scenarios.
-		</p>
-	</div>
+			<span class="wordmark text-base text-emerald-50">table.place</span>
+			<span class="alpha-badge">alpha</span>
+			<span>free, no accounts</span>
+			<a href="https://github.com/JollyGrin/tableplace" class="link-light ml-auto">GitHub</a>
+		</div>
+	</footer>
 </div>
+
+<style>
+	.page {
+		font-family:
+			ui-sans-serif,
+			system-ui,
+			-apple-system,
+			'Segoe UI',
+			sans-serif;
+	}
+
+	.wordmark {
+		font-family: 'Fraunces', Georgia, serif;
+		font-weight: 600;
+	}
+
+	/* --- felt table surfaces --- */
+	.felt,
+	.felt-deep {
+		position: relative;
+		background-color: #1d5c3a;
+	}
+	.felt {
+		background-image: radial-gradient(
+			ellipse 120% 90% at 50% 20%,
+			#2f7d52 0%,
+			#1d5c3a 55%,
+			#123f27 100%
+		);
+	}
+	.felt-deep {
+		background-image: radial-gradient(ellipse 120% 120% at 50% 0%, #1d5c3a 0%, #123f27 80%);
+	}
+	/* felt grain */
+	.felt::after,
+	.felt-deep::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+		opacity: 0.5;
+		mix-blend-mode: overlay;
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)' opacity='0.35'/%3E%3C/svg%3E");
+	}
+	.felt > *,
+	.felt-deep > * {
+		position: relative;
+		z-index: 1;
+	}
+
+	.paper {
+		background-color: #f6f1e3;
+		background-image: radial-gradient(ellipse 100% 80% at 50% 0%, #fbf8ee 0%, #f6f1e3 70%);
+	}
+
+	.alpha-badge {
+		font-size: 0.7rem;
+		font-weight: 600;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: #fef3c7;
+		background: rgba(180, 83, 9, 0.55);
+		border: 1px solid rgba(254, 243, 199, 0.4);
+		border-radius: 9999px;
+		padding: 0.15rem 0.6rem;
+	}
+
+	/* --- the dealt hand --- */
+	.fan {
+		--card-w: clamp(76px, 17vw, 118px);
+		position: relative;
+		width: calc(var(--card-w) * 3.4);
+		height: calc(var(--card-w) * 1.9);
+	}
+	.card {
+		position: absolute;
+		bottom: 0;
+		left: 50%;
+		width: var(--card-w);
+		aspect-ratio: 5 / 7;
+		transform-origin: 50% 130%;
+		transform: translateX(-50%) rotate(var(--r));
+		background: linear-gradient(160deg, #fdfaf2 0%, #f3edda 100%);
+		border-radius: calc(var(--card-w) * 0.09);
+		border: 1px solid rgba(30, 41, 34, 0.12);
+		box-shadow:
+			0 2px 3px rgba(10, 30, 18, 0.25),
+			0 10px 24px rgba(10, 30, 18, 0.35);
+		color: #263528;
+		animation: deal 0.7s cubic-bezier(0.2, 0.7, 0.3, 1.05) backwards;
+		animation-delay: calc(var(--i) * 110ms + 150ms);
+		transition: transform 0.35s ease;
+	}
+	.card.red {
+		color: #bb4430;
+	}
+	.fan:hover .card {
+		transform: translateX(-50%) rotate(calc(var(--r) * 1.3)) translateY(-6px);
+	}
+	@keyframes deal {
+		from {
+			transform: translateX(-50%) translateY(55%) rotate(0deg);
+			opacity: 0;
+		}
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.card {
+			animation: none;
+			transition: none;
+		}
+	}
+	.corner {
+		position: absolute;
+		top: 6%;
+		left: 9%;
+		font-size: calc(var(--card-w) * 0.15);
+		font-weight: 700;
+		line-height: 1.05;
+		text-align: center;
+	}
+	.corner-bottom {
+		top: auto;
+		left: auto;
+		right: 9%;
+		bottom: 6%;
+		transform: rotate(180deg);
+	}
+	.pip {
+		position: absolute;
+		inset: 0;
+		display: grid;
+		place-items: center;
+		font-size: calc(var(--card-w) * 0.44);
+	}
+
+	/* --- buttons --- */
+	.cta {
+		display: inline-block;
+		font-family: 'Fraunces', Georgia, serif;
+		font-weight: 600;
+		font-size: 1.15rem;
+		color: #1d3a28;
+		background: linear-gradient(160deg, #fdfaf2 0%, #f0e8d0 100%);
+		border-radius: 0.75rem;
+		padding: 0.8rem 2.4rem;
+		box-shadow:
+			0 2px 0 rgba(10, 30, 18, 0.35),
+			0 10px 22px rgba(10, 30, 18, 0.35);
+		transition:
+			transform 0.15s ease,
+			box-shadow 0.15s ease;
+	}
+	.cta:hover {
+		transform: translateY(-2px);
+		box-shadow:
+			0 4px 0 rgba(10, 30, 18, 0.35),
+			0 14px 26px rgba(10, 30, 18, 0.4);
+	}
+	.cta:active {
+		transform: translateY(0);
+	}
+	.cta-ghost {
+		display: inline-block;
+		font-family: 'Fraunces', Georgia, serif;
+		font-weight: 600;
+		color: #ecfdf5;
+		border: 1.5px solid rgba(236, 253, 245, 0.5);
+		border-radius: 0.75rem;
+		padding: 0.7rem 2rem;
+		transition:
+			background-color 0.15s ease,
+			border-color 0.15s ease;
+	}
+	.cta-ghost:hover {
+		background: rgba(236, 253, 245, 0.1);
+		border-color: rgba(236, 253, 245, 0.8);
+	}
+
+	.link-light {
+		color: #ecfdf5;
+		text-decoration: underline;
+		text-decoration-color: rgba(236, 253, 245, 0.4);
+		text-underline-offset: 4px;
+	}
+	.link-light:hover {
+		text-decoration-color: rgba(236, 253, 245, 0.9);
+	}
+
+	/* --- how-to-play step cards --- */
+	.step {
+		position: relative;
+		background: #fffdf6;
+		border: 1px solid rgba(30, 41, 34, 0.1);
+		border-radius: 0.9rem;
+		padding: 1.5rem 1.5rem 1.5rem 4.2rem;
+		box-shadow: 0 6px 16px rgba(30, 41, 34, 0.08);
+	}
+	.step-index {
+		position: absolute;
+		top: 1.1rem;
+		left: 1.2rem;
+		font-family: 'Fraunces', Georgia, serif;
+		font-weight: 700;
+		font-size: 1.3rem;
+		line-height: 1.05;
+		text-align: center;
+		color: #263528;
+	}
+	.step-index.red {
+		color: #bb4430;
+	}
+	.step h3 {
+		font-family: 'Fraunces', Georgia, serif;
+		font-weight: 600;
+		font-size: 1.2rem;
+		color: #14351f;
+	}
+	.step p {
+		margin-top: 0.5rem;
+		font-size: 0.95rem;
+		color: rgba(20, 53, 31, 0.75);
+	}
+	.step code,
+	.paper code {
+		background: rgba(30, 41, 34, 0.07);
+		border-radius: 0.25rem;
+		padding: 0.1rem 0.35rem;
+		font-size: 0.85em;
+	}
+</style>


### PR DESCRIPTION
## What

Replaces the developer-instructions `/` page (run.sh, ngrok) with a real landing page, and points the client's default server at the live public server.

### Landing page (`src/routes/+page.svelte`)
- **Hero** — purely static (no WebGL/Threlte): felt-green table surface with an animated CSS card fan, the one-liner pitch ("Board games in your browser. No installs, no accounts — a table is just a link."), and an **Open a table** CTA that keeps the existing random-lobby-name behavior (href fallback + fresh roll on click).
- **How to play** — 3 steps: open a table → share the URL (the URL *is* the invite) → spawn a deck and play.
- **Bring your own game** — import decks by image URL or TTS-format JSON (fan-made decks from the-unmatched.club), build a setup in `/setup`, seed lobbies from Settings → Scenarios. Framing: fan-made content, creators host their own assets, table.place hosts none.
- **Where this is going** — short vision blurb (game-from-a-file, spreadsheet → deck creator tools, communities embedding "play online"). No pricing/tiers/partner talk; free-forever framing.
- Alpha badge worn openly, GitHub links, proper `<title>` + meta description (+ og tags). Static-adapter compatible, mobile-presentable, dependency-light (one Google Font, everything else CSS).

### Default server (`src/lib/websocket/connection.ts`)
- Fallback changes from `localhost:8080` to `api.table.place`, so the hero CTA delivers real multiplayer for a first-time visitor with empty localStorage.
- A non-empty `localStorage.serverurl` (Settings) and the `?server=` query param override exactly as before. Uses `||` rather than `??` because `connectionStore` writes `''` to localStorage on first `/play` visit — with `??` the default would stop applying from the second visit on.

## Verification
- `bun run check` — 0 errors (8 pre-existing warnings documented in UPGRADE_FOLLOWUPS.md)
- `bun run test` — 85/85 pass
- `bun run build` — static build succeeds; `vite preview` serves `/`, `/play`, `/setup`
- prettier clean on both changed files; the one eslint error in `connection.ts` (`value?: any`) is pre-existing and untouched

Task: tableplace-52
Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqzdTMbFjuQYBzzbzpAvka