### PR TITLE
tableplace-61: visualize remote players' cameras as floating frustum avatars

### DIFF
--- a/server/game/game.go
+++ b/server/game/game.go
@@ -27,6 +27,12 @@ func (g *Game) HandleMessage(from *Player, msg Message) {
 		return
 	case "update":
 		g.update(msg)
+	case "camera":
+		// Ephemeral tier (SPEC.md §4c). Presence-only traffic — remote camera
+		// poses today. Deliberately does NOT touch g.Data: it must never be
+		// persisted, never appear in a `sync` snapshot and never replay to a
+		// joiner. Falling straight through to the broadcast below *is* the
+		// contract; this case exists so nobody "fixes" it into an update.
 	}
 
 	// For whatever reason, we broadcast every message.

--- a/server/game/game_test.go
+++ b/server/game/game_test.go
@@ -1,0 +1,154 @@
+package game
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// nextOfType drains the out channel until a message of the given type shows up.
+// ConnectPlayer broadcasts a presence update of its own (#48), so a camera
+// relay is never the first thing on the channel.
+func nextOfType(t *testing.T, out <-chan *PlayerMessage, want string) (*PlayerMessage, Message) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case pm := <-out:
+			var m Message
+			if err := json.Unmarshal(pm.Content, &m); err != nil {
+				t.Fatalf("undecodable broadcast: %v", err)
+			}
+			if m.Type == want {
+				return pm, m
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for a %q broadcast", want)
+		}
+	}
+}
+
+func drain(out <-chan *PlayerMessage) {
+	for {
+		select {
+		case <-out:
+		default:
+			return
+		}
+	}
+}
+
+// The ephemeral tier (SPEC.md §4c): `camera` messages are relayed to peers but
+// must never touch the canonical state — no persistence, nothing in `sync`,
+// nothing replayed to a joiner.
+//
+// Note this is a stronger claim than "g.Data is empty": #48's presence path
+// legitimately writes players[id].connected on attach, so the test pins the
+// state *before* the camera traffic and requires it to be byte-identical after.
+func TestCameraMessageIsRelayedButNeverMerged(t *testing.T) {
+	g, out := NewGame()
+	alice := g.ConnectPlayer("alice")
+	drain(out) // alice's presence patch
+
+	g.mu.Lock()
+	before, _ := json.Marshal(g.Data)
+	updatesBefore := g.Updates
+	g.mu.Unlock()
+
+	g.HandleMessage(alice, Message{
+		Type:      "camera",
+		PlayerID:  "alice",
+		Timestamp: time.Now().UnixMilli(),
+		Value:     json.RawMessage(`{"p":[0,25,0],"t":[0,0,0],"seq":1}`),
+	})
+
+	broadcast, relayed := nextOfType(t, out, "camera")
+	if broadcast.Exclude != "alice" {
+		t.Fatalf("camera message should be relayed to everyone but the sender, got exclude=%q", broadcast.Exclude)
+	}
+	if len(broadcast.To) != 0 {
+		t.Fatalf("camera message should go to the whole lobby, got to=%v", broadcast.To)
+	}
+	var value map[string]any
+	if err := json.Unmarshal(relayed.Value, &value); err != nil {
+		t.Fatalf("relayed value is not an object: %v", err)
+	}
+	if value["seq"] != float64(1) {
+		t.Fatalf("relayed payload lost its seq: %v", value)
+	}
+
+	g.mu.Lock()
+	after, _ := json.Marshal(g.Data)
+	updatesAfter := g.Updates
+	g.mu.Unlock()
+
+	if string(before) != string(after) {
+		t.Fatalf("camera message mutated game state:\n before %s\n after  %s", before, after)
+	}
+	if updatesAfter != updatesBefore {
+		t.Fatalf("camera message counted as a state update: %d → %d", updatesBefore, updatesAfter)
+	}
+}
+
+// A joiner's sync snapshot is g.Data — so if camera never merges, it can never
+// appear there. Presence *is* expected in the snapshot; camera poses are not.
+func TestSyncSnapshotContainsNoCameraData(t *testing.T) {
+	g, out := NewGame()
+	alice := g.ConnectPlayer("alice")
+
+	g.HandleMessage(alice, Message{
+		Type:     "update",
+		PlayerID: "alice",
+		Value:    json.RawMessage(`{"cards":{"card:1":{"position":[1,2,3]}}}`),
+	})
+
+	for seq := 1; seq <= 10; seq++ {
+		g.HandleMessage(alice, Message{
+			Type:     "camera",
+			PlayerID: "alice",
+			Value:    json.RawMessage(`{"p":[0,25,0],"t":[0,0,0],"seq":7}`),
+		})
+	}
+	drain(out)
+
+	g.SyncPlayerState("bob")
+	_, msg := nextOfType(t, out, "sync")
+
+	var state map[string]any
+	if err := json.Unmarshal(msg.Value, &state); err != nil {
+		t.Fatalf("sync value is not an object: %v", err)
+	}
+	if _, ok := state["cards"]; !ok {
+		t.Fatalf("sync lost the real state: %v", state)
+	}
+	// presence is supposed to be here — that is #48's channel, not ours
+	if _, ok := state["players"]; !ok {
+		t.Fatalf("sync lost presence state: %v", state)
+	}
+	for _, key := range []string{"camera", "cameras", "p", "t", "seq"} {
+		if _, ok := state[key]; ok {
+			t.Fatalf("sync snapshot contains camera data under %q: %v", key, state)
+		}
+	}
+	// and nothing camera-shaped hid inside a player row
+	raw, _ := json.Marshal(state["players"])
+	for _, needle := range []string{`"seq"`, `"p":[`, `"t":[`} {
+		if bytesContains(raw, needle) {
+			t.Fatalf("camera data leaked into a player row: %s", raw)
+		}
+	}
+}
+
+func bytesContains(haystack []byte, needle string) bool {
+	return len(needle) > 0 && len(haystack) >= len(needle) &&
+		json.Valid(haystack) && containsSub(string(haystack), needle)
+}
+
+func containsSub(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/src/lib/RemoteCameraAvatar.svelte
+++ b/src/lib/RemoteCameraAvatar.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+	/**
+	 * One remote player's camera, drawn in the shared scene: a small body box at
+	 * their eye position with a translucent view pyramid opening toward whatever
+	 * they are orbiting around. Watching it glide and tip is how you see an
+	 * opponent lean over the board.
+	 *
+	 * Purely decorative: no pointer handlers (so it can never eat a drag) and
+	 * `depthWrite={false}` everywhere (so it can never occlude a drop indicator
+	 * or a card face — it only ever tints what is behind it).
+	 */
+	import { T } from '@threlte/core';
+	import * as THREE from 'three';
+	import { Spring } from 'svelte/motion';
+	import {
+		remoteCameraStore,
+		remoteCameraNow,
+		cameraOpacity
+	} from '$lib/store/remoteCameraStore.svelte';
+	import { createFrustumGeometry, createFrustumEdgesGeometry } from '$lib/utils/frustum';
+
+	let { playerId, color }: { playerId: string; color: string } = $props();
+
+	const camera = $derived($remoteCameraStore[playerId]);
+
+	// Built once per avatar (there are at most three) and never rebuilt: the
+	// frustum is authored at unit length and the stub is applied as a uniform
+	// scale, so changing zoom never touches a GPU buffer. Per-instance rather
+	// than module-level so Threlte's unmount disposal can't free a geometry
+	// another avatar is still drawing.
+	const frustumGeometry = createFrustumGeometry();
+	const frustumEdges = createFrustumEdgesGeometry();
+
+	/** body box, in world units — small enough to read as a prop, not an object */
+	const BODY = [0.5, 0.36, 0.62] as const;
+
+	// The stub tracks orbit distance so "leaning in" reads: a player zoomed onto
+	// one card gets a short, tight cone; someone sitting back gets a longer one
+	// that still visibly reaches for the felt. Never the real far plane (40) —
+	// that would fill the board.
+	const STUB_MIN = 0.9;
+	const STUB_MAX = 3;
+	const STUB_PER_UNIT_DISTANCE = 0.12;
+
+	// Remote samples arrive at ≤ 3 Hz, so both ends of the pose spring toward
+	// the latest sample instead of teleporting between packets — the same
+	// pattern (and constants) as the remote-drag glide in Card/Piece.svelte.
+	// Seeded from the first sample by the effect below rather than from
+	// `camera` here: reading reactive state in a constructor would capture only
+	// its initial value.
+	const pose = new Spring(
+		{ px: 0, py: 0, pz: 0, tx: 0, ty: 0, tz: 0 },
+		{ stiffness: 0.15, damping: 0.8, precision: 0.0001 }
+	);
+
+	// gates the first render too: without it the avatar would flash at the
+	// origin for one frame before the seeding effect runs
+	let seeded = $state(false);
+	$effect(() => {
+		if (!camera) return;
+		const next = {
+			px: camera.p[0],
+			py: camera.p[1],
+			pz: camera.p[2],
+			tx: camera.t[0],
+			ty: camera.t[1],
+			tz: camera.t[2]
+		};
+		// first sample places the avatar; everything after glides to it
+		if (!seeded) {
+			seeded = true;
+			pose.set(next, { instant: true });
+		} else {
+			pose.target = next;
+		}
+	});
+
+	// scratch objects — reused so the per-frame derive allocates nothing
+	const eye = new THREE.Vector3();
+	const focus = new THREE.Vector3();
+	const up = new THREE.Vector3(0, 1, 0);
+	const basis = new THREE.Matrix4();
+	const euler = new THREE.Euler();
+
+	const position = $derived<[number, number, number]>([
+		pose.current.px,
+		pose.current.py,
+		pose.current.pz
+	]);
+
+	/** how far they are zoomed out — OrbitControls clamps it to 1…40 */
+	const orbitDistance = $derived(
+		Math.hypot(
+			pose.current.px - pose.current.tx,
+			pose.current.py - pose.current.ty,
+			pose.current.pz - pose.current.tz
+		)
+	);
+
+	/**
+	 * `Matrix4.lookAt` builds the camera-style basis (-Z toward the target),
+	 * which is exactly how the frustum geometry is authored — so no quaternion
+	 * slerp is needed, the springed endpoints already carry the orientation.
+	 */
+	const rotation = $derived.by<[number, number, number]>(() => {
+		if (orbitDistance < 1e-4) return [0, 0, 0];
+		eye.set(pose.current.px, pose.current.py, pose.current.pz);
+		focus.set(pose.current.tx, pose.current.ty, pose.current.tz);
+		basis.lookAt(eye, focus, up);
+		euler.setFromRotationMatrix(basis);
+		return [euler.x, euler.y, euler.z];
+	});
+
+	const stub = $derived(
+		Math.min(STUB_MAX, Math.max(STUB_MIN, orbitDistance * STUB_PER_UNIT_DISTANCE))
+	);
+
+	// fade a peer out once their samples stop; the store drops them entirely
+	// after CAMERA_EXPIRE_MS (see remoteCameraStore for why expiry is our only
+	// disconnect signal)
+	const fade = $derived(cameraOpacity(Math.max(0, $remoteCameraNow - (camera?.lastSeen ?? 0))));
+</script>
+
+{#if camera && seeded}
+	<T.Group {position} {rotation}>
+		<!-- camera body -->
+		<T.Mesh position={[0, 0, BODY[2] / 2]}>
+			<T.BoxGeometry args={[BODY[0], BODY[1], BODY[2]]} />
+			<T.MeshBasicMaterial {color} transparent opacity={0.55 * fade} depthWrite={false} />
+		</T.Mesh>
+
+		<!-- view frustum: translucent body … -->
+		<T.Mesh scale={stub}>
+			<T is={frustumGeometry} />
+			<T.MeshBasicMaterial
+				{color}
+				transparent
+				opacity={0.14 * fade}
+				depthWrite={false}
+				side={THREE.DoubleSide}
+			/>
+		</T.Mesh>
+
+		<!-- … plus its edges, which is what actually reads at a distance -->
+		<T.LineSegments scale={stub}>
+			<T is={frustumEdges} />
+			<T.LineBasicMaterial {color} transparent opacity={0.6 * fade} depthWrite={false} />
+		</T.LineSegments>
+	</T.Group>
+{/if}

--- a/src/lib/TableCamera.svelte
+++ b/src/lib/TableCamera.svelte
@@ -4,9 +4,11 @@
 	import type { OrbitControls as OrbitControlsType } from 'three/examples/jsm/controls/OrbitControls.js';
 	import * as THREE from 'three';
 	import { dragStore } from '$lib/store/dragStore.svelte';
-	import { cameraResetSignal } from '$lib/store/cameraStore.svelte';
+	import { cameraBroadcastSignal, cameraResetSignal } from '$lib/store/cameraStore.svelte';
 	import { gameActions } from './store/game/actions';
 	import { gameStore } from './store/game/gameStore.svelte';
+	import { createCameraStream } from '$lib/websocket/cameraStream';
+	import { isWebSocketConnected, sendMessage } from '$lib/websocket/connection';
 
 	const isDragging = $derived($dragStore.isDragging !== null);
 
@@ -33,6 +35,59 @@
 		controls.target.set(0, 0, 0);
 		controls.update();
 	});
+
+	/**
+	 * Presence: stream our pose to peers so they can draw our camera avatar.
+	 *
+	 * This bypasses gameStore entirely — see websocket/cameraStream.ts for why
+	 * (unthrottled path + poses would be persisted into lobby state). The
+	 * stream is self-throttling and silent while the camera is still, so an
+	 * idle client puts nothing on the wire.
+	 */
+	const cameraStream = createCameraStream((sample) => {
+		if (!isWebSocketConnected()) return false;
+		const playerId = gameActions.getMyId();
+		if (!playerId) return false;
+		return sendMessage({ type: 'camera', playerId, timestamp: Date.now(), value: sample });
+	});
+
+	$effect(() => () => cameraStream.dispose());
+
+	/**
+	 * A local drag already spends 5 Hz of the server's 7 msg/s budget, and the
+	 * limiter *disconnects* rather than drops. Measured against the Go server:
+	 * a sustained 5 Hz drag plus 2.9 Hz of camera is 7.9/s and closes the
+	 * socket with StatusPolicyViolation after ~20s. So the camera yields
+	 * entirely while dragging — which costs nothing real, since OrbitControls
+	 * rotation is already disabled then (only the wheel can still move it) —
+	 * and the settled pose goes out on release.
+	 */
+	let forceOnRelease = false;
+
+	function broadcastPose(force = false) {
+		if (!camera || !controls) return;
+		if (isDragging) {
+			forceOnRelease ||= force;
+			return;
+		}
+		const { x, y, z } = camera.position;
+		const { x: tx, y: ty, z: tz } = controls.target;
+		cameraStream.offer([x, y, z], [tx, ty, tz], force);
+	}
+
+	// a peer just joined and missed everything we sent before they connected
+	$effect(() => {
+		if ($cameraBroadcastSignal === 0) return;
+		broadcastPose(true);
+	});
+
+	// drag released: resume the stream, and honour any join request we swallowed
+	$effect(() => {
+		if (isDragging) return;
+		const force = forceOnRelease;
+		forceOnRelease = false;
+		broadcastPose(force);
+	});
 </script>
 
 <!-- near/far bound tightly to the orbit range (min 1 / max 40): depth precision
@@ -47,6 +102,7 @@
 >
 	<OrbitControls
 		bind:ref={controls}
+		onchange={() => broadcastPose()}
 		enableRotate={!isDragging}
 		enableDamping
 		maxPolarAngle={Math.PI / 2 - 0.1}

--- a/src/lib/TableScene.svelte
+++ b/src/lib/TableScene.svelte
@@ -11,11 +11,16 @@
 	import Piece from './Piece.svelte';
 	import Hdr from './HDR.svelte';
 	import HudPreviewScene from './HUDPreview/HUDPreviewScene.svelte';
+	import RemoteCameraAvatar from './RemoteCameraAvatar.svelte';
 	import { dragStore } from '$lib/store/dragStore.svelte';
 	import { gameStore } from './store/game/gameStore.svelte';
+	import { gameActions } from './store/game/actions';
+	import { remoteCameraActions, remoteCameraStore } from './store/remoteCameraStore.svelte';
+	import { playerColor } from './hud/players';
 	import { clampToTable } from './utils/transforms/drop';
 	import { cancelActiveDrag, commitActiveDrag } from './drop/commit';
 	import { onMount } from 'svelte';
+	import { get } from 'svelte/store';
 	import { CARD_DRAG_Y } from '$lib/utils/constants-cards';
 	import { PIECE_DRAG_Y } from '$lib/utils/constants-pieces';
 	import { TABLE_TOP_Y } from '$lib/utils/constants-table';
@@ -89,6 +94,31 @@
 			window.removeEventListener('keydown', onKeyDown);
 		};
 	});
+
+	/**
+	 * Remote camera avatars. Never our own — the store filters it on receive,
+	 * this filters it again because the id can arrive before we have one.
+	 */
+	const remoteCameras = $derived(
+		Object.keys($remoteCameraStore)
+			.filter((id) => id !== gameActions.getMyId())
+			.map((id) => ({ id, color: playerColor(id, $gameStore?.players?.[id]?.seat) }))
+	);
+
+	// One shared clock for the presence fade + expiry, instead of a timer per
+	// avatar. Cheap enough to leave running; it only touches a store. The
+	// roster goes in so a player the server says is still connected keeps their
+	// avatar however long they sit still — expiry is only the fallback for
+	// peers we have no presence for (see remoteCameraStore).
+	$effect(() => {
+		// `get`, not `$gameStore`: reading the store reactively here would make
+		// the effect re-run — and rebuild the interval — on every state change
+		const handle = setInterval(
+			() => remoteCameraActions.tick(Date.now(), get(gameStore)?.players),
+			500
+		);
+		return () => clearInterval(handle);
+	});
 </script>
 
 <TableCamera />
@@ -118,4 +148,8 @@
 
 {#each Object.keys($gameStore?.pieces ?? {}).filter((key) => $gameStore?.pieces?.[key]) as id (id)}
 	<Piece {id} />
+{/each}
+
+{#each remoteCameras as { id, color } (id)}
+	<RemoteCameraAvatar playerId={id} {color} />
 {/each}

--- a/src/lib/hud/__tests__/players.test.ts
+++ b/src/lib/hud/__tests__/players.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { derivePlayerRows, summarize, SEAT_ROTATION_DEG } from '../players';
+import {
+	derivePlayerRows,
+	summarize,
+	SEAT_ROTATION_DEG,
+	SEAT_COLOR,
+	playerColor
+} from '../players';
 import type { GameDTO } from '$lib/store/game/types';
 
 const card = {
@@ -176,5 +182,24 @@ describe('summarize', () => {
 			players: { solo: { id: 'solo', seat: 0, joinTimestamp: 1, tray: {}, metadata: {} } }
 		});
 		expect(summarize(rows)).toBe('1 player');
+	});
+});
+
+describe('playerColor', () => {
+	it('gives each seat its own colour', () => {
+		const colors = [0, 1, 2, 3].map((seat) => playerColor('anyone', seat));
+		expect(new Set(colors).size).toBe(4);
+		expect(colors[0]).toBe(SEAT_COLOR[0]);
+	});
+
+	it('falls back to a deterministic hash for a seatless peer', () => {
+		expect(playerColor('peer-a')).toBe(playerColor('peer-a'));
+		expect(playerColor('peer-a', null)).toBe(playerColor('peer-a'));
+		expect(Object.values(SEAT_COLOR)).toContain(playerColor('peer-a'));
+	});
+
+	it('never reuses the scene highlight colours', () => {
+		const reserved = ['#5ee7ff', '#ffc94a'];
+		for (const color of Object.values(SEAT_COLOR)) expect(reserved).not.toContain(color);
 	});
 });

--- a/src/lib/hud/players.ts
+++ b/src/lib/hud/players.ts
@@ -22,6 +22,33 @@ export const SEAT_ROTATION_DEG: Record<number, number> = {
 	3: 270
 };
 
+/**
+ * Per-seat tint, currently used only by the remote camera avatars.
+ * Chosen clear of the scene's existing signal colours — the cyan drop
+ * highlight (#5ee7ff) and the amber stack highlight (#ffc94a) — so a hovering
+ * avatar can never be mistaken for a drop cue.
+ */
+export const SEAT_COLOR: Record<number, string> = {
+	0: '#ff6b8a', // rose
+	1: '#6ee7a0', // green
+	2: '#b98cff', // violet
+	3: '#ff8a3d' // orange
+};
+
+const SEAT_PALETTE = Object.values(SEAT_COLOR);
+
+/**
+ * Colour for a player. Seated players get their seat's colour; a peer we have
+ * no seat for (present on the wire but not yet in `players`) falls back to a
+ * deterministic hash of the id, so both ends agree without extra messages.
+ */
+export function playerColor(playerId: string, seat?: number | null): string {
+	if (seat != null && SEAT_COLOR[seat]) return SEAT_COLOR[seat];
+	let hash = 0;
+	for (let i = 0; i < playerId.length; i++) hash = (hash * 31 + playerId.charCodeAt(i)) | 0;
+	return SEAT_PALETTE[Math.abs(hash) % SEAT_PALETTE.length];
+}
+
 export type DeckCount = {
 	/** the `<slot>` part of `deck:<playerId>:<slot>` */
 	slot: string;

--- a/src/lib/store/__tests__/remoteCamera.test.ts
+++ b/src/lib/store/__tests__/remoteCamera.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import type { Vec3 } from '$lib/websocket/cameraStream';
+import {
+	CAMERA_EXPIRE_MS,
+	CAMERA_FADE_MS,
+	CAMERA_MIN_OPACITY,
+	CAMERA_SEQ_RESET_GAP,
+	CAMERA_STALE_MS,
+	applyCameraSample,
+	cameraOpacity,
+	parseCameraSample,
+	pruneExpiredCameras,
+	remoteCameraActions,
+	remoteCameraStore,
+	type RemoteCameraMap
+} from '../remoteCameraStore.svelte';
+
+const sample = (seq: number, x = 0) => ({ p: [x, 25, 0], t: [0, 0, 0], seq });
+
+describe('parseCameraSample', () => {
+	it('accepts a well-formed payload', () => {
+		expect(parseCameraSample(sample(1))).toEqual({ p: [0, 25, 0], t: [0, 0, 0], seq: 1 });
+	});
+
+	it.each([
+		['null', null],
+		['a string', 'nope'],
+		['a missing target', { p: [0, 0, 0], seq: 1 }],
+		['a short vector', { p: [0, 0], t: [0, 0, 0], seq: 1 }],
+		['a non-numeric vector', { p: [0, '25', 0], t: [0, 0, 0], seq: 1 }],
+		['NaN', { p: [0, NaN, 0], t: [0, 0, 0], seq: 1 }],
+		['a missing seq', { p: [0, 0, 0], t: [0, 0, 0] }]
+	])('rejects %s', (_label, value) => {
+		expect(parseCameraSample(value)).toBeNull();
+	});
+});
+
+describe('applyCameraSample', () => {
+	const empty: RemoteCameraMap = {};
+
+	it('stores the first sample with its arrival time', () => {
+		const next = applyCameraSample(empty, 'bob', sample(1, 3), 1_000);
+		expect(next.bob).toEqual({ p: [3, 25, 0], t: [0, 0, 0], seq: 1, lastSeen: 1_000 });
+	});
+
+	it('applies a newer seq', () => {
+		const first = applyCameraSample(empty, 'bob', sample(1, 3), 1_000);
+		const second = applyCameraSample(first, 'bob', sample(2, 7), 1_400);
+		expect(second.bob).toMatchObject({ p: [7, 25, 0], seq: 2, lastSeen: 1_400 });
+	});
+
+	it('drops a reordered (older) sample, keeping the newest pose', () => {
+		const first = applyCameraSample(empty, 'bob', sample(5, 7), 1_000);
+		const stale = applyCameraSample(first, 'bob', sample(4, 3), 1_100);
+		expect(stale).toBe(first); // same object → no subscriber churn
+		expect(stale.bob).toMatchObject({ p: [7, 25, 0], seq: 5, lastSeen: 1_000 });
+	});
+
+	it('drops a duplicate seq', () => {
+		const first = applyCameraSample(empty, 'bob', sample(5, 7), 1_000);
+		expect(applyCameraSample(first, 'bob', sample(5, 3), 1_100)).toBe(first);
+	});
+
+	it('accepts a restarted stream — a peer that reloaded begins at seq 1 again', () => {
+		const first = applyCameraSample(empty, 'bob', sample(CAMERA_SEQ_RESET_GAP + 50, 7), 1_000);
+		const restarted = applyCameraSample(first, 'bob', sample(1, 3), 9_000);
+		expect(restarted.bob).toMatchObject({ p: [3, 25, 0], seq: 1, lastSeen: 9_000 });
+	});
+
+	it('keeps players independent', () => {
+		let map = applyCameraSample(empty, 'bob', sample(9), 1_000);
+		map = applyCameraSample(map, 'ana', sample(1), 1_050);
+		expect(Object.keys(map).sort()).toEqual(['ana', 'bob']);
+	});
+
+	it('ignores malformed payloads and empty ids', () => {
+		expect(applyCameraSample(empty, 'bob', { nope: true }, 1)).toBe(empty);
+		expect(applyCameraSample(empty, '', sample(1), 1)).toBe(empty);
+	});
+});
+
+describe('pruneExpiredCameras', () => {
+	const stale = (lastSeen: number) => ({
+		p: [0, 0, 0] as Vec3,
+		t: [0, 0, 0] as Vec3,
+		seq: 1,
+		lastSeen
+	});
+	const NOW = 100_000;
+
+	it('drops only entries past the expiry window', () => {
+		const map: RemoteCameraMap = {
+			fresh: stale(NOW),
+			gone: stale(NOW - CAMERA_EXPIRE_MS - 1)
+		};
+		expect(Object.keys(pruneExpiredCameras(map, NOW))).toEqual(['fresh']);
+	});
+
+	it('returns the same map when nothing expired', () => {
+		const map: RemoteCameraMap = { fresh: stale(NOW) };
+		expect(pruneExpiredCameras(map, NOW)).toBe(map);
+	});
+
+	// #48 gave us a real presence flag, so a silent-but-present player must not
+	// blink out just because their camera has not moved. The sender goes quiet
+	// on purpose when a camera settles — expiry alone would punish sitting still.
+	it('keeps a long-silent player the server says is still connected', () => {
+		const map: RemoteCameraMap = { parked: stale(NOW - CAMERA_EXPIRE_MS * 10) };
+		const kept = pruneExpiredCameras(map, NOW, CAMERA_EXPIRE_MS, {
+			parked: { connected: true }
+		});
+		expect(Object.keys(kept)).toEqual(['parked']);
+	});
+
+	it('drops a player the server reports offline, without waiting out the expiry', () => {
+		const map: RemoteCameraMap = { left: stale(NOW) };
+		expect(pruneExpiredCameras(map, NOW, CAMERA_EXPIRE_MS, { left: { connected: false } })).toEqual(
+			{}
+		);
+	});
+
+	it('falls back to expiry when presence is unknown', () => {
+		const map: RemoteCameraMap = {
+			unknown: stale(NOW - CAMERA_EXPIRE_MS - 1),
+			noRow: stale(NOW)
+		};
+		// a row with no `connected` field yet is offline-unknown, not connected
+		const kept = pruneExpiredCameras(map, NOW, CAMERA_EXPIRE_MS, { unknown: {}, noRow: null });
+		expect(Object.keys(kept)).toEqual(['noRow']);
+	});
+});
+
+describe('cameraOpacity', () => {
+	it('is fully opaque until the sample goes stale', () => {
+		expect(cameraOpacity(0)).toBe(1);
+		expect(cameraOpacity(CAMERA_STALE_MS)).toBe(1);
+	});
+
+	it('fades to the floor and stays there', () => {
+		expect(cameraOpacity(CAMERA_STALE_MS + CAMERA_FADE_MS / 2)).toBeCloseTo(
+			1 - (1 - CAMERA_MIN_OPACITY) / 2
+		);
+		expect(cameraOpacity(CAMERA_STALE_MS + CAMERA_FADE_MS)).toBeCloseTo(CAMERA_MIN_OPACITY);
+		expect(cameraOpacity(CAMERA_EXPIRE_MS)).toBeCloseTo(CAMERA_MIN_OPACITY);
+	});
+});
+
+describe('remoteCameraActions', () => {
+	beforeEach(() => remoteCameraActions.reset());
+
+	it('receive → tick expiry removes an avatar that stopped sending', () => {
+		remoteCameraActions.receive('bob', sample(1), 1_000);
+		expect(get(remoteCameraStore).bob).toBeDefined();
+
+		remoteCameraActions.tick(1_000 + CAMERA_EXPIRE_MS - 1);
+		expect(get(remoteCameraStore).bob).toBeDefined();
+
+		remoteCameraActions.tick(1_000 + CAMERA_EXPIRE_MS);
+		expect(get(remoteCameraStore).bob).toBeUndefined();
+	});
+
+	it('tick keeps a connected player past expiry and drops a disconnected one', () => {
+		remoteCameraActions.receive('bob', sample(1), 1_000);
+		remoteCameraActions.receive('ana', sample(1), 1_000);
+
+		remoteCameraActions.tick(1_000 + CAMERA_EXPIRE_MS * 5, {
+			bob: { connected: true },
+			ana: { connected: false }
+		});
+
+		expect(Object.keys(get(remoteCameraStore))).toEqual(['bob']);
+	});
+
+	it('forget drops one player', () => {
+		remoteCameraActions.receive('bob', sample(1), 1_000);
+		remoteCameraActions.receive('ana', sample(1), 1_000);
+		remoteCameraActions.forget('bob');
+		expect(Object.keys(get(remoteCameraStore))).toEqual(['ana']);
+	});
+
+	it('retain keeps only players still in the roster', () => {
+		remoteCameraActions.receive('bob', sample(1), 1_000);
+		remoteCameraActions.receive('ana', sample(1), 1_000);
+		remoteCameraActions.retain(['ana']);
+		expect(Object.keys(get(remoteCameraStore))).toEqual(['ana']);
+	});
+});

--- a/src/lib/store/cameraStore.svelte.ts
+++ b/src/lib/store/cameraStore.svelte.ts
@@ -6,3 +6,14 @@ export const cameraResetSignal = writable(0);
 export function requestCameraReset() {
 	cameraResetSignal.update((n) => n + 1);
 }
+
+/**
+ * Incremented to ask TableCamera to push its current pose onto the ephemeral
+ * `camera` stream even though it hasn't moved — used when a peer joins, since
+ * the server never replays ephemeral messages to a joiner.
+ */
+export const cameraBroadcastSignal = writable(0);
+
+export function requestCameraBroadcast() {
+	cameraBroadcastSignal.update((n) => n + 1);
+}

--- a/src/lib/store/remoteCameraStore.svelte.ts
+++ b/src/lib/store/remoteCameraStore.svelte.ts
@@ -1,0 +1,171 @@
+/**
+ * Remote players' camera poses — the receive half of the ephemeral `camera`
+ * message (see websocket/cameraStream.ts and SPEC.md §4c).
+ *
+ * Kept completely out of `gameStore` on purpose: writing presence into game
+ * state would echo back onto the wire as an `update` (SPEC.md §161), persist
+ * on the server and replay to joiners. Nothing in here is ever sent.
+ */
+
+import { writable, get } from 'svelte/store';
+import type { CameraSample, Vec3 } from '$lib/websocket/cameraStream';
+
+/** no sample for this long → the avatar starts fading out */
+export const CAMERA_STALE_MS = 5_000;
+/** how long the fade from full to CAMERA_MIN_OPACITY takes */
+export const CAMERA_FADE_MS = 2_500;
+/**
+ * No sample for this long → the avatar is dropped, *unless* the server says
+ * that player is still connected.
+ *
+ * The issue specified a flat 30s expiry because "the client has no reliable
+ * connected flag (#33 is still in review)". #33 has since merged: presence now
+ * arrives as `players[id].connected` merge patches. That matters, because the
+ * sender goes deliberately silent while a camera is still — under a flat
+ * expiry a player who parks their view and thinks for 30s would blink out.
+ * So expiry is now the *fallback* for peers we have no presence for, and a
+ * `connected: false` patch is the real removal signal.
+ */
+export const CAMERA_EXPIRE_MS = 30_000;
+/** faded-out avatars stay faintly visible until they expire */
+export const CAMERA_MIN_OPACITY = 0.15;
+
+/**
+ * A peer that reloads restarts its counter at 1. Only reject seqs inside this
+ * window below the newest one (genuine reordering); a bigger backwards jump is
+ * a restarted stream and must be accepted or that peer never reappears.
+ */
+export const CAMERA_SEQ_RESET_GAP = 32;
+
+export type RemoteCamera = {
+	p: Vec3;
+	t: Vec3;
+	seq: number;
+	/** local clock when the newest accepted sample arrived */
+	lastSeen: number;
+};
+
+export type RemoteCameraMap = Record<string, RemoteCamera>;
+
+function isVec3(value: unknown): value is Vec3 {
+	return (
+		Array.isArray(value) &&
+		value.length === 3 &&
+		value.every((n) => typeof n === 'number' && isFinite(n))
+	);
+}
+
+/** A wire payload we are willing to render. Anything else is dropped silently. */
+export function parseCameraSample(value: unknown): CameraSample | null {
+	if (!value || typeof value !== 'object') return null;
+	const { p, t, seq } = value as Partial<CameraSample>;
+	if (!isVec3(p) || !isVec3(t)) return null;
+	if (typeof seq !== 'number' || !isFinite(seq)) return null;
+	return { p, t, seq };
+}
+
+/**
+ * Last-write-wins per player (SPEC.md:181): a sample that is not newer than
+ * the one already applied is dropped. Returns the same map object when
+ * nothing changed so subscribers don't churn.
+ */
+export function applyCameraSample(
+	map: RemoteCameraMap,
+	playerId: string,
+	value: unknown,
+	receivedAt: number
+): RemoteCameraMap {
+	if (!playerId) return map;
+	const sample = parseCameraSample(value);
+	if (!sample) return map;
+
+	const existing = map[playerId];
+	if (existing && sample.seq <= existing.seq && sample.seq > existing.seq - CAMERA_SEQ_RESET_GAP)
+		return map;
+
+	return {
+		...map,
+		[playerId]: { p: sample.p, t: sample.t, seq: sample.seq, lastSeen: receivedAt }
+	};
+}
+
+/** Presence as the lobby state carries it — `players` from a GameDTO. */
+export type PresenceRoster = Record<string, { connected?: boolean } | null | undefined>;
+
+/**
+ * Drop avatars whose newest sample is older than `expireMs`.
+ *
+ * `roster` is the server's presence view (#48). Per player:
+ *  - `connected === true`  → keep, however stale. They are here, just still.
+ *  - `connected === false` → drop now, without waiting out the expiry.
+ *  - unknown               → fall back to `expireMs`.
+ */
+export function pruneExpiredCameras(
+	map: RemoteCameraMap,
+	now: number,
+	expireMs = CAMERA_EXPIRE_MS,
+	roster?: PresenceRoster
+): RemoteCameraMap {
+	const live = Object.entries(map).filter(([id, cam]) => {
+		const connected = roster?.[id]?.connected;
+		if (connected === true) return true;
+		if (connected === false) return false;
+		return now - cam.lastSeen < expireMs;
+	});
+	if (live.length === Object.keys(map).length) return map;
+	return Object.fromEntries(live);
+}
+
+/** Full → faint over CAMERA_FADE_MS once a sample is CAMERA_STALE_MS old. */
+export function cameraOpacity(ageMs: number): number {
+	if (ageMs <= CAMERA_STALE_MS) return 1;
+	const progress = Math.min(1, (ageMs - CAMERA_STALE_MS) / CAMERA_FADE_MS);
+	return 1 - progress * (1 - CAMERA_MIN_OPACITY);
+}
+
+/** playerId → newest pose. Never contains our own id (index.ts filters it). */
+export const remoteCameraStore = writable<RemoteCameraMap>({});
+
+/**
+ * Shared "now" driving the fade. Bumped on every accepted sample and by
+ * TableScene's tick, so avatars dim without every component owning a timer.
+ */
+export const remoteCameraNow = writable(0);
+
+export const remoteCameraActions = {
+	/** Apply an inbound `camera` payload. */
+	receive(playerId: string, value: unknown, receivedAt: number = Date.now()) {
+		const before = get(remoteCameraStore);
+		const after = applyCameraSample(before, playerId, value, receivedAt);
+		if (after === before) return;
+		remoteCameraStore.set(after);
+		remoteCameraNow.set(receivedAt);
+	},
+
+	/** Age the fade and drop avatars that expired or went offline. */
+	tick(now: number = Date.now(), roster?: PresenceRoster) {
+		remoteCameraNow.set(now);
+		remoteCameraStore.update((map) => pruneExpiredCameras(map, now, CAMERA_EXPIRE_MS, roster));
+	},
+
+	forget(playerId: string) {
+		remoteCameraStore.update((map) => {
+			if (!(playerId in map)) return map;
+			return Object.fromEntries(Object.entries(map).filter(([id]) => id !== playerId));
+		});
+	},
+
+	/** Keep only players present in an authoritative roster. */
+	retain(playerIds: string[]) {
+		const keep = new Set(playerIds);
+		remoteCameraStore.update((map) => {
+			const live = Object.entries(map).filter(([id]) => keep.has(id));
+			if (live.length === Object.keys(map).length) return map;
+			return Object.fromEntries(live);
+		});
+	},
+
+	reset() {
+		remoteCameraStore.set({});
+	}
+};

--- a/src/lib/utils/__tests__/frustum.test.ts
+++ b/src/lib/utils/__tests__/frustum.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import * as THREE from 'three';
+import {
+	FRUSTUM_ASPECT,
+	FRUSTUM_FOV_DEG,
+	createFrustumEdgesGeometry,
+	createFrustumGeometry,
+	frustumHalfExtents
+} from '../frustum';
+
+/** Mirrors RemoteCameraAvatar: Matrix4.lookAt basis + a uniform stub scale. */
+function placeAvatar(
+	eye: [number, number, number],
+	target: [number, number, number],
+	stub: number
+) {
+	const group = new THREE.Object3D();
+	const basis = new THREE.Matrix4().lookAt(
+		new THREE.Vector3(...eye),
+		new THREE.Vector3(...target),
+		new THREE.Vector3(0, 1, 0)
+	);
+	group.position.set(...eye);
+	group.rotation.setFromRotationMatrix(basis);
+	group.scale.setScalar(stub);
+	group.updateMatrixWorld(true);
+	return group;
+}
+
+describe('frustumHalfExtents', () => {
+	it('matches the camera fov and widens with aspect', () => {
+		const { halfWidth, halfHeight } = frustumHalfExtents(1);
+		expect(halfHeight).toBeCloseTo(Math.tan((FRUSTUM_FOV_DEG * Math.PI) / 360));
+		expect(halfWidth / halfHeight).toBeCloseTo(FRUSTUM_ASPECT);
+	});
+
+	it('scales linearly with length', () => {
+		expect(frustumHalfExtents(4).halfHeight).toBeCloseTo(frustumHalfExtents(1).halfHeight * 4);
+	});
+});
+
+describe('createFrustumGeometry', () => {
+	it('is a unit-length open pyramid: apex at the origin, mouth at z = -1', () => {
+		const positions = createFrustumGeometry().getAttribute('position');
+		expect(positions.count).toBe(12); // 4 side triangles, no cap
+
+		const z = Array.from({ length: positions.count }, (_, i) => positions.getZ(i));
+		expect(Math.max(...z)).toBe(0); // apex
+		expect(Math.min(...z)).toBe(-1); // mouth
+	});
+
+	it('draws the four apex rays and the mouth rectangle as edges', () => {
+		expect(createFrustumEdgesGeometry().getAttribute('position').count).toBe(16); // 8 segments
+	});
+});
+
+describe('avatar orientation', () => {
+	it('points the mouth at the orbit target', () => {
+		const eye: [number, number, number] = [0, 25, 0];
+		const target: [number, number, number] = [0, 0, 0];
+		const stub = 3;
+		const group = placeAvatar(eye, target, stub);
+
+		// the geometry's mouth centre is at local (0, 0, -1)
+		const mouth = new THREE.Vector3(0, 0, -1).applyMatrix4(group.matrixWorld);
+
+		// a bird's-eye camera's frustum must open straight down toward the felt
+		expect(mouth.x).toBeCloseTo(0);
+		expect(mouth.z).toBeCloseTo(0);
+		expect(mouth.y).toBeCloseTo(25 - stub);
+	});
+
+	it('reorients as the player orbits around the table', () => {
+		const stub = 2;
+		// low, off to the +x side, still looking at the centre
+		const group = placeAvatar([20, 5, 0], [0, 0, 0], stub);
+		const mouth = new THREE.Vector3(0, 0, -1).applyMatrix4(group.matrixWorld);
+
+		// the mouth sits `stub` units along the eye→target direction
+		const expected = new THREE.Vector3(0, 0, 0)
+			.sub(new THREE.Vector3(20, 5, 0))
+			.normalize()
+			.multiplyScalar(stub)
+			.add(new THREE.Vector3(20, 5, 0));
+		expect(mouth.distanceTo(expected)).toBeLessThan(1e-6);
+	});
+
+	it('keeps the mouth well short of the far plane so it cannot swallow the board', () => {
+		// TableCamera's maxDistance is 40; the avatar's stub never approaches it
+		const { halfWidth } = frustumHalfExtents(3);
+		expect(halfWidth * 2).toBeLessThan(4); // narrower than a few card widths
+	});
+});

--- a/src/lib/utils/frustum.ts
+++ b/src/lib/utils/frustum.ts
@@ -1,0 +1,83 @@
+/**
+ * Geometry for the remote-player camera avatar: an open, rectangular view
+ * pyramid with its apex at the origin, opening along -Z (three.js' camera
+ * forward axis, so a `Matrix4.lookAt` basis orients it correctly).
+ *
+ * Built at unit length so a single shared geometry can be scaled per avatar —
+ * a uniform scale preserves the fov, and rebuilding geometry every frame would
+ * churn GPU buffers.
+ *
+ * The real frustum is never drawn: the scene's depth range is deliberately
+ * tight (near 0.5 / far 200, TableCamera.svelte) and a 40-unit cone from a
+ * bird's-eye orbit would swallow the whole board. The avatar shows a short
+ * stub of it instead — see FRUSTUM_STUB_* in RemoteCameraAvatar.svelte.
+ */
+
+import * as THREE from 'three';
+
+/** matches TableCamera's fixed fov — "zoom" here is orbit distance, not fov */
+export const FRUSTUM_FOV_DEG = 35;
+/** nominal viewport aspect; avatars are a cue, not a projection replica */
+export const FRUSTUM_ASPECT = 16 / 9;
+
+/** Half-width/half-height of the frustum's far rectangle at `length`. */
+export function frustumHalfExtents(
+	length = 1,
+	fovDeg = FRUSTUM_FOV_DEG,
+	aspect = FRUSTUM_ASPECT
+): { halfWidth: number; halfHeight: number } {
+	const halfHeight = Math.tan((fovDeg * Math.PI) / 360) * length;
+	return { halfWidth: halfHeight * aspect, halfHeight };
+}
+
+/**
+ * Four side triangles, no cap — the open mouth reads as a view cone rather
+ * than a solid wedge. DoubleSide material, so winding does not matter.
+ */
+export function createFrustumGeometry(
+	fovDeg = FRUSTUM_FOV_DEG,
+	aspect = FRUSTUM_ASPECT
+): THREE.BufferGeometry {
+	const { halfWidth: w, halfHeight: h } = frustumHalfExtents(1, fovDeg, aspect);
+	const apex: [number, number, number] = [0, 0, 0];
+	const corners: [number, number, number][] = [
+		[-w, -h, -1],
+		[w, -h, -1],
+		[w, h, -1],
+		[-w, h, -1]
+	];
+
+	const vertices: number[] = [];
+	for (let i = 0; i < corners.length; i++) {
+		vertices.push(...apex, ...corners[i], ...corners[(i + 1) % corners.length]);
+	}
+
+	const geometry = new THREE.BufferGeometry();
+	geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
+	geometry.computeVertexNormals();
+	return geometry;
+}
+
+/** The four apex→corner rays plus the mouth rectangle, as line segments. */
+export function createFrustumEdgesGeometry(
+	fovDeg = FRUSTUM_FOV_DEG,
+	aspect = FRUSTUM_ASPECT
+): THREE.BufferGeometry {
+	const { halfWidth: w, halfHeight: h } = frustumHalfExtents(1, fovDeg, aspect);
+	const corners: [number, number, number][] = [
+		[-w, -h, -1],
+		[w, -h, -1],
+		[w, h, -1],
+		[-w, h, -1]
+	];
+
+	const vertices: number[] = [];
+	for (let i = 0; i < corners.length; i++) {
+		vertices.push(0, 0, 0, ...corners[i]); // apex → corner
+		vertices.push(...corners[i], ...corners[(i + 1) % corners.length]); // mouth edge
+	}
+
+	const geometry = new THREE.BufferGeometry();
+	geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
+	return geometry;
+}

--- a/src/lib/websocket/__tests__/cameraStream.test.ts
+++ b/src/lib/websocket/__tests__/cameraStream.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	CAMERA_POSITION_EPSILON,
+	CAMERA_STREAM_INTERVAL_MS,
+	createCameraStream,
+	poseChanged,
+	type CameraSample,
+	type Vec3
+} from '../cameraStream';
+
+const ORIGIN: Vec3 = [0, 0, 0];
+
+describe('poseChanged', () => {
+	it('ignores sub-threshold jitter on both endpoints', () => {
+		expect(
+			poseChanged({ p: [0, 25, 0], t: ORIGIN }, { p: [0.001, 25, 0.001], t: [0, 0, 0.001] })
+		).toBe(false);
+	});
+
+	it('fires when the eye moves past the position epsilon', () => {
+		expect(
+			poseChanged(
+				{ p: [0, 25, 0], t: ORIGIN },
+				{ p: [0, 25, CAMERA_POSITION_EPSILON * 2], t: ORIGIN }
+			)
+		).toBe(true);
+	});
+
+	it('fires when only the orbit target moves (pan)', () => {
+		expect(poseChanged({ p: [0, 25, 0], t: ORIGIN }, { p: [0, 25, 0], t: [1, 0, 0] })).toBe(true);
+	});
+});
+
+describe('createCameraStream', () => {
+	let clock = 0;
+	let sent: CameraSample[];
+	const now = () => clock;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		clock = 10_000;
+		sent = [];
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	function makeStream(deliver = true) {
+		return createCameraStream(
+			(sample) => {
+				if (!deliver) return false;
+				sent.push(sample);
+				return true;
+			},
+			{ now }
+		);
+	}
+
+	/** advance both the injected clock and the timer queue together */
+	function advance(ms: number) {
+		clock += ms;
+		vi.advanceTimersByTime(ms);
+	}
+
+	it('sends the first sample immediately (leading edge)', () => {
+		const stream = makeStream();
+		stream.offer([0, 25, 0], ORIGIN);
+		expect(sent).toEqual([{ p: [0, 25, 0], t: ORIGIN, seq: 1 }]);
+	});
+
+	it('sends nothing at all while the camera is idle', () => {
+		const stream = makeStream();
+		stream.offer([0, 25, 0], ORIGIN);
+		sent = [];
+
+		// a settled OrbitControls still fires `change` during damping
+		for (let i = 0; i < 100; i++) {
+			stream.offer([0, 25, 0.0001], ORIGIN);
+			advance(16);
+		}
+		expect(sent).toEqual([]);
+	});
+
+	it('coalesces a burst into one leading and one trailing sample', () => {
+		const stream = makeStream();
+		for (let i = 0; i < 30; i++) {
+			stream.offer([i, 25, 0], ORIGIN);
+			advance(16); // ~60 Hz orbit
+		}
+		stream.dispose();
+
+		// 30 offers over ~480ms → 1 leading + at most 2 more at 350ms spacing
+		expect(sent.length).toBeLessThanOrEqual(3);
+		expect(sent[0].p).toEqual([0, 25, 0]);
+	});
+
+	it('never exceeds the interval budget under sustained orbiting', () => {
+		const stream = makeStream();
+		const durationMs = 10_000;
+		for (let t = 0; t < durationMs; t += 16) {
+			stream.offer([t / 100, 25, 0], ORIGIN);
+			advance(16);
+		}
+		stream.dispose();
+
+		const maxSends = Math.ceil(durationMs / CAMERA_STREAM_INTERVAL_MS) + 1;
+		expect(sent.length).toBeLessThanOrEqual(maxSends);
+		// and comfortably under the server's 7 msg/s disconnect threshold,
+		// which drag streaming already spends 5 Hz of
+		expect(sent.length / (durationMs / 1000)).toBeLessThanOrEqual(3);
+	});
+
+	it('delivers the settled pose as a trailing sample after motion stops', () => {
+		const stream = makeStream();
+		stream.offer([0, 25, 0], ORIGIN); // leading
+		stream.offer([5, 25, 0], ORIGIN); // throttled → queued
+		stream.offer([9, 25, 0], ORIGIN); // supersedes the queued one
+		expect(sent).toHaveLength(1);
+
+		advance(CAMERA_STREAM_INTERVAL_MS);
+		expect(sent).toHaveLength(2);
+		expect(sent[1]).toEqual({ p: [9, 25, 0], t: ORIGIN, seq: 2 });
+	});
+
+	it('assigns a strictly increasing seq', () => {
+		const stream = makeStream();
+		for (let i = 0; i < 5; i++) {
+			stream.offer([i * 10, 25, 0], ORIGIN);
+			advance(CAMERA_STREAM_INTERVAL_MS);
+		}
+		expect(sent.map((s) => s.seq)).toEqual([1, 2, 3, 4, 5]);
+	});
+
+	it('force bypasses the movement gate but not the throttle', () => {
+		const stream = makeStream();
+		stream.offer([0, 25, 0], ORIGIN);
+		expect(sent).toHaveLength(1);
+
+		// same pose, forced: queued rather than sent, so a burst of joiners
+		// cannot spend the rate budget
+		stream.offer([0, 25, 0], ORIGIN, true);
+		expect(sent).toHaveLength(1);
+
+		advance(CAMERA_STREAM_INTERVAL_MS);
+		expect(sent).toHaveLength(2);
+		expect(sent[1].p).toEqual([0, 25, 0]);
+	});
+
+	it('copies the pose so later mutation of the caller vectors cannot leak', () => {
+		const stream = makeStream();
+		const p: Vec3 = [0, 25, 0];
+		stream.offer(p, ORIGIN);
+		p[0] = 99;
+		expect(sent[0].p).toEqual([0, 25, 0]);
+	});
+
+	it('does not consider an undelivered sample sent (socket not up yet)', () => {
+		let connected = false;
+		const stream = createCameraStream(
+			(sample) => {
+				if (!connected) return false;
+				sent.push(sample);
+				return true;
+			},
+			{ now }
+		);
+
+		stream.offer([0, 25, 0], ORIGIN); // dropped: not connected
+		expect(sent).toEqual([]);
+
+		// same pose once the socket is up — hysteresis must not swallow it, or a
+		// camera that connects and then sits still would never appear to peers
+		connected = true;
+		advance(CAMERA_STREAM_INTERVAL_MS);
+		stream.offer([0, 25, 0], ORIGIN);
+		expect(sent).toEqual([{ p: [0, 25, 0], t: ORIGIN, seq: 1 }]);
+	});
+
+	it('drops a queued trailing sample on dispose', () => {
+		const stream = makeStream();
+		stream.offer([0, 25, 0], ORIGIN);
+		stream.offer([5, 25, 0], ORIGIN);
+		stream.dispose();
+
+		advance(CAMERA_STREAM_INTERVAL_MS * 2);
+		expect(sent).toHaveLength(1);
+	});
+});

--- a/src/lib/websocket/cameraStream.ts
+++ b/src/lib/websocket/cameraStream.ts
@@ -1,0 +1,146 @@
+/**
+ * Outbound camera-pose stream — the first consumer of the ephemeral message
+ * tier sketched in SPEC.md §4c.
+ *
+ * Deliberately NOT routed through `gameStore.updateState`:
+ *  - that wrapper only throttles `position` under `cards`/`pieces`, so a pose
+ *    would take the immediate branch and fire at pointer-move rate, and
+ *  - it sends `type:'update'`, which the server merges into the lobby's
+ *    canonical state — poses would be persisted, inflate the `/view` state
+ *    size and replay to every joiner.
+ *
+ * `type:'camera'` instead falls through the server's switch untouched and is
+ * relayed to every peer but the sender (server/game/game.go) — pure relay,
+ * never persisted, never in a `sync` snapshot.
+ *
+ * Budget: the server *disconnects* (it does not drop) at 7 msg/s sustained
+ * with a burst bucket of 15 (server/lobby/lobby.go). Drag streaming already
+ * owns 5 Hz of that, so the camera gets ≤ 3 Hz — leading edge plus one
+ * trailing sample — and goes completely silent once the camera settles.
+ */
+
+export type Vec3 = [number, number, number];
+
+/** Wire payload of a `type:'camera'` message. ~60 bytes. */
+export type CameraSample = {
+	/** camera position */
+	p: Vec3;
+	/** orbit target the camera is looking at */
+	t: Vec3;
+	/** monotonic per-sender counter; receivers drop anything not newer */
+	seq: number;
+};
+
+/** ~2.9 Hz — see the rate budget above. */
+export const CAMERA_STREAM_INTERVAL_MS = 350;
+/** world units the eye must travel before a new sample is worth sending */
+export const CAMERA_POSITION_EPSILON = 0.04;
+/** the target moves far less than the eye during an orbit, so it gets a tighter gate */
+export const CAMERA_TARGET_EPSILON = 0.02;
+
+type Pose = { p: Vec3; t: Vec3 };
+
+function distance(a: Vec3, b: Vec3): number {
+	return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+/**
+ * Hysteresis gate: has the pose moved enough to be worth a packet?
+ * A camera nobody is touching returns false forever, which is what keeps an
+ * idle client completely off the wire.
+ */
+export function poseChanged(
+	previous: Pose,
+	next: Pose,
+	positionEpsilon = CAMERA_POSITION_EPSILON,
+	targetEpsilon = CAMERA_TARGET_EPSILON
+): boolean {
+	return (
+		distance(previous.p, next.p) > positionEpsilon || distance(previous.t, next.t) > targetEpsilon
+	);
+}
+
+export type CameraStream = {
+	/**
+	 * Offer the current pose. Sends at most once per interval, and only when
+	 * the pose actually moved.
+	 * @param force skip the movement gate (still throttled) — used to answer a
+	 * peer joining, so they get an avatar without waiting for us to orbit.
+	 */
+	offer(p: Vec3, t: Vec3, force?: boolean): void;
+	/** cancel any queued trailing sample */
+	dispose(): void;
+};
+
+export type CameraStreamOptions = {
+	intervalMs?: number;
+	positionEpsilon?: number;
+	targetEpsilon?: number;
+	/** injectable clock, for tests */
+	now?: () => number;
+};
+
+/**
+ * @param send delivers a sample; return `false` when it could not go out (not
+ * connected yet) so the stream neither burns a seq nor records the pose as
+ * already sent — otherwise hysteresis would suppress it forever and peers
+ * would never see a camera that connected and then sat still.
+ */
+export function createCameraStream(
+	send: (sample: CameraSample) => boolean | void,
+	options: CameraStreamOptions = {}
+): CameraStream {
+	const intervalMs = options.intervalMs ?? CAMERA_STREAM_INTERVAL_MS;
+	const positionEpsilon = options.positionEpsilon ?? CAMERA_POSITION_EPSILON;
+	const targetEpsilon = options.targetEpsilon ?? CAMERA_TARGET_EPSILON;
+	const now = options.now ?? Date.now;
+
+	let seq = 0;
+	let lastSent: Pose | null = null;
+	let lastSentAt = Number.NEGATIVE_INFINITY;
+	let pending: Pose | null = null;
+	let timer: ReturnType<typeof setTimeout> | null = null;
+
+	function emit(pose: Pose) {
+		if (send({ p: pose.p, t: pose.t, seq: seq + 1 }) === false) return;
+		seq += 1;
+		lastSent = pose;
+		lastSentAt = now();
+	}
+
+	function flushPending() {
+		timer = null;
+		if (!pending) return;
+		const pose = pending;
+		pending = null;
+		emit(pose);
+	}
+
+	return {
+		offer(p, t, force = false) {
+			const pose: Pose = { p: [p[0], p[1], p[2]], t: [t[0], t[1], t[2]] };
+
+			// compare against the newest pose already committed to the wire (or
+			// queued for it), so a settled camera stops sending entirely
+			const reference = pending ?? lastSent;
+			if (!force && reference && !poseChanged(reference, pose, positionEpsilon, targetEpsilon))
+				return;
+
+			const elapsed = now() - lastSentAt;
+			if (!timer && elapsed >= intervalMs) {
+				emit(pose); // leading edge
+				return;
+			}
+			// trailing: keep only the newest pose — unlike entity updates there is
+			// nothing to coalesce, the latest pose supersedes every earlier one
+			pending = pose;
+			if (!timer) timer = setTimeout(flushPending, Math.max(0, intervalMs - elapsed));
+		},
+
+		dispose() {
+			if (timer) clearTimeout(timer);
+			timer = null;
+			pending = null;
+		}
+	};
+}

--- a/src/lib/websocket/connection.ts
+++ b/src/lib/websocket/connection.ts
@@ -3,9 +3,12 @@ import toast from 'svelte-french-toast';
 
 export type WebSocketMessage = {
 	// 'connect' is outbound-only: the join handshake sent by joinLobby().
-	// Inbound traffic is 'sync' | 'update' | 'error' — presence arrives as an
-	// ordinary 'update' merge patch on players[id].connected.
-	type: 'connect' | 'sync' | 'update' | 'error';
+	// Inbound traffic is 'sync' | 'update' | 'error' | 'camera' — presence
+	// arrives as an ordinary 'update' merge patch on players[id].connected,
+	// while 'camera' is the ephemeral tier (SPEC.md §4c): relayed to peers,
+	// never merged into lobby state. It flows both ways. Old clients log an
+	// unknown-type warning and carry on, so it is safe to roll out one-sided.
+	type: 'connect' | 'sync' | 'update' | 'error' | 'camera';
 	path?: string[];
 	value?: any;
 	playerId: string;
@@ -208,8 +211,9 @@ export function onMessage(callback: MessageCallback): void {
  * @param message Message received from the server
  */
 function handleMessage(message: WebSocketMessage): void {
-	// Log the message
-	console.log('Received message:', message);
+	// Log the message — except the ephemeral camera stream, which arrives
+	// several times a second per peer and would bury everything else
+	if (message.type !== 'camera') console.log('Received message:', message);
 
 	// Call all registered callbacks
 	messageCallbacks.forEach((callback) => {

--- a/src/lib/websocket/index.ts
+++ b/src/lib/websocket/index.ts
@@ -2,6 +2,8 @@ import { connect, joinLobby, onMessage, sendMessage, type WebSocketMessage } fro
 import { gameActions } from '$lib/store/game/actions';
 import { gameStore } from '$lib/store/game/gameStore.svelte';
 import { prewarmGameState } from '$lib/packs/prewarm-state';
+import { remoteCameraActions } from '$lib/store/remoteCameraStore.svelte';
+import { requestCameraBroadcast } from '$lib/store/cameraStore.svelte';
 import toast from 'svelte-french-toast';
 
 /**
@@ -47,6 +49,10 @@ export async function initWebsocket(lobbyId: string, serverUrl?: string): Promis
 		// clobber the seat a reconnecting player already holds in lobby state.
 		publishMyPlayerRow();
 
+		// announce our camera to whoever is already here — the ephemeral tier is
+		// never replayed, so without this we stay invisible until we orbit
+		requestCameraBroadcast();
+
 		return true;
 	} catch (error) {
 		console.error('Error initializing websocket:', error);
@@ -65,6 +71,34 @@ function publishMyPlayerRow(): void {
 	gameStore.updateState({
 		players: { [me.id]: { id: me.id, joinTimestamp: me.joinTimestamp ?? Date.now() } }
 	});
+}
+
+/**
+ * React to #48's presence patches on behalf of the camera avatars.
+ *
+ * Presence rides the ordinary `update` channel as `players[id].connected`, so
+ * there is no connect/disconnect message to hook — this reads the same patch
+ * the HUD dots read:
+ *  - a peer going `true` is a joiner who missed every camera sample we sent
+ *    before they attached (the ephemeral tier is never replayed), so we answer
+ *    with one of ours or stay invisible until we next orbit;
+ *  - a peer going `false` has really left, so their avatar goes immediately
+ *    rather than lingering until the staleness timeout.
+ */
+function applyPresenceToCameras(value: unknown): void {
+	const players = (
+		value as { players?: Record<string, { connected?: boolean } | null> } | undefined
+	)?.players;
+	if (!players) return;
+
+	const myId = gameActions.getMyId();
+	let peerCameOnline = false;
+	for (const [id, player] of Object.entries(players)) {
+		if (!player || id === myId) continue;
+		if (player.connected === true) peerCameOnline = true;
+		else if (player.connected === false) remoteCameraActions.forget(id);
+	}
+	if (peerCameOnline) requestCameraBroadcast();
 }
 
 /**
@@ -93,6 +127,17 @@ function setupMessageHandlers(): void {
 				console.log('Received update message', message);
 				gameStore.updateStateSilently(message.value);
 				prewarmGameState(message.value, () => gameStore.updateStateSilently({}));
+				applyPresenceToCameras(message.value);
+				break;
+
+			case 'camera':
+				// Ephemeral presence (SPEC.md §4c). Deliberately NOT routed through
+				// gameStore: any updateState here would echo straight back onto the
+				// wire and persist a pose in lobby state.
+				// The server already excludes the sender, but guard anyway — a
+				// self-echo would draw our own camera in our own face.
+				if (message.playerId && message.playerId !== gameActions.getMyId())
+					remoteCameraActions.receive(message.playerId, message.value);
 				break;
 
 			case 'error':


### PR DESCRIPTION
Task: tableplace-61

Closes #61

Each remote player's camera now shows up in the shared scene as a small body box with a translucent view pyramid opening toward whatever they're orbiting around. You can watch an opponent glide around the table and lean in over the board. Zero required server changes.

Rebased onto current main (#48 presence, #54 tbpp/tbps, #62 piles, #58 seat claim, #56 tbps v2, #55 pack editor, #57 landing page).

## Protocol — new ephemeral `camera` message

The Go relay already broadcast unknown message types to every peer but the sender, so `{type:'camera', playerId, timestamp, value:{p,t,seq}}` (~60 bytes) is a pure relay: never persisted, never in a `sync` snapshot, never replayed to a joiner. Old clients log an unknown-type warning and carry on.

I still added the optional explicit `case "camera":` in `server/game/game.go` documenting the skip-merge/still-relay contract, plus Go tests. Note those tests assert something stronger than "`g.Data` is empty" — #48's presence path legitimately writes `players[id].connected` on attach, so they pin the state before the camera traffic and require it byte-identical after.

## Send path

`src/lib/websocket/cameraStream.ts` bypasses `gameStore` entirely — routing poses through `updateState` would take the unthrottled branch *and* persist them into lobby state. Instead: a leading-edge + trailing throttle at ~2.9 Hz with movement hysteresis, so a settled camera goes **completely silent**. An undelivered sample (socket not up yet) isn't recorded as sent, so hysteresis can't permanently swallow the first pose.

## Two corrections to the issue's plan

**1. The rate budget is off by one.** The issue says 5 Hz drag + 3 Hz camera "stays under 7". It's 7.9/s against a 7/s refill, so the bucket drains. Measured against the merged server:

| stream | result |
|---|---|
| **shipped: drag 5 Hz, camera gated off** | **survived 25s** |
| issue budget: drag 5 Hz + camera 2.9 Hz | **DISCONNECTED** `1008 rate limit exceeded` |
| camera 2.9 Hz alone (free orbiting) | survived 25s |

So the camera **yields entirely while a local drag is in flight** — which costs nothing real, since `enableRotate={!isDragging}` already disables orbiting then. Re-measured after the rebase: #48's presence broadcasts are server→client, and the limiter is on the client's *read* path, so inbound presence doesn't consume send budget and the finding is unchanged.

**2. The staleness design was built on a premise #48 invalidated.** The issue specified a flat 30s expiry because "the client has no reliable connected flag (#33 is still in review)". It's landed. That matters: the sender is silent *by design* while a camera is still, so a flat expiry would blink out a player who parks their view and thinks for 30s. Expiry is now the **fallback** for peers we have no presence for; `players[id].connected` is the real signal, read off the same merge patches the HUD dots use.

That also replaces the connect/disconnect handler branches #48 deleted (I did not resurrect them). A peer flipping to `connected: true` prompts one re-broadcast of our pose — the ephemeral tier is never replayed to a joiner — and flipping to `false` drops their avatar at once.

## Receive path

`src/lib/store/remoteCameraStore.svelte.ts`, standalone — a pose written to `gameStore` would echo straight back onto the wire. Last-write-wins per player by `seq`, with a reset gap so a peer that reloads (seq restarts at 1) reappears instead of being dropped forever. Poses spring-tweened with the same constants as the remote-drag glide in `Card`/`Piece.svelte`; orientation from a `Matrix4.lookAt` basis, so no quaternion slerp.

## Rendering

`RemoteCameraAvatar.svelte`, mounted per remote player from `TableScene` (never your own). Unit-length frustum geometry scaled by a short stub (0.9–3 units, tracking orbit distance so "leaning in" reads) — never the real 40-unit far plane, which would swallow the board. Per-seat coloured from a new `SEAT_COLOR` palette chosen clear of the cyan drop (`#5ee7ff`) and amber stack (`#ffc94a`) highlights, with a playerId-hash fallback for seatless peers. No pointer handlers and `depthWrite: false` throughout.

## Verification

`bun run test` 251 passed · `bun run build` clean · `go test -race ./...` green. `bun run check` has 1 error — `src/lib/packs/__tests__/schemas.test.ts` (`allowUnionTypes`), which reproduces identically on a clean `origin/main` worktree, so it is pre-existing and not from this branch. ESLint likewise unchanged from its already-red baseline; none in new code.

**Two headless Chrome sessions in one lobby** (separate origins so they get distinct player ids), driven against a local server:

- **The avatar renders, glides, and reorients.** As A orbited, B's view showed A's avatar move across screen and the frustum swing from pointing straight down to pointing sideways — always aimed at A's orbit target. Dropping A's altitude flattened the cone from a downward view to a near-horizontal one, which is the "leaning in" read. Screenshots attached below.
- **Own camera never rendered:** B saw exactly one avatar (A's) at all times.
- **Idle is silent:** 6s with both cameras still → 0 camera frames received.
- **Rate:** A sent 14–17 frames across several orbits and zooms over ~15s, comfortably under the 3 Hz ceiling. B, which never orbited, sent exactly 1 (its join announce).
- **Wire contract:** 20 camera samples relayed with seqs intact, 0 echoed to sender, `/view` StateKB flat at 0.1 KB, and a joiner's sync snapshot contained `cards` + `players` presence but no camera data.

**Still not directly captured:** a frame with the avatar overlapping a card, to show non-occlusion visually. The translucency is visible in the shots (felt grid lines read through the frustum) and `depthWrite: false` is set on every material, but I did not land a screenshot with the two superimposed — worth a glance when you run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCepenXVv9cS2SH97frYTs