### PR TITLE
tableplace-58: seat claim — a shared invite link seats the joiner and hands over its decks

### DIFF
--- a/src/lib/hud/PlayerHud.svelte
+++ b/src/lib/hud/PlayerHud.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	/**
-	 * Read-only overlay listing who is at the table: seat, hand size, deck
-	 * counts, and which seats are still open. Counts only — another player's
-	 * card faces/ids are never rendered.
+	 * Overlay listing who is at the table: seat, hand size, deck counts, and
+	 * which seats are still open. Open-seat rows are the primary claim
+	 * affordance — clicking one sits you there and hands you its decks.
+	 * Counts only — another player's card faces/ids are never rendered.
 	 *
 	 * Plain DOM (not svelte-tweakpane-ui) since this is player-facing game
 	 * info, and anchored top-right so it clears the Settings (x=0) and Decks
@@ -10,7 +11,9 @@
 	 */
 	import { gameActions } from '$lib/store/game/actions';
 	import { gameStore } from '$lib/store/game/gameStore.svelte';
+	import { claimSeat, type SeatIndex } from '$lib/scenario/scenario';
 	import { derivePlayerRows, summarize, type DeckCount } from './players';
+	import toast from 'svelte-french-toast';
 
 	/** `main 34 · discard 6` */
 	const deckLine = (decks: DeckCount[]) => decks.map((d) => `${d.slot} ${d.count}`).join(' · ');
@@ -41,6 +44,11 @@
 			// private mode / storage disabled — collapse still works for this session
 		}
 	}
+
+	function handleClaimSeat(seat: number) {
+		if (claimSeat(seat as SeatIndex)) toast(`Seat ${seat} claimed — your decks are ready`);
+		else toast.error(`Seat ${seat} is no longer open`);
+	}
 </script>
 
 <!-- wrapper is click-through so cards can still be dragged underneath -->
@@ -67,14 +75,7 @@
 					<li class="px-3 py-2 text-xs opacity-50">Nobody at the table yet</li>
 				{/if}
 				{#each rows as row (row.id)}
-					<li
-						class={[
-							'flex gap-2 border-b border-white/5 px-3 py-2 text-xs last:border-b-0',
-							row.isOpenSeat && 'opacity-50',
-							row.isMe && 'bg-emerald-400/10'
-						]}
-						data-open-seat={row.isOpenSeat}
-					>
+					{#snippet seatBadge()}
 						<span
 							class={[
 								'mt-0.5 flex h-6 w-6 shrink-0 flex-col items-center justify-center rounded',
@@ -85,11 +86,36 @@
 							<span class="text-[0.65rem] leading-none font-bold">{row.seat}</span>
 							<span class="text-[0.5rem] leading-none opacity-60">{row.rotationDeg}°</span>
 						</span>
-
-						<span class="min-w-0 flex-1">
-							{#if row.isOpenSeat}
-								<span class="block italic">Seat {row.seat} — open</span>
-							{:else}
+					{/snippet}
+					<li
+						class={[
+							'border-b border-white/5 text-xs last:border-b-0',
+							!row.isOpenSeat && 'flex gap-2 px-3 py-2',
+							row.isMe && 'bg-emerald-400/10'
+						]}
+						data-open-seat={row.isOpenSeat}
+					>
+						{#if row.isOpenSeat}
+							<!-- an open seat is claimable: sit here and take over its decks -->
+							<button
+								type="button"
+								onclick={() => handleClaimSeat(row.seat)}
+								class="flex w-full gap-2 px-3 py-2 text-left opacity-50 hover:bg-white/10 hover:opacity-100"
+							>
+								{@render seatBadge()}
+								<span class="min-w-0 flex-1">
+									<span class="block italic">Seat {row.seat} — open</span>
+									{#if row.decks.length > 0}
+										<span class="block opacity-70">{deckLine(row.decks)}</span>
+									{/if}
+									<span class="block text-[0.6rem] text-emerald-300 uppercase">
+										click to sit here
+									</span>
+								</span>
+							</button>
+						{:else}
+							{@render seatBadge()}
+							<span class="min-w-0 flex-1">
 								<span class="flex items-baseline gap-1">
 									<!-- presence dot: green = connected; hollow = offline or unknown
 									     (a client that never got a presence patch must not show green) -->
@@ -109,11 +135,11 @@
 								<span class="block opacity-70">
 									hand {row.handCount}{#if row.tableCount > 0}&nbsp;· table {row.tableCount}{/if}
 								</span>
-							{/if}
-							{#if row.decks.length > 0}
-								<span class="block opacity-70">{deckLine(row.decks)}</span>
-							{/if}
-						</span>
+								{#if row.decks.length > 0}
+									<span class="block opacity-70">{deckLine(row.decks)}</span>
+								{/if}
+							</span>
+						{/if}
 					</li>
 				{/each}
 			</ul>

--- a/src/lib/hud/__tests__/PlayerHud.test.ts
+++ b/src/lib/hud/__tests__/PlayerHud.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { render, screen, cleanup, fireEvent } from '@testing-library/svelte';
+import { get } from 'svelte/store';
 import PlayerHud from '../PlayerHud.svelte';
 import { gameStore } from '$lib/store/game/gameStore.svelte';
 import type { GameDTO } from '$lib/store/game/types';
@@ -74,9 +75,27 @@ describe('PlayerHud', () => {
 		expect(container.textContent).toContain('main 0');
 	});
 
+	it('claims an open seat when its row is clicked', async () => {
+		gameStore.updateState({
+			decks: {
+				'deck:seat2:main': {
+					id: 'deck:seat2:main',
+					cards: [{ id: 'card:seat2:main-1', faceImageUrl: 'face.png' }]
+				}
+			}
+		});
+		render(PlayerHud);
+		await fireEvent.click(screen.getByRole('button', { name: /seat 2 — open/i }));
+
+		const state = get(gameStore);
+		expect(state.players?.seat2).toBeUndefined();
+		expect(state.players?.me?.seat).toBe(2);
+		expect(Object.keys(state.decks ?? {})).toContain('deck:me:main');
+	});
+
 	it('collapses to a summary and persists the choice', async () => {
 		const { container, unmount } = render(PlayerHud);
-		await fireEvent.click(screen.getByRole('button'));
+		await fireEvent.click(screen.getByRole('button', { name: /players/i }));
 
 		expect(container.textContent).toContain('2 players · 1 open');
 		expect(container.textContent).not.toContain('Seat 2 — open');

--- a/src/lib/scenario/__tests__/auto-claim.test.ts
+++ b/src/lib/scenario/__tests__/auto-claim.test.ts
@@ -1,0 +1,151 @@
+/**
+ * startAutoClaim must survive the real join sequence: the scenario syncs in
+ * some time after connecting, the local player id may not exist yet, and a
+ * stale invite's seat may already be gone. It retries until claimSeat truly
+ * succeeds and always reports a give-up.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { gameActions } from '$lib/store/game/actions';
+import { startAutoClaim, type AutoClaimFailureReason } from '../autoClaim';
+import { ensureSeatPlaceholder, type SeatIndex } from '../scenario';
+import type { GameDTO } from '$lib/store/game/types';
+
+/** flush pending microtasks (queueMicrotask-scheduled claim attempts) */
+const flush = () => Promise.resolve().then(() => Promise.resolve());
+
+function seedSeat(seat: SeatIndex) {
+	ensureSeatPlaceholder(seat);
+	gameStore.updateState({
+		decks: {
+			[`deck:seat${seat}:main`]: {
+				id: `deck:seat${seat}:main`,
+				cards: [{ id: 'c1', faceImageUrl: 'f.png' }]
+			}
+		}
+	} as Partial<GameDTO>);
+}
+
+describe('startAutoClaim', () => {
+	let stop: () => void = () => {};
+	const claimed: SeatIndex[] = [];
+	const failures: { seat: SeatIndex; reason: AutoClaimFailureReason }[] = [];
+	const handlers = {
+		onClaimed: (seat: SeatIndex) => claimed.push(seat),
+		onFailed: (seat: SeatIndex, reason: AutoClaimFailureReason) => failures.push({ seat, reason })
+	};
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		localStorage.clear();
+		claimed.length = 0;
+		failures.length = 0;
+		gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {} });
+	});
+
+	afterEach(() => {
+		stop();
+		vi.useRealTimers();
+	});
+
+	it('ignores missing or invalid seat params', async () => {
+		startAutoClaim(null, handlers)();
+		startAutoClaim('7', handlers)();
+		startAutoClaim('nope', handlers)();
+		await flush();
+		vi.advanceTimersByTime(30000);
+		expect(claimed).toEqual([]);
+		expect(failures).toEqual([]);
+	});
+
+	it('claims once the scenario placeholder arrives', async () => {
+		localStorage.setItem('myPlayerId', 'joiner');
+		gameActions.addPlayer('joiner');
+		stop = startAutoClaim('1', handlers);
+		await flush();
+		expect(claimed).toEqual([]); // nothing to claim yet
+
+		seedSeat(1);
+		await flush();
+
+		expect(claimed).toEqual([1]);
+		expect(get(gameStore).players?.joiner?.seat).toBe(1);
+		expect(Object.keys(get(gameStore).decks ?? {})).toEqual(['deck:joiner:main']);
+	});
+
+	it('retries until the claim actually succeeds instead of latching on the first attempt', async () => {
+		// the placeholder is already synced, but my player id does not exist yet
+		// — the first claim attempt fails and must NOT end the watch
+		seedSeat(0);
+		stop = startAutoClaim('0', handlers);
+		await flush();
+		expect(claimed).toEqual([]);
+
+		// websocket init finishes: player id lands, store changes, retry succeeds
+		localStorage.setItem('myPlayerId', 'joiner');
+		gameActions.addPlayer('joiner');
+		await flush();
+
+		expect(claimed).toEqual([0]);
+		expect(get(gameStore).players?.joiner?.seat).toBe(0);
+	});
+
+	it('retries on the poll interval even without further store changes', async () => {
+		seedSeat(0);
+		stop = startAutoClaim('0', handlers);
+		await flush();
+		expect(claimed).toEqual([]);
+
+		// the id appears without any store update to re-trigger the subscription
+		localStorage.setItem('myPlayerId', 'joiner');
+		await vi.advanceTimersByTimeAsync(600);
+
+		expect(claimed).toEqual([0]);
+	});
+
+	it('reports seat-taken when someone else beat the invite to the seat', async () => {
+		// host claimed seat 1 before this invite was opened: no placeholder,
+		// the seat occupied by a player who owns decks
+		localStorage.setItem('myPlayerId', 'joiner');
+		gameActions.addPlayer('joiner');
+		gameStore.updateState({
+			players: { rival: { id: 'rival', seat: 1, joinTimestamp: 1, tray: {}, metadata: {} } },
+			decks: { 'deck:rival:main': { id: 'deck:rival:main', cards: [] } }
+		} as Partial<GameDTO>);
+
+		stop = startAutoClaim('1', handlers);
+		await vi.advanceTimersByTimeAsync(20000);
+
+		expect(claimed).toEqual([]);
+		expect(failures).toEqual([{ seat: 1, reason: 'seat-taken' }]);
+		// the joiner stays unseated — nothing was claimed or renamed
+		expect(get(gameStore).players?.joiner?.seat).toBe(0);
+		expect(Object.keys(get(gameStore).decks ?? {})).toEqual(['deck:rival:main']);
+	});
+
+	it('reports timed-out when no scenario ever arrives', async () => {
+		localStorage.setItem('myPlayerId', 'joiner');
+		gameActions.addPlayer('joiner');
+
+		stop = startAutoClaim('2', handlers);
+		await vi.advanceTimersByTimeAsync(20000);
+
+		expect(claimed).toEqual([]);
+		expect(failures).toEqual([{ seat: 2, reason: 'timed-out' }]);
+	});
+
+	it('does not fire handlers after being stopped', async () => {
+		seedSeat(0);
+		stop = startAutoClaim('0', handlers);
+		stop();
+		await flush();
+
+		localStorage.setItem('myPlayerId', 'joiner');
+		gameActions.addPlayer('joiner');
+		await vi.advanceTimersByTimeAsync(30000);
+
+		expect(claimed).toEqual([]);
+		expect(failures).toEqual([]);
+	});
+});

--- a/src/lib/scenario/__tests__/claim-seat.test.ts
+++ b/src/lib/scenario/__tests__/claim-seat.test.ts
@@ -1,0 +1,102 @@
+/**
+ * claimSeat is the invite-link handoff: every `kind:seat<N>:slug` id in
+ * decks/cards/pieces must be rewritten to the claimer's id, the placeholder
+ * player removed, and the seat + tray moved onto the claimer. A seat that is
+ * already taken must be a strict no-op.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { gameActions } from '$lib/store/game/actions';
+import { claimSeat, ensureSeatPlaceholder } from '../scenario';
+import type { GameDTO } from '$lib/store/game/types';
+
+const card = {
+	position: [0, 0, 0] as [number, number, number],
+	rotation: [0, 0, 0] as [number, number, number],
+	faceImageUrl: 'face.png'
+};
+
+/** A seeded two-seat table where seat 1 is still the placeholder. */
+function seedTable() {
+	gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {} });
+	ensureSeatPlaceholder(1);
+	gameStore.updateState({
+		players: {
+			seat1: { tray: { 'card:seat1:hand-1': card } }
+		},
+		decks: {
+			'deck:seat1:main': { id: 'deck:seat1:main', cards: [{ id: 'c1', faceImageUrl: 'f.png' }] },
+			'deck:seat1:discard': { id: 'deck:seat1:discard', cards: [] },
+			'deck:host:main': { id: 'deck:host:main', cards: [] }
+		},
+		cards: {
+			'card:seat1:table-1': card,
+			'card:host:table-1': card
+		},
+		pieces: {
+			'piece:seat1:hp-0': { id: 'piece:seat1:hp-0', kind: 'counter', value: 20 }
+		}
+	} as Partial<GameDTO>);
+}
+
+describe('claimSeat', () => {
+	beforeEach(() => {
+		localStorage.clear();
+		seedTable();
+		localStorage.setItem('myPlayerId', 'joiner');
+		gameActions.addPlayer('joiner');
+	});
+
+	it('rewrites the placeholder owner across decks, cards, and pieces', () => {
+		expect(claimSeat(1)).toBe(true);
+
+		const s = get(gameStore);
+		expect(Object.keys(s.decks ?? {}).sort()).toEqual([
+			'deck:host:main',
+			'deck:joiner:discard',
+			'deck:joiner:main'
+		]);
+		expect(Object.keys(s.cards ?? {}).sort()).toEqual(['card:host:table-1', 'card:joiner:table-1']);
+		expect(Object.keys(s.pieces ?? {})).toEqual(['piece:joiner:hp-0']);
+		// deck payloads follow their new id
+		expect(s.decks?.['deck:joiner:main']).toMatchObject({
+			id: 'deck:joiner:main',
+			cards: [{ id: 'c1' }]
+		});
+	});
+
+	it('moves the seat index and tray onto the claimer and removes the placeholder', () => {
+		expect(claimSeat(1)).toBe(true);
+
+		const s = get(gameStore);
+		expect(s.players?.seat1).toBeUndefined();
+		expect(s.players?.joiner?.seat).toBe(1);
+		expect(Object.keys(s.players?.joiner?.tray ?? {})).toEqual(['card:seat1:hand-1']);
+	});
+
+	it('is a no-op when the seat is already taken', () => {
+		expect(claimSeat(1)).toBe(true);
+		const afterFirstClaim = get(gameStore);
+
+		// a second player following the same stale invite
+		localStorage.setItem('myPlayerId', 'latecomer');
+		gameActions.addPlayer('latecomer');
+		const beforeSecondClaim = get(gameStore);
+
+		expect(claimSeat(1)).toBe(false);
+		const s = get(gameStore);
+		expect(s.decks).toEqual(beforeSecondClaim.decks);
+		expect(s.cards).toEqual(beforeSecondClaim.cards);
+		expect(s.pieces).toEqual(beforeSecondClaim.pieces);
+		expect(s.players?.joiner?.seat).toBe(1);
+		expect(s.players?.latecomer?.seat).toBe(0);
+		expect(afterFirstClaim.decks).toEqual(s.decks);
+	});
+
+	it('fails without a local player id', () => {
+		localStorage.removeItem('myPlayerId');
+		expect(claimSeat(1)).toBe(false);
+		expect(get(gameStore).players?.seat1).toBeDefined();
+	});
+});

--- a/src/lib/scenario/__tests__/invite.test.ts
+++ b/src/lib/scenario/__tests__/invite.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { buildInviteUrl, pickInviteSeat } from '../invite';
+
+describe('pickInviteSeat', () => {
+	it('prefers the first open seat that is not mine', () => {
+		expect(pickInviteSeat([0, 1], 0)).toBe(1);
+		expect(pickInviteSeat([0, 1, 2], 1)).toBe(0);
+	});
+
+	it('falls back to any open seat when they are all mine', () => {
+		expect(pickInviteSeat([1], 1)).toBe(1);
+	});
+
+	it('is undefined with no open seats', () => {
+		expect(pickInviteSeat([], 0)).toBeUndefined();
+	});
+});
+
+describe('buildInviteUrl', () => {
+	it('produces an absolute URL carrying server, lobby, and seat', () => {
+		const url = buildInviteUrl({
+			origin: 'https://table.place',
+			server: 'wss://sync.table.place',
+			lobby: 'mossy-glade',
+			seat: 1
+		});
+		expect(url).toBe(
+			'https://table.place/play?server=wss%3A%2F%2Fsync.table.place&lobby=mossy-glade&seat=1'
+		);
+		// chat clients only linkify schemed URLs
+		expect(new URL(url).origin).toBe('https://table.place');
+	});
+
+	it('omits seat when none is open', () => {
+		const url = buildInviteUrl({
+			origin: 'http://localhost:5173',
+			server: 'ws://localhost:8080',
+			lobby: 'dev',
+			seat: undefined
+		});
+		expect(url).toBe('http://localhost:5173/play?server=ws%3A%2F%2Flocalhost%3A8080&lobby=dev');
+		expect(url).not.toContain('seat=');
+	});
+});

--- a/src/lib/scenario/autoClaim.ts
+++ b/src/lib/scenario/autoClaim.ts
@@ -1,0 +1,102 @@
+/**
+ * Auto-claim for `?seat=N` invite links: keep trying to claim the seat's
+ * placeholder until it actually succeeds, and report failure loudly instead
+ * of going quiet.
+ *
+ * The claim can fail transiently — the scenario hasn't synced yet, or my
+ * player id hasn't been created — so every store change (plus a slow poll as
+ * a backstop) retries until `claimSeat` returns true. Only then is the claim
+ * considered done. On timeout the failure handler gets a reason so the UI
+ * can distinguish "someone took your seat" from "no scenario ever arrived".
+ */
+
+import { get } from 'svelte/store';
+import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { gameActions } from '$lib/store/game/actions';
+import type { GameDTO } from '$lib/store/game/types';
+import { claimSeat, isSeatPlaceholder, seatPlaceholderId, type SeatIndex } from './scenario';
+
+export type AutoClaimFailureReason = 'seat-taken' | 'timed-out';
+
+export type AutoClaimHandlers = {
+	onClaimed?: (seat: SeatIndex) => void;
+	onFailed?: (seat: SeatIndex, reason: AutoClaimFailureReason) => void;
+};
+
+const RETRY_POLL_MS = 500;
+
+/** A deck id `deck:<owner>:<slot>` owned by this player marks a claimed seat. */
+function ownsAnyDeck(state: Partial<GameDTO> | undefined, playerId: string): boolean {
+	return Object.keys(state?.decks ?? {}).some((key) => key.split(':')[1] === playerId);
+}
+
+function failureReason(seat: SeatIndex): AutoClaimFailureReason {
+	const s = get(gameStore);
+	const myId = gameActions.getMyId() ?? undefined;
+	// the placeholder is gone but another player sits at that seat with decks
+	// of their own — somebody beat this invite to the seat
+	const takenBy = Object.entries(s?.players ?? {}).some(
+		([id, player]) =>
+			!isSeatPlaceholder(id) && id !== myId && player?.seat === seat && ownsAnyDeck(s, id)
+	);
+	return takenBy ? 'seat-taken' : 'timed-out';
+}
+
+/**
+ * Watch the synced state and claim `seatParam`'s placeholder as soon as that
+ * succeeds. Returns a cleanup function. No-op for missing/invalid params.
+ */
+export function startAutoClaim(
+	seatParam: string | null,
+	handlers: AutoClaimHandlers = {},
+	timeoutMs = 20000
+): () => void {
+	const seat = Number(seatParam) as SeatIndex;
+	if (seatParam === null || ![0, 1, 2, 3].includes(seat)) return () => {};
+
+	let done = false;
+	let scheduled = false;
+
+	// hoisted: every caller runs from a microtask or timer, by which point the
+	// consts below are assigned
+	function cleanup() {
+		done = true;
+		clearTimeout(timer);
+		clearInterval(poll);
+		unsubscribe();
+	}
+
+	function attempt() {
+		scheduled = false;
+		if (done) return;
+		if (!get(gameStore)?.players?.[seatPlaceholderId(seat)]) return; // keep waiting
+		if (!claimSeat(seat)) return; // transient failure (e.g. no player id yet) — retry
+		cleanup();
+		handlers.onClaimed?.(seat);
+	}
+
+	// claim outside the store notification cycle, at most one pending attempt
+	function scheduleAttempt() {
+		if (done || scheduled) return;
+		scheduled = true;
+		queueMicrotask(attempt);
+	}
+
+	// subscribe() invokes the callback synchronously, but that only queues a
+	// microtask — so nothing touches `unsubscribe` before it is assigned
+	const unsubscribe = gameStore.subscribe(scheduleAttempt);
+	// backstop for the placeholder-present-but-claim-failed case when no
+	// further store change arrives to re-trigger the subscription
+	const poll = setInterval(scheduleAttempt, RETRY_POLL_MS);
+
+	const timer = setTimeout(() => {
+		if (done) return;
+		const reason = failureReason(seat);
+		cleanup();
+		handlers.onFailed?.(seat, reason);
+	}, timeoutMs);
+
+	return () => {
+		if (!done) cleanup();
+	};
+}

--- a/src/lib/scenario/invite.ts
+++ b/src/lib/scenario/invite.ts
@@ -1,0 +1,33 @@
+/**
+ * Invite links: a shared URL that drops the joiner into a lobby and (when it
+ * carries `seat=N`) auto-claims that seat's placeholder so its decks become
+ * theirs. Kept free of Svelte imports so URL building is unit-testable.
+ */
+
+import type { SeatIndex } from './scenario';
+
+/**
+ * The seat an invite should target: the first open seat that isn't mine,
+ * falling back to any open seat. Undefined when nothing is open.
+ */
+export function pickInviteSeat(
+	openSeats: SeatIndex[],
+	mySeat: number | undefined
+): SeatIndex | undefined {
+	return openSeats.find((s) => s !== mySeat) ?? openSeats[0];
+}
+
+/**
+ * Absolute lobby URL — chat clients only linkify schemed URLs, so this must
+ * start from `page.url.origin` (`https://…`), never `page.url.host`.
+ */
+export function buildInviteUrl(opts: {
+	origin: string;
+	server: string;
+	lobby: string;
+	seat?: SeatIndex;
+}): string {
+	const params = new URLSearchParams({ server: opts.server, lobby: opts.lobby });
+	if (opts.seat !== undefined) params.set('seat', String(opts.seat));
+	return `${opts.origin}/play?${params.toString()}`;
+}

--- a/src/routes/play/+page.svelte
+++ b/src/routes/play/+page.svelte
@@ -7,8 +7,7 @@
 	import { initWrappers } from '$lib/websocket/storeIntegration';
 	import { initWebsocket } from '$lib/websocket';
 	import { gameActions } from '$lib/store/game/actions';
-	import { gameStore } from '$lib/store/game/gameStore.svelte';
-	import { claimSeat, seatPlaceholderId, type SeatIndex } from '$lib/scenario/scenario';
+	import { startAutoClaim } from '$lib/scenario/autoClaim';
 	import Pane from './Pane.svelte';
 	import { page } from '$app/state';
 	import { replaceState } from '$app/navigation';
@@ -34,23 +33,19 @@
 	initWrappers();
 	let isConnected = $state(false);
 
-	// ?seat=N invite links: once the sync delivers a scenario with that seat's
-	// placeholder still open, claim it automatically for the joining player
+	// ?seat=N invite links: keep trying to claim that seat's placeholder until
+	// it succeeds; a give-up is announced, never silent (see autoClaim.ts)
 	function autoClaimSeat(seatParam: string | null) {
-		const seat = Number(seatParam) as SeatIndex;
-		if (seatParam === null || ![0, 1, 2, 3].includes(seat)) return;
-		let claimed = false;
-		const stop = gameStore.subscribe((s) => {
-			if (claimed || !s?.players?.[seatPlaceholderId(seat)]) return;
-			claimed = true;
-			// claim outside the store notification cycle
-			queueMicrotask(() => {
-				if (claimSeat(seat)) toast(`Seat ${seat} claimed — your decks are ready`);
-				stop();
-			});
+		startAutoClaim(seatParam, {
+			onClaimed: (seat) => toast(`Seat ${seat} claimed — your decks are ready`),
+			onFailed: (seat, reason) =>
+				toast.error(
+					reason === 'seat-taken'
+						? `Seat ${seat} is already taken — click an open seat in the Players list to sit down`
+						: `Couldn't claim seat ${seat} — once the table is seeded, click an open seat in the Players list`,
+					{ duration: 10000 }
+				)
 		});
-		// stop waiting if no scenario ever shows up
-		setTimeout(() => stop(), 20000);
 	}
 
 	onMount(() => {

--- a/src/routes/play/Pane.svelte
+++ b/src/routes/play/Pane.svelte
@@ -25,6 +25,7 @@
 		isSeatPlaceholder,
 		type SeatIndex
 	} from '$lib/scenario/scenario';
+	import { buildInviteUrl, pickInviteSeat } from '$lib/scenario/invite';
 	import { List } from 'svelte-tweakpane-ui';
 	import HUDPieces from '$lib/HUDPieces.svelte';
 	import { page } from '$app/state';
@@ -95,20 +96,22 @@
 		else toast.error(`Seat ${seat} is no longer open`);
 	}
 
-	// invite link that auto-claims the opposing (first open, non-mine) seat on join
-	function copyOpponentInvite() {
-		const mySeat = gameActions.getMySeat();
-		const inviteSeat = openSeats.find((s) => s !== mySeat) ?? openSeats[0];
-		if (inviteSeat === undefined)
-			return toast.error('No open seats — seed a scenario and claim yours first');
-		const params = new URLSearchParams({
+	// invite link that auto-claims the opposing (first open, non-mine) seat on
+	// join; without open seats it degrades to a plain lobby link
+	function copyInvite() {
+		const inviteSeat = pickInviteSeat(openSeats, gameActions.getMySeat());
+		const url = buildInviteUrl({
+			origin: page.url.origin,
 			server: $connectionStore.serverUrl,
 			lobby: lobbyId,
-			seat: String(inviteSeat)
+			seat: inviteSeat
 		});
-		const url = `${page.url.host}/play?${params.toString()}`;
 		navigator.clipboard.writeText(url);
-		toast(`Copied invite — joiner auto-claims seat ${inviteSeat}`);
+		toast(
+			inviteSeat === undefined
+				? `Copied lobby link (no open seats): ${url}`
+				: `Copied invite — joiner auto-claims seat ${inviteSeat}`
+		);
 	}
 </script>
 
@@ -129,26 +132,28 @@
 		<Button
 			title="Share lobby: {lobbyId}"
 			on:click={() => {
+				// copy an invite that seats the joiner; my own navigation must NOT
+				// carry ?seat= or I'd claim the seat meant for the opponent
+				copyInvite();
 				goto(`/play?${lobbyUrl}`, { invalidateAll: true });
-				const hostUrl = page.url.host ?? '';
-				const url = `${hostUrl}/play?${lobbyUrl}`;
-				navigator.clipboard.writeText(url);
-				toast(`Copied to clipboard: ` + url);
 			}}
 		/>
 		<Textarea
 			disabled
-			value={`Enter the server and lobby names. Then click share to copy to clipboard. Then refresh page to join.`}
+			value={`Share copies an invite link — whoever opens it is seated at the first open seat and gets its decks.`}
 		/>
 	</Folder>
 	<Folder title="Scenarios" expanded={false}>
 		<List label="Preset" bind:value={selectedScenario} options={scenarioOptions} />
 		<Button title="Seed lobby with preset" on:click={seedLobby} />
-		<Button title="Refresh preset list" on:click={() => (scenarioNames = listScenarios().map((s) => s.name))} />
+		<Button
+			title="Refresh preset list"
+			on:click={() => (scenarioNames = listScenarios().map((s) => s.name))}
+		/>
 		{#each openSeats as seat (seat)}
 			<Button title="Claim seat {seat}" on:click={() => handleClaimSeat(seat)} />
 		{/each}
-		<Button title="Copy opponent invite" on:click={copyOpponentInvite} />
+		<Button title="Copy opponent invite" on:click={copyInvite} />
 		<Textarea
 			disabled
 			rows={3}

--- a/src/routes/play/PaneDecks.svelte
+++ b/src/routes/play/PaneDecks.svelte
@@ -6,10 +6,15 @@
 	import { importTtsFile } from '$lib/tts/import';
 	import toast from 'svelte-french-toast';
 
-	const playerId = gameActions.getMyId();
-	const myDecks = $derived(
-		Object.keys($gameStore?.decks ?? {}).filter((key) => key.split(':').includes(playerId ?? ''))
-	);
+	// getMyId() reads localStorage, which a first-time visitor only gets during
+	// websocket init — re-read on store changes so decks claimed via an invite
+	// link show up without a refresh
+	const myDecks = $derived.by(() => {
+		const playerId = gameActions.getMyId();
+		return Object.keys($gameStore?.decks ?? {}).filter((key) =>
+			key.split(':').includes(playerId || '')
+		);
+	});
 
 	let fileInput: HTMLInputElement | undefined = $state();
 	let isImporting = $state(false);

--- a/src/routes/play/__tests__/PaneDecks.test.ts
+++ b/src/routes/play/__tests__/PaneDecks.test.ts
@@ -1,0 +1,92 @@
+/**
+ * The visible symptom of the broken invite handoff: a joiner had no Shuffle
+ * button, because PaneDecks only lists decks whose owner segment is their own
+ * id and the seat placeholder still owned them. After claiming the seat the
+ * decks must appear — without a remount — and Shuffle must act on them.
+ *
+ * Drives the real tweakpane controls in jsdom, like HUDPieces.test.ts.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import PaneDecks from '../PaneDecks.svelte';
+import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { gameActions } from '$lib/store/game/actions';
+import { claimSeat, ensureSeatPlaceholder } from '$lib/scenario/scenario';
+import type { GameDTO } from '$lib/store/game/types';
+
+// the draggable Pane observes its own size; jsdom has no ResizeObserver
+class NoopResizeObserver {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+}
+vi.stubGlobal('ResizeObserver', NoopResizeObserver);
+
+/** tweakpane renders asynchronously; let its microtasks flush */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 20));
+
+const button = (container: HTMLElement, label: string) =>
+	[...container.querySelectorAll('button')].find((b) => b.textContent?.includes(label));
+
+const deckOf = (id: string, n: number) => ({
+	id,
+	cards: Array.from({ length: n }, (_, i) => ({ id: `${id}-${i}`, faceImageUrl: 'f.png' }))
+});
+
+/** a seeded table where seat 1's decks still belong to the placeholder */
+function seedSeatOneDecks() {
+	gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {} });
+	ensureSeatPlaceholder(1);
+	gameStore.updateState({
+		decks: { 'deck:seat1:main': deckOf('deck:seat1:main', 8) }
+	} as Partial<GameDTO>);
+}
+
+describe('PaneDecks after an invite seat claim', () => {
+	beforeEach(() => {
+		cleanup();
+		localStorage.clear();
+		seedSeatOneDecks();
+	});
+
+	it('lists no decks while the placeholder still owns them', async () => {
+		localStorage.setItem('myPlayerId', 'joiner');
+		gameActions.addPlayer('joiner');
+		const { container } = render(PaneDecks);
+		await settle();
+		expect(button(container, 'Shuffle')).toBeUndefined();
+	});
+
+	it('shows the seat decks and shuffles them once the seat is claimed', async () => {
+		// a joiner following an invite link mounts the pane before websocket
+		// init has written their player id — the deck list must pick the id up
+		// afterwards rather than latching the empty one from mount
+		const { container } = render(PaneDecks);
+		await settle();
+		expect(button(container, 'Shuffle')).toBeUndefined();
+
+		localStorage.setItem('myPlayerId', 'joiner');
+		gameActions.addPlayer('joiner');
+		expect(claimSeat(1)).toBe(true);
+		// the pane re-derives from the store — no remount, no refresh
+		await settle();
+
+		const shuffle = button(container, 'Shuffle deck:joiner:main');
+		expect(shuffle).toBeDefined();
+
+		const before = get(gameStore).decks?.['deck:joiner:main']?.cards?.map((c) => c.id);
+		expect(before).toHaveLength(8);
+
+		// pin Math.random so the shuffle cannot flake into an identity permutation
+		const random = vi.spyOn(Math, 'random').mockReturnValue(0);
+		await fireEvent.click(shuffle!);
+		random.mockRestore();
+
+		const after = get(gameStore).decks?.['deck:joiner:main']?.cards?.map((c) => c.id);
+		expect(after).toHaveLength(8);
+		// same cards, different order
+		expect(after?.slice().sort()).toEqual(before?.slice().sort());
+		expect(after).not.toEqual(before);
+	});
+});


### PR DESCRIPTION
A shared lobby link dropped the joiner at the table with **no seat and no decks**: the scenario's placeholder kept owning that side, so the joiner had nothing to draw, move, or shuffle — the visible symptom being a missing Shuffle button.

`claimSeat()` already did the id rewrite correctly. Everything *around* it was missing, hidden, or best-effort. This PR fixes the four gaps.

## What changed

**The share link carries the seat, and is a real link.** Both copy paths now go through one builder (`src/lib/scenario/invite.ts`) that produces an absolute URL from `page.url.origin` — the old `page.url.host` produced `localhost:5173/play?…`, which no chat client linkifies and which has no scheme on prod. "Share lobby" targets the first open seat that isn't mine, so the prominent affordance actually invites someone to a seat instead of an empty table. My own navigation deliberately omits `seat=` — otherwise I'd claim the seat I just shared.

**Auto-claim retries until it actually works.** The old `autoClaimSeat` set `claimed = true` before knowing the claim succeeded and called `stop()` unconditionally, so a transient failure (no player id yet, sync race) ended the watch permanently and silently. `startAutoClaim` (`src/lib/scenario/autoClaim.ts`) keeps trying on every store change plus a slow poll backstop, and only finishes when `claimSeat` returns true. On give-up it distinguishes *"someone already took that seat"* from *"the table never arrived"* and points at the manual claim either way — never silence.

**Claiming moved into the player HUD.** Open-seat rows were already rendering that seat's deck line but were inert. They're now buttons: click to sit down and take the decks listed on the row. This is the affordance a joiner who just followed a link can actually find — the old path was behind a collapsed `Scenarios` folder inside a pane titled "Settings". The tweakpane buttons stay as a fallback.

**The Decks pane picks up the claim without a refresh.** It read `getMyId()` once at component init; a first-time visitor mounts the pane *before* websocket init writes that id, so the list latched empty and the decks never appeared. It now re-derives on store changes.

## Acceptance criteria

- [x] Share link is absolute (`http(s)://…`) and contains `seat=` — `buildInviteUrl`, covered in `invite.test.ts`
- [x] Following the link seats the joiner and rewrites every `deck|card|piece:seat<N>:*` id — `auto-claim.test.ts`, `claim-seat.test.ts`
- [x] The joiner's decks appear in the Decks pane and **Shuffle works** — `PaneDecks.test.ts` drives the real tweakpane control; verified failing against the pre-fix pane
- [x] The host sees the handoff without a refresh — `claimSeat` goes through `gameStore.updateState`, which `storeIntegration` wraps to broadcast; both panes derive from `$gameStore`
- [x] Open-seat HUD rows are clickable and claim that seat — `PlayerHud.test.ts`
- [x] Auto-claim failure produces a visible message — both reasons covered in `auto-claim.test.ts`
- [x] Tests: id-rewrite across all three collections, retry-until-success, taken-seat no-op

## Verification

`bun run test` — 141 tests / 20 files pass. `bun run check` — 0 errors (the 8 warnings are the pre-existing `Card.svelte`/`Piece.svelte` ones). `bun run build` succeeds. ESLint on the touched directories sits at its 4 pre-existing baseline errors, none of them mine; `bun run lint` is red on `main` already, so I compared against baseline rather than chasing a clean run.

Rebased onto current `main` after #48 (presence) and #60 (tbps) merged — #48's presence dot and ghost-row guard both compose with the new claimable rows, and the suite is green post-rebase.

Not done here, per the ticket's out-of-scope list: tbps v2 scenario restructuring (#56), remote lobby seeding (#39), websocket rate-limit hardening.

Task: tableplace-58

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbpMq51u6hhA6WeiW6EHYd