### PR TITLE
tableplace-55: /create — pack editor screen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,8 @@ containerized for Railway.
 ## Layout
 
 - `src/routes/` — SvelteKit pages: `/` landing, `/play` (the table +
-  `Pane.svelte`/`PaneDecks.svelte` tweakpane HUD), `/setup` (scenario editor).
+  `Pane.svelte`/`PaneDecks.svelte` tweakpane HUD), `/setup` (scenario editor),
+  `/create` (pack editor — authors `.tbpp.json` packs with live 3D preview).
 - `src/lib/` — Threlte components (`TableScene.svelte`, `Card.svelte`,
   `Deck.svelte`, `Piece.svelte`, `Table.svelte`, `TableCamera.svelte`,
   `HUDTray/`, `HUDPreview/`, `table-overlay/`).
@@ -89,6 +90,20 @@ go build -o tts-server .
   radii, rotations) rather than inline literals.
 - Commits: lowercase conventional prefixes (`feat:`, `fix:`, `chore:`, `docs:`,
   `revert:`) with a short subject, often followed by an em-dash rationale.
+
+## Primitive parity rule
+
+The `/create` pack editor exposing **everything the primitives allow** is an
+invariant. Any PR that expands the primitive vocabulary — a new `PieceKind`,
+a new imported-object kind, a new deck/card field, a new face-ref scheme —
+must, in the same change, also update:
+
+- the `/create` editor (`src/routes/create/`) so the new primitive can be
+  authored, previewed, and exported;
+- the tbpp/tbps types and validators (`src/lib/packs/types.ts`,
+  `src/lib/packs/file.ts`) and the published JSON schemas;
+- the TTS import mapping (`src/lib/tts/parse.ts`, `src/lib/tts/to-pack.ts`)
+  so the TTS analog of the primitive converts into it.
 
 ## Gotchas
 

--- a/src/lib/Deck.svelte
+++ b/src/lib/Deck.svelte
@@ -30,7 +30,9 @@
 	const position: [number, number, number] = $derived(deck.position ?? [0, 0, 0]);
 	const rotation: [number, number, number] = $derived(deck.rotation ?? [0, 0, 0]);
 	const isFaceUp = $derived(deck.isFaceUp ?? false); // true = cards[0] is top, false = cards[cards.length - 1] is top
-	const lastCardImage = $derived(cards?.[0].faceImageUrl ?? '');
+	// the element, not just the array, can be missing: a pack may declare a deck
+	// with no cards (the tbpp schema allows it) and spawn it empty
+	const lastCardImage = $derived(cards?.[0]?.faceImageUrl ?? '');
 	const displayedImage = $derived(
 		resolveCardImage(isFaceUp ? lastCardImage : deckBackImage, $sheetRefCache)
 	);

--- a/src/lib/packs/drafts.ts
+++ b/src/lib/packs/drafts.ts
@@ -1,0 +1,48 @@
+/**
+ * Pack drafts: save in-progress `GamePackDef`s from the /create editor to
+ * localStorage (`packs:v1`, mirroring `scenarios:v1` in scenario.ts).
+ * Drafts are local working copies — sharing happens via .tbpp.json export.
+ */
+
+import type { GamePackDef } from './types';
+
+const STORAGE_KEY = 'packs:v1';
+
+export type PackDraft = {
+	updatedAt: number;
+	pack: GamePackDef;
+};
+
+function readAll(): Record<string, PackDraft> {
+	try {
+		return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}');
+	} catch {
+		return {};
+	}
+}
+
+function writeAll(all: Record<string, PackDraft>) {
+	localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+}
+
+export function listPackDrafts(): PackDraft[] {
+	return Object.values(readAll()).sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+export function getPackDraft(id: string): PackDraft | undefined {
+	return readAll()[id];
+}
+
+export function savePackDraft(pack: GamePackDef): PackDraft {
+	const draft: PackDraft = { updatedAt: Date.now(), pack };
+	const all = readAll();
+	all[pack.id] = draft;
+	writeAll(all);
+	return draft;
+}
+
+export function deletePackDraft(id: string) {
+	const all = readAll();
+	delete all[id];
+	writeAll(all);
+}

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import { Canvas } from '@threlte/core';
+	import { ACESFilmicToneMapping } from 'three';
+	import TableScene from '$lib/TableScene.svelte';
+	import { cameraTransforms } from '$lib/utils/transforms/camera';
+	import { onMount } from 'svelte';
+	import { gameActions } from '$lib/store/game/actions';
+	import { disconnect } from '$lib/websocket/connection';
+	import CreatePane from './CreatePane.svelte';
+
+	function handleKeyDown(event: KeyboardEvent) {
+		if (event.code === 'KeyC') cameraTransforms.resetView();
+	}
+
+	let isReady = $state(false);
+	onMount(() => {
+		// hard-local editor: kill any live socket from a previous /play visit so
+		// authoring a pack never broadcasts into a lobby
+		disconnect();
+		if (!gameActions.getMe()) gameActions.addPlayer();
+		isReady = true;
+	});
+</script>
+
+<svelte:head>
+	<title>pack editor — table.place</title>
+	<meta name="description" content="Author a table.place game pack (.tbpp.json) locally" />
+</svelte:head>
+
+<svelte:window on:keydown={handleKeyDown} />
+
+<CreatePane />
+
+<div class="h-screen w-screen overflow-clip bg-gray-700">
+	<Canvas toneMapping={ACESFilmicToneMapping}>
+		{#if isReady}
+			<TableScene />
+		{/if}
+	</Canvas>
+</div>

--- a/src/routes/create/CreatePane.svelte
+++ b/src/routes/create/CreatePane.svelte
@@ -1,0 +1,486 @@
+<script lang="ts">
+	import {
+		AutoValue,
+		Button,
+		Checkbox,
+		Color,
+		Element,
+		Folder,
+		List,
+		Pane,
+		Point,
+		Text,
+		Textarea
+	} from 'svelte-tweakpane-ui';
+	import { get } from 'svelte/store';
+	import { gameStore } from '$lib/store/game/gameStore.svelte';
+	import { makeSheetRef } from '$lib/packs/resolve.svelte';
+	import { prewarmGameState } from '$lib/packs/prewarm-state';
+	import { spawnPackDeck, spawnPackPiece, spawnPackOverlay } from '$lib/packs/spawn';
+	import { CARD_BACK_DEFAULT } from '$lib/packs/standard52';
+	import { parsePackFile, serializePackFile, packFileName } from '$lib/packs/file';
+	import { listPackDrafts, getPackDraft, savePackDraft, deletePackDraft } from '$lib/packs/drafts';
+	import type { PackPieceKind } from '$lib/packs/types';
+	import { parseSavedObject } from '$lib/tts/parse';
+	import { ttsToPack } from '$lib/tts/to-pack';
+	import { COUNTER_MAX_DEFAULT, PIECE_RADIUS } from '$lib/utils/constants-pieces';
+	import {
+		withEditorDefaults,
+		cleanForExport,
+		PIECE_COLOR_DEFAULT,
+		type EditorPack
+	} from './normalize';
+	import toast from 'svelte-french-toast';
+
+	/** Everything the /create preview spawns is owned by this placeholder id */
+	const PREVIEW_OWNER = 'preview';
+
+	const HELP_TEXT =
+		'A pack is a content library: decks (piles of cards), pieces, and board overlays. ' +
+		'Everything here is local — no lobby is touched, and drafts stay in this browser. ' +
+		'The table previews the pack live as you edit. Export validates against the tbpp ' +
+		'format (docs/packs.md), then /setup spawns the file onto a seat.';
+
+	function emptyPack(): EditorPack {
+		return withEditorDefaults({
+			id: 'my-pack',
+			name: 'My Pack',
+			scope: 'player',
+			decks: [
+				{
+					slot: 'main',
+					name: 'Draw Pile',
+					back: CARD_BACK_DEFAULT,
+					cards: [{ code: 'AS', name: 'Ace of Spades', face: 'gen:std52/AS' }]
+				}
+			]
+		});
+	}
+
+	let pack: EditorPack = $state(emptyPack());
+	/** the draft as a plain (non-proxy) object, cleaned of editing defaults */
+	const exportable = $derived(cleanForExport($state.snapshot(pack) as EditorPack));
+
+	// ——— cursors (indexes into the draft's arrays, clamped as arrays shrink) ———
+	let deckCursor = $state(0);
+	let cardCursor = $state(0);
+	let pieceCursor = $state(0);
+	let overlayCursor = $state(0);
+
+	const deckIndex = $derived(Math.min(deckCursor, Math.max(0, pack.decks.length - 1)));
+	const deck = $derived(pack.decks[deckIndex]);
+	const cardIndex = $derived(Math.min(cardCursor, Math.max(0, (deck?.cards.length ?? 0) - 1)));
+	const card = $derived(deck?.cards[cardIndex]);
+	const pieceIndex = $derived(Math.min(pieceCursor, Math.max(0, pack.pieces.length - 1)));
+	const piece = $derived(pack.pieces[pieceIndex]);
+	const overlayIndex = $derived(Math.min(overlayCursor, Math.max(0, pack.overlays.length - 1)));
+	const overlay = $derived(pack.overlays[overlayIndex]);
+
+	const deckOptions = $derived(
+		pack.decks.length
+			? Object.fromEntries(pack.decks.map((d, i) => [`${i}: ${d.slot}`, i]))
+			: { '(no decks)': 0 }
+	);
+	const cardOptions = $derived(
+		deck?.cards.length
+			? Object.fromEntries(deck.cards.map((c, i) => [`${i}: ${c.code}`, i]))
+			: { '(no cards)': 0 }
+	);
+	const pieceOptions = $derived(
+		pack.pieces.length
+			? Object.fromEntries(pack.pieces.map((p, i) => [`${i}: ${p.kind} ${p.name}`, i]))
+			: { '(no pieces)': 0 }
+	);
+	const overlayOptions = $derived(
+		pack.overlays.length
+			? Object.fromEntries(pack.overlays.map((_, i) => [`overlay ${i}`, i]))
+			: { '(no overlays)': 0 }
+	);
+
+	// ——— structure edits ———
+	function addDeck() {
+		pack.decks.push({
+			slot: `deck-${pack.decks.length}`,
+			name: `Deck ${pack.decks.length + 1}`,
+			back: CARD_BACK_DEFAULT,
+			isFaceUp: false,
+			cards: []
+		});
+		deckCursor = pack.decks.length - 1;
+	}
+
+	function removeDeck() {
+		if (!deck) return;
+		pack.decks.splice(deckIndex, 1);
+		deckCursor = Math.max(0, deckIndex - 1);
+	}
+
+	function addCard() {
+		if (!deck) return toast.error('Add a deck first');
+		deck.cards.push({ code: `card-${deck.cards.length}`, name: '', face: '' });
+		cardCursor = deck.cards.length - 1;
+	}
+
+	function duplicateCard() {
+		if (!deck || !card) return;
+		deck.cards.splice(cardIndex + 1, 0, { ...card, code: `${card.code}-copy` });
+		cardCursor = cardIndex + 1;
+	}
+
+	function removeCard() {
+		if (!deck || !card) return;
+		deck.cards.splice(cardIndex, 1);
+		cardCursor = Math.max(0, cardIndex - 1);
+	}
+
+	const kindOptions: Record<string, PackPieceKind> = {
+		Token: 'token',
+		Pawn: 'pawn',
+		Counter: 'counter'
+	};
+	let newPieceKind: PackPieceKind = $state('token');
+
+	function addPiece() {
+		pack.pieces.push({
+			kind: newPieceKind,
+			name: newPieceKind,
+			color: PIECE_COLOR_DEFAULT,
+			imageUrl: '',
+			radius: PIECE_RADIUS[newPieceKind],
+			maxValue: COUNTER_MAX_DEFAULT,
+			position: [0, 0]
+		});
+		pieceCursor = pack.pieces.length - 1;
+	}
+
+	function removePiece() {
+		if (!piece) return;
+		pack.pieces.splice(pieceIndex, 1);
+		pieceCursor = Math.max(0, pieceIndex - 1);
+	}
+
+	function addOverlay() {
+		pack.overlays.push({ imageUrl: '', ratio: 1, scale: 12 });
+		overlayCursor = pack.overlays.length - 1;
+	}
+
+	function removeOverlay() {
+		if (!overlay) return;
+		pack.overlays.splice(overlayIndex, 1);
+		overlayCursor = Math.max(0, overlayIndex - 1);
+	}
+
+	// ——— face-ref builder: raw url / gen:std52 / sheet:{…} ———
+	type FaceScheme = 'url' | 'gen' | 'sheet';
+	const schemeOptions: Record<string, FaceScheme> = {
+		'Image URL (https:)': 'url',
+		'Generated (gen:std52)': 'gen',
+		'Sprite sheet (sheet:)': 'sheet'
+	};
+	let faceScheme: FaceScheme = $state('url');
+	let faceUrl = $state('');
+	let genCode = $state('AS');
+	let sheetUrl = $state('');
+	let sheetCols = $state(10);
+	let sheetRows = $state(7);
+	let sheetIndex = $state(0);
+
+	const builtFaceRef = $derived.by(() => {
+		if (faceScheme === 'url') return faceUrl.trim();
+		if (faceScheme === 'gen') return `gen:std52/${genCode.trim()}`;
+		if (!sheetUrl.trim()) return '';
+		return makeSheetRef({
+			url: sheetUrl.trim(),
+			cols: Math.max(1, Math.round(sheetCols)),
+			rows: Math.max(1, Math.round(sheetRows)),
+			index: Math.max(0, Math.round(sheetIndex))
+		});
+	});
+
+	function applyFaceToCard() {
+		if (!card) return toast.error('Select a card first');
+		if (!builtFaceRef) return toast.error('Face ref is empty');
+		card.face = builtFaceRef;
+	}
+
+	function applyFaceToBack() {
+		if (!deck) return toast.error('Select a deck first');
+		if (!builtFaceRef) return toast.error('Face ref is empty');
+		deck.back = builtFaceRef;
+	}
+
+	// ——— live preview: respawn the pack under the preview owner on every edit ———
+
+	/**
+	 * Overlays are keyed by pack id, not by owner (claimSeat never renames
+	 * them), so the owner match below can't find them — the ids spawned by the
+	 * last preview are remembered instead. Not $state: only clearPreview reads it.
+	 */
+	let previewOverlayIds: string[] = [];
+
+	function clearPreview() {
+		const s = get(gameStore);
+		const update: Record<string, Record<string, null>> = {
+			cards: {},
+			decks: {},
+			pieces: {},
+			overlays: {}
+		};
+		for (const collection of ['cards', 'decks', 'pieces'] as const) {
+			for (const key of Object.keys(s?.[collection] ?? {})) {
+				if (key.includes(`:${PREVIEW_OWNER}:`)) update[collection][key] = null;
+			}
+		}
+		for (const id of previewOverlayIds) update.overlays[id] = null;
+		previewOverlayIds = [];
+		gameStore.updateState(update as Parameters<typeof gameStore.updateState>[0]);
+	}
+
+	function respawnPreview() {
+		clearPreview();
+		const preview = exportable;
+		// spawned per entity rather than through spawnPack: the preview must show
+		// the deck in AUTHORED order (spawnPack shuffles facedown decks), and an
+		// empty deck mid-authoring has no cards[0] for Deck.svelte to render
+		preview.decks
+			.filter((deck) => deck.cards.length > 0)
+			.forEach((deck, index) =>
+				spawnPackDeck(preview, deck, { ownerId: PREVIEW_OWNER, index, shuffle: false })
+			);
+		preview.pieces?.forEach((_, index) =>
+			spawnPackPiece(preview, index, { ownerId: PREVIEW_OWNER })
+		);
+		preview.overlays?.forEach((_, index) => {
+			spawnPackOverlay(preview, index, { ownerId: PREVIEW_OWNER });
+			previewOverlayIds.push(`overlay:${preview.id}:${index}`);
+		});
+		void prewarmGameState(get(gameStore), () => gameStore.updateStateSilently({}));
+	}
+
+	$effect(() => {
+		JSON.stringify(pack); // subscribe to every field of the draft
+		const timer = setTimeout(respawnPreview, 300);
+		return () => clearTimeout(timer);
+	});
+
+	// ——— drafts (localStorage packs:v1) ———
+	let selectedDraft = $state(listPackDrafts()[0]?.pack.id ?? '');
+	let draftIds = $state(listPackDrafts().map((d) => d.pack.id));
+	const draftOptions = $derived(
+		draftIds.length ? Object.fromEntries(draftIds.map((id) => [id, id])) : { '(none saved)': '' }
+	);
+
+	function refreshDrafts() {
+		draftIds = listPackDrafts().map((d) => d.pack.id);
+	}
+
+	function handleSaveDraft() {
+		if (!pack.id.trim()) return toast.error('Give the pack an id first');
+		savePackDraft(exportable);
+		refreshDrafts();
+		selectedDraft = pack.id;
+		toast(`Saved draft: ${pack.id}`);
+	}
+
+	function handleLoadDraft() {
+		const draft = getPackDraft(selectedDraft);
+		if (!draft) return toast.error('Pick a saved draft first');
+		pack = withEditorDefaults(draft.pack);
+		toast(`Loaded: ${draft.pack.id}`);
+	}
+
+	function handleDeleteDraft() {
+		if (!selectedDraft) return;
+		deletePackDraft(selectedDraft);
+		refreshDrafts();
+		selectedDraft = draftIds[0] ?? '';
+	}
+
+	// ——— import / export ———
+	let ttsFileInput: HTMLInputElement | undefined = $state();
+	let packFileInput: HTMLInputElement | undefined = $state();
+
+	async function handleImportTts(event: Event) {
+		const input = event.target as HTMLInputElement;
+		const file = input.files?.[0];
+		if (!file) return;
+		try {
+			const parsed = parseSavedObject(JSON.parse(await file.text()));
+			const imported = ttsToPack(parsed);
+			pack = withEditorDefaults(imported);
+			const skipped = parsed.skipped.length ? ` (skipped: ${parsed.skipped.join(', ')})` : '';
+			toast(
+				`Imported ${imported.decks.length} deck(s), ${imported.pieces?.length ?? 0} piece(s)${skipped}`,
+				{ duration: 5000 }
+			);
+		} catch (error) {
+			toast.error(`Import failed: ${error instanceof Error ? error.message : 'invalid file'}`);
+		} finally {
+			input.value = '';
+		}
+	}
+
+	async function handleImportPack(event: Event) {
+		const input = event.target as HTMLInputElement;
+		const file = input.files?.[0];
+		if (!file) return;
+		try {
+			const imported = parsePackFile(await file.text());
+			pack = withEditorDefaults(imported);
+			toast(`Loaded pack: ${imported.name}`);
+		} catch (error) {
+			toast.error(`Import failed: ${error instanceof Error ? error.message : 'invalid file'}`);
+		} finally {
+			input.value = '';
+		}
+	}
+
+	function handleExport() {
+		try {
+			const text = serializePackFile(exportable);
+			// validate before download with the same parser importers use, so a
+			// broken pack surfaces here rather than on someone else's table
+			parsePackFile(text);
+			const blob = new Blob([text], { type: 'application/json' });
+			const a = document.createElement('a');
+			a.href = URL.createObjectURL(blob);
+			a.download = packFileName(exportable);
+			a.click();
+			URL.revokeObjectURL(a.href);
+			toast(`Exported ${packFileName(exportable)}`);
+		} catch (error) {
+			toast.error(`Export failed: ${error instanceof Error ? error.message : 'invalid pack'}`);
+		}
+	}
+</script>
+
+<Pane
+	position="draggable"
+	title="Pack Editor (local)"
+	expanded={true}
+	y={0}
+	x={0}
+	width={340}
+	localStoreId="create-pane"
+>
+	<Folder title="Pack" expanded={true}>
+		<Text label="Id" bind:value={pack.id} />
+		<Text label="Name" bind:value={pack.name} />
+		<List
+			label="Scope"
+			bind:value={pack.scope}
+			options={{ 'player (one seat brings it)': 'player', 'table (the shared game)': 'table' }}
+		/>
+	</Folder>
+
+	<Folder title="Decks ({pack.decks.length})" expanded={true}>
+		<List label="Deck" bind:value={deckCursor} options={deckOptions} />
+		<Button title="Add deck" on:click={addDeck} />
+		{#if deck}
+			<Text label="Slot" bind:value={deck.slot} />
+			<Text label="Name" bind:value={deck.name} />
+			<Text label="Back ref" bind:value={deck.back} />
+			<Checkbox label="Face up" bind:value={deck.isFaceUp} />
+			<Button title="Remove deck" on:click={removeDeck} />
+			<Folder title="Cards ({deck.cards.length})" expanded={true}>
+				<List label="Card" bind:value={cardCursor} options={cardOptions} />
+				<Button title="Add card" on:click={addCard} />
+				{#if card}
+					<Text label="Code" bind:value={card.code} />
+					<Text label="Name" bind:value={card.name} />
+					<Text label="Face ref" bind:value={card.face} />
+					<Button title="Duplicate card" on:click={duplicateCard} />
+					<Button title="Remove card" on:click={removeCard} />
+				{/if}
+			</Folder>
+		{/if}
+	</Folder>
+
+	<Folder title="Face ref builder" expanded={false}>
+		<List label="Scheme" bind:value={faceScheme} options={schemeOptions} />
+		{#if faceScheme === 'url'}
+			<Text label="Image URL" bind:value={faceUrl} />
+		{:else if faceScheme === 'gen'}
+			<Text label="Code (AS…KC, back)" bind:value={genCode} />
+		{:else}
+			<Text label="Sheet URL" bind:value={sheetUrl} />
+			<AutoValue label="Columns" bind:value={sheetCols} />
+			<AutoValue label="Rows" bind:value={sheetRows} />
+			<AutoValue label="Cell index" bind:value={sheetIndex} />
+		{/if}
+		<Text label="Result" value={builtFaceRef} disabled />
+		<Button title="Set as card face" on:click={applyFaceToCard} />
+		<Button title="Set as deck back" on:click={applyFaceToBack} />
+	</Folder>
+
+	<Folder title="Pieces ({pack.pieces.length})" expanded={false}>
+		<List label="New kind" bind:value={newPieceKind} options={kindOptions} />
+		<Button title="Add {newPieceKind}" on:click={addPiece} />
+		{#if piece}
+			<List label="Piece" bind:value={pieceCursor} options={pieceOptions} />
+			<Text label="Name" bind:value={piece.name} />
+			<Color label="Color" bind:value={piece.color} />
+			{#if piece.kind === 'token'}
+				<Text label="Image URL" bind:value={piece.imageUrl} />
+			{/if}
+			<AutoValue label="Radius" bind:value={piece.radius} />
+			{#if piece.kind === 'counter'}
+				<AutoValue label="Max value" bind:value={piece.maxValue} />
+			{/if}
+			<Point
+				label="Position"
+				value={{ x: piece.position[0], y: piece.position[1] }}
+				on:change={(e) => {
+					//@ts-expect-error: does exist
+					const x = e.detail.value?.x ?? piece.position[0];
+					//@ts-expect-error: does exist
+					const z = e.detail.value?.y ?? piece.position[1];
+					piece.position = [x, z];
+				}}
+			/>
+			<Button title="Remove piece" on:click={removePiece} />
+		{/if}
+	</Folder>
+
+	<Folder title="Overlays — boards/maps ({pack.overlays.length})" expanded={false}>
+		<Button title="Add overlay" on:click={addOverlay} />
+		{#if overlay}
+			<List label="Overlay" bind:value={overlayCursor} options={overlayOptions} />
+			<Text label="Image URL" bind:value={overlay.imageUrl} />
+			<AutoValue label="Ratio (w/h)" bind:value={overlay.ratio} />
+			<AutoValue label="Scale" bind:value={overlay.scale} />
+			<Button title="Remove overlay" on:click={removeOverlay} />
+		{/if}
+	</Folder>
+
+	<Folder title="Start from an existing file" expanded={false}>
+		<Button title="Import TTS json → pack" on:click={() => ttsFileInput?.click()} />
+		<Button title="Open a pack (.tbpp.json)" on:click={() => packFileInput?.click()} />
+		<Element>
+			<input
+				bind:this={ttsFileInput}
+				type="file"
+				accept=".json,application/json"
+				class="hidden"
+				onchange={handleImportTts}
+			/>
+			<input
+				bind:this={packFileInput}
+				type="file"
+				accept=".json,application/json"
+				class="hidden"
+				onchange={handleImportPack}
+			/>
+		</Element>
+	</Folder>
+
+	<Folder title="Drafts / Export" expanded={true}>
+		<Button title="Save draft" on:click={handleSaveDraft} />
+		<List label="Saved" bind:value={selectedDraft} options={draftOptions} />
+		<Button title="Load selected" on:click={handleLoadDraft} />
+		<Button title="Delete selected" on:click={handleDeleteDraft} />
+		<Button title="Export pack (.tbpp.json)" on:click={handleExport} />
+	</Folder>
+
+	<Textarea disabled rows={5} value={HELP_TEXT} />
+</Pane>

--- a/src/routes/create/__tests__/CreatePane.test.ts
+++ b/src/routes/create/__tests__/CreatePane.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Drives the real tweakpane controls in jsdom rather than calling the editor's
+ * functions directly — that's what proves the pane is wired to the draft and
+ * that the draft reaches the table as a live preview.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import CreatePane from '../CreatePane.svelte';
+import { gameStore } from '$lib/store/game/gameStore.svelte';
+
+// the draggable Pane observes its own size; jsdom has no ResizeObserver
+globalThis.ResizeObserver ??= class {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+} as unknown as typeof ResizeObserver;
+
+/** tweakpane renders asynchronously, and the preview respawn is debounced 300ms */
+const settle = (ms = 20) => new Promise((resolve) => setTimeout(resolve, ms));
+const settlePreview = () => settle(400);
+
+const button = (container: HTMLElement, label: string) =>
+	[...container.querySelectorAll('button')].find((b) => b.textContent?.includes(label));
+
+const labels = (container: HTMLElement) =>
+	[...container.querySelectorAll('.tp-lblv_l')].map((el) => el.textContent);
+
+async function mount() {
+	const { container } = render(CreatePane);
+	await settle();
+	return container;
+}
+
+describe('CreatePane', () => {
+	beforeEach(() => {
+		gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {}, overlays: {} });
+		localStorage.clear();
+	});
+
+	it('mounts with a starter pack and previews it on the table', async () => {
+		await mount();
+		await settlePreview();
+
+		const decks = get(gameStore).decks ?? {};
+		expect(Object.keys(decks)).toEqual(['deck:preview:main']);
+		expect(decks['deck:preview:main'].cards).toHaveLength(1);
+		expect(decks['deck:preview:main'].cards?.[0].faceImageUrl).toBe('gen:std52/AS');
+	});
+
+	it('adding a deck and a card updates the live preview', async () => {
+		const container = await mount();
+		await settlePreview();
+
+		button(container, 'Add deck')!.click();
+		await settle();
+		button(container, 'Add card')!.click();
+		await settlePreview();
+
+		const decks = get(gameStore).decks ?? {};
+		// the new deck becomes the cursor's deck, so the card lands in it
+		expect(Object.keys(decks).sort()).toEqual(['deck:preview:deck-1', 'deck:preview:main']);
+		expect(decks['deck:preview:deck-1'].cards).toHaveLength(1);
+	});
+
+	it('exposes the per-kind piece fields and previews spawned pieces', async () => {
+		const container = await mount();
+
+		// the Pieces folder's kind list is the second select (Scope is the first)
+		const selects = [...container.querySelectorAll('select')];
+		const kindSelect = selects.find((s) =>
+			[...s.options].some((o) => o.textContent?.includes('Counter'))
+		)!;
+		kindSelect.selectedIndex = 2; // Token, Pawn, Counter
+		kindSelect.dispatchEvent(new Event('change', { bubbles: true }));
+		await settle();
+
+		button(container, 'Add counter')!.click();
+		await settlePreview();
+
+		expect(labels(container)).toContain('Max value'); // counter-only control
+		const pieces = Object.values(get(gameStore).pieces ?? {});
+		expect(pieces).toHaveLength(1);
+		expect(pieces[0]).toMatchObject({ kind: 'counter', value: 20, maxValue: 20 });
+	});
+
+	it('saves a draft to packs:v1 and reloads it', async () => {
+		const container = await mount();
+		button(container, 'Save draft')!.click();
+		await settle();
+
+		const stored = JSON.parse(localStorage.getItem('packs:v1') ?? '{}');
+		expect(Object.keys(stored)).toEqual(['my-pack']);
+		expect(stored['my-pack'].pack.decks[0].cards[0].face).toBe('gen:std52/AS');
+
+		button(container, 'Load selected')!.click();
+		await settlePreview();
+		expect(Object.keys(get(gameStore).decks ?? {})).toEqual(['deck:preview:main']);
+	});
+
+	it('does not preview a deck that has no cards yet', async () => {
+		const container = await mount();
+		button(container, 'Add deck')!.click(); // new decks start empty
+		await settlePreview();
+
+		// an empty deck has no cards[0] for Deck.svelte to render
+		expect(Object.keys(get(gameStore).decks ?? {})).toEqual(['deck:preview:main']);
+	});
+
+	it('previews only under the preview owner, leaving other entities alone', async () => {
+		gameStore.set({
+			players: {},
+			decks: { 'deck:seat0:main': { id: 'deck:seat0:main', cards: [] } },
+			cards: {},
+			pieces: {}
+		});
+		const container = await mount();
+		button(container, 'Add deck')!.click();
+		await settlePreview();
+
+		expect(get(gameStore).decks?.['deck:seat0:main']).toBeTruthy();
+	});
+});

--- a/src/routes/create/__tests__/roundtrip.test.ts
+++ b/src/routes/create/__tests__/roundtrip.test.ts
@@ -1,0 +1,239 @@
+/**
+ * The /create acceptance path: import a real TTS fixture, edit it with every
+ * implemented primitive (all piece kinds, overlays, all three face-ref
+ * schemes), export it as tbpp, and load the export back through the same
+ * validator + spawnPack that /setup uses. The exported file is checked
+ * against the published pack.schema.json, not just the runtime parser.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { get } from 'svelte/store';
+import Ajv from 'ajv';
+import { parseSavedObject } from '$lib/tts/parse';
+import { ttsToPack } from '$lib/tts/to-pack';
+import { parsePackFile, serializePackFile } from '$lib/packs/file';
+import { spawnPack, spawnPackDeck } from '$lib/packs/spawn';
+import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { makeSheetRef } from '$lib/packs/resolve.svelte';
+import type { GamePackDef } from '$lib/packs/types';
+import { withEditorDefaults, cleanForExport, type EditorPack } from '../normalize';
+
+const cloneFixture = JSON.parse(
+	readFileSync(join(__dirname, '../../../../tts-clonetroopers.json'), 'utf-8')
+);
+
+const validatePack = new Ajv().compile(
+	JSON.parse(readFileSync(join(__dirname, '../../../../static/pack.schema.json'), 'utf-8'))
+);
+
+/** Mirrors the /create workflow: TTS import → edits in the pane → export text */
+function importEditExport(): { draft: EditorPack; exported: string } {
+	// import: the same pipeline the pane runs on a picked TTS file
+	const draft = withEditorDefaults(ttsToPack(parseSavedObject(cloneFixture)));
+
+	// edit: touch metadata and cards, then author every primitive the pane offers
+	draft.name = 'Clone Troopers (edited)';
+	draft.decks[0].cards[0].name = 'Renamed Card';
+	draft.decks[0].cards.push({ code: 'AS', name: 'Ace of Spades', face: 'gen:std52/AS' });
+	draft.pieces.push(
+		{
+			kind: 'token',
+			name: 'Objective',
+			color: '#c8c4b8',
+			imageUrl: 'https://example.com/token.png',
+			radius: 0.75,
+			maxValue: 20,
+			position: [1, 1]
+		},
+		{
+			kind: 'pawn',
+			name: 'Runner',
+			color: '#3366ff',
+			imageUrl: '',
+			radius: 0.3,
+			maxValue: 20,
+			position: [2, -1]
+		},
+		{
+			kind: 'counter',
+			name: 'HP',
+			color: '#b3202e',
+			imageUrl: '',
+			radius: 0.6,
+			maxValue: 12,
+			position: [3, 0]
+		}
+	);
+	draft.overlays.push({ imageUrl: 'https://example.com/map.png', ratio: 1.5, scale: 12 });
+
+	return { draft, exported: serializePackFile(cleanForExport(draft)) };
+}
+
+describe('/create round-trip (tts-clonetroopers.json)', () => {
+	it('imports, edits, exports valid tbpp, and parses back identically', () => {
+		const { draft, exported } = importEditExport();
+		const reparsed = parsePackFile(exported);
+
+		expect(reparsed).toEqual(cleanForExport(draft));
+		expect(reparsed.source).toBe('tts');
+		expect(reparsed.decks[0].cards.length).toBeGreaterThan(1); // fixture content survived
+	});
+
+	it('exports a file the published pack.schema.json accepts', () => {
+		const file = JSON.parse(importEditExport().exported);
+		const ok = validatePack(file);
+		expect(validatePack.errors ?? []).toEqual([]);
+		expect(ok).toBe(true);
+
+		// the schema has teeth: a malformed piece is caught
+		expect(validatePack({ ...file, pieces: [{ kind: 'dice', name: 'd6' }] })).toBe(false);
+	});
+
+	it('covers every implemented piece kind, overlays, and all three face-ref schemes', () => {
+		const pack = parsePackFile(importEditExport().exported);
+
+		expect(new Set(pack.pieces?.map((p) => p.kind))).toEqual(new Set(['token', 'pawn', 'counter']));
+		expect(pack.overlays?.length).toBe(1);
+
+		const faces = pack.decks.flatMap((d) => [d.back, ...d.cards.map((c) => c.face)]);
+		expect(faces.some((f) => f.startsWith('sheet:'))).toBe(true);
+		expect(faces.some((f) => f.startsWith('gen:'))).toBe(true);
+		expect(pack.pieces?.some((p) => p.imageUrl?.startsWith('https:'))).toBe(true);
+	});
+
+	it('strips editing defaults instead of shipping them', () => {
+		const pack = parsePackFile(importEditExport().exported);
+		const pawn = pack.pieces?.find((p) => p.name === 'Runner');
+		expect(pawn?.kind).toBe('pawn');
+		expect(pawn?.imageUrl).toBeUndefined(); // empty image URL never ships
+		expect(pawn?.maxValue).toBeUndefined(); // maxValue is counters-only
+		expect(pack.pieces?.find((p) => p.name === 'HP')?.maxValue).toBe(12);
+	});
+
+	it('does not corrupt an untouched import', () => {
+		const imported = ttsToPack(parseSavedObject(cloneFixture));
+		const roundTripped = parsePackFile(
+			serializePackFile(cleanForExport(withEditorDefaults(imported)))
+		);
+		// decks, cards, and face refs come back byte-identical; pieces may gain
+		// explicit editor defaults (color/radius) but never lose authored data
+		expect(roundTripped.decks).toEqual(imported.decks);
+		expect(roundTripped.pieces?.length).toBe(imported.pieces?.length);
+		for (const [i, piece] of (imported.pieces ?? []).entries()) {
+			expect(roundTripped.pieces?.[i]).toMatchObject(piece);
+		}
+	});
+});
+
+describe('spawnPack — the /setup load path for an exported pack', () => {
+	beforeEach(() => {
+		gameStore.set({ players: { seat0: { id: 'seat0', seat: 0, tray: {} } } } as never);
+		localStorage.setItem('myPlayerId', 'seat0');
+	});
+
+	it('spawns decks, pieces, and overlays', () => {
+		const pack = parsePackFile(importEditExport().exported);
+		spawnPack(pack, { ownerId: 'seat0' });
+
+		const s = get(gameStore);
+		const deckIds = Object.keys(s.decks ?? {});
+		expect(deckIds.length).toBe(pack.decks.length);
+		const spawnedCards = deckIds.flatMap((id) => s.decks?.[id]?.cards ?? []);
+		expect(spawnedCards.length).toBe(pack.decks.reduce((n, d) => n + d.cards.length, 0));
+		// every deck carries the provenance stamp that lets a scenario re-resolve it
+		expect(s.decks?.[deckIds[0]]?.packOrigin).toMatchObject({ pack: pack.id });
+
+		const pieces = Object.values(s.pieces ?? {});
+		expect(pieces.length).toBe(pack.pieces?.length);
+		expect(pieces.find((p) => p?.name === 'HP')?.value).toBe(12); // counters spawn full
+
+		expect(Object.values(s.overlays ?? {}).length).toBe(pack.overlays?.length);
+	});
+
+	it('passes every face-ref scheme through to spawned cards untouched', () => {
+		const pack: GamePackDef = {
+			id: 'schemes',
+			name: 'Schemes',
+			scope: 'player',
+			decks: [
+				{
+					slot: 'main',
+					name: 'Main',
+					back: 'gen:std52/back',
+					cards: [
+						{ code: 'a', face: 'https://example.com/a.png' },
+						{ code: 'b', face: 'gen:std52/2H' },
+						{
+							code: 'c',
+							face: makeSheetRef({
+								url: 'https://example.com/s.png',
+								cols: 2,
+								rows: 2,
+								index: 3
+							})
+						}
+					]
+				}
+			]
+		};
+		// the editor previews through spawnPackDeck with shuffle off, which is the
+		// only way to get authored order — spawnPack shuffles facedown decks
+		spawnPackDeck(pack, pack.decks[0], { ownerId: 'seat0', shuffle: false });
+		const cards = get(gameStore).decks?.['deck:seat0:main']?.cards ?? [];
+		expect(cards.map((c) => c.faceImageUrl)).toEqual(pack.decks[0].cards.map((c) => c.face));
+	});
+
+	it('shuffles a facedown deck but keeps every card', () => {
+		const pack: GamePackDef = {
+			id: 'shuffled',
+			name: 'Shuffled',
+			scope: 'player',
+			decks: [
+				{
+					slot: 'main',
+					name: 'Main',
+					back: 'gen:std52/back',
+					cards: Array.from({ length: 20 }, (_, i) => ({
+						code: `c${i}`,
+						face: `gen:std52/${i}S`
+					}))
+				}
+			]
+		};
+		spawnPack(pack, { ownerId: 'seat0' });
+		const cards = get(gameStore).decks?.['deck:seat0:main']?.cards ?? [];
+		expect(new Set(cards.map((c) => c.faceImageUrl))).toEqual(
+			new Set(pack.decks[0].cards.map((c) => c.face))
+		);
+	});
+
+	it('places decks relative to the owner seat, without a local player', () => {
+		// no myPlayerId and no player entry: the scenario/pack editors spawn for
+		// placeholder seats that no real player occupies
+		gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {} } as never);
+		localStorage.removeItem('myPlayerId');
+
+		const deck = (slot: string) => ({
+			slot,
+			name: slot,
+			back: 'gen:std52/back',
+			cards: [{ code: 'a', face: 'gen:std52/AS' }]
+		});
+		const pack: GamePackDef = {
+			id: 'seats',
+			name: 'Seats',
+			scope: 'player',
+			decks: [deck('main'), deck('discard')]
+		};
+
+		spawnPack(pack, { ownerId: 'seat1' });
+		const decks = get(gameStore).decks ?? {};
+		expect(decks['deck:seat1:main']?.position).toEqual([8.5, 0.4, -4.7]); // far seat
+		expect(decks['deck:seat1:discard']?.position).toEqual([11, 0.4, -4.7]); // fanned sideways
+		expect(decks['deck:seat1:main']?.rotation?.[1]).toBeCloseTo(Math.PI);
+
+		spawnPack(pack, { ownerId: 'seat0' });
+		expect(get(gameStore).decks?.['deck:seat0:main']?.position).toEqual([8.5, 0.4, 4.5]);
+	});
+});

--- a/src/routes/create/normalize.ts
+++ b/src/routes/create/normalize.ts
@@ -1,0 +1,97 @@
+/**
+ * The /create editor binds tweakpane controls directly to a `GamePackDef`
+ * draft, so every optional field needs a concrete value while editing —
+ * and empty editing defaults must not leak into exported files (the tbpp
+ * validator rejects empty strings). These two functions are that boundary.
+ */
+
+import type {
+	GamePackDef,
+	PackCardDef,
+	PackDeckDef,
+	PackOverlayDef,
+	PackPieceDef
+} from '$lib/packs/types';
+import { PIECE_RADIUS, COUNTER_MAX_DEFAULT } from '$lib/utils/constants-pieces';
+
+export const PIECE_COLOR_DEFAULT = '#c8c4b8';
+
+/** A `GamePackDef` with every pane-bound optional field made concrete */
+export type EditorCard = PackCardDef & { name: string };
+export type EditorDeck = Omit<PackDeckDef, 'cards' | 'isFaceUp'> & {
+	isFaceUp: boolean;
+	cards: EditorCard[];
+};
+export type EditorPiece = PackPieceDef & {
+	color: string;
+	imageUrl: string;
+	radius: number;
+	maxValue: number;
+};
+export type EditorPack = Omit<GamePackDef, 'decks' | 'pieces' | 'overlays'> & {
+	decks: EditorDeck[];
+	pieces: EditorPiece[];
+	overlays: PackOverlayDef[];
+};
+
+/** Deep-clone a pack and fill every optional field the editor binds to. */
+export function withEditorDefaults(pack: GamePackDef): EditorPack {
+	return {
+		...pack,
+		decks: pack.decks.map((deck) => ({
+			...deck,
+			isFaceUp: deck.isFaceUp ?? false,
+			cards: deck.cards.map((card) => ({ ...card, name: card.name ?? '' }))
+		})),
+		pieces: (pack.pieces ?? []).map((piece) => ({
+			...piece,
+			color: piece.color ?? PIECE_COLOR_DEFAULT,
+			imageUrl: piece.imageUrl ?? '',
+			radius: piece.radius ?? PIECE_RADIUS[piece.kind],
+			maxValue: piece.maxValue ?? COUNTER_MAX_DEFAULT,
+			position: [...piece.position] as [number, number]
+		})),
+		overlays: (pack.overlays ?? []).map((overlay) => ({ ...overlay }))
+	};
+}
+
+/**
+ * Deep-clone a draft, dropping empty editing defaults so the exported file
+ * only carries what the creator actually set (`maxValue` is meaningful on
+ * counters only, an unset image URL must not ship as `""`). Kept dumb on
+ * purpose — real validation is parsePackFile's job.
+ */
+export function cleanForExport(draft: GamePackDef): GamePackDef {
+	const pieces = (draft.pieces ?? []).map((piece) => ({
+		kind: piece.kind,
+		name: piece.name,
+		...(piece.color ? { color: piece.color } : {}),
+		...(piece.imageUrl ? { imageUrl: piece.imageUrl } : {}),
+		...(piece.radius !== undefined ? { radius: piece.radius } : {}),
+		...(piece.kind === 'counter' && piece.maxValue !== undefined
+			? { maxValue: piece.maxValue }
+			: {}),
+		position: [...piece.position] as [number, number]
+	}));
+	const overlays = (draft.overlays ?? []).map((overlay) => ({ ...overlay }));
+
+	return {
+		id: draft.id,
+		name: draft.name,
+		scope: draft.scope,
+		decks: draft.decks.map((deck) => ({
+			slot: deck.slot,
+			name: deck.name,
+			back: deck.back,
+			...(deck.isFaceUp ? { isFaceUp: true } : {}),
+			cards: deck.cards.map((card) => ({
+				code: card.code,
+				...(card.name ? { name: card.name } : {}),
+				face: card.face
+			}))
+		})),
+		...(pieces.length > 0 ? { pieces } : {}),
+		...(overlays.length > 0 ? { overlays } : {}),
+		...(draft.source ? { source: draft.source } : {})
+	};
+}

--- a/src/routes/setup/SetupPane.svelte
+++ b/src/routes/setup/SetupPane.svelte
@@ -18,7 +18,7 @@
 	import { gameActions } from '$lib/store/game/actions';
 	import { cameraTransforms } from '$lib/utils/transforms/camera';
 	import { importTtsFile } from '$lib/tts/import';
-	import { spawnPack, STANDARD_52 } from '$lib/packs';
+	import { parsePackFile, spawnPack, STANDARD_52 } from '$lib/packs';
 	import {
 		saveScenario,
 		listScenarios,
@@ -33,6 +33,7 @@
 		type SeatIndex
 	} from '$lib/scenario/scenario';
 	import HUDPieces from '$lib/HUDPieces.svelte';
+	import { prewarmGameState } from '$lib/packs/prewarm-state';
 	import { purgeUndefinedValues } from '$lib/utils/transforms/data';
 	import { DEG2RAD } from 'three/src/math/MathUtils.js';
 	import type { GameDTO } from '$lib/store/game/types';
@@ -42,6 +43,7 @@
 	const seatOptions = { 'Seat 0 (near)': 0, 'Seat 1 (far)': 1, 'Seat 2': 2, 'Seat 3': 3 };
 
 	let deckFileInput: HTMLInputElement | undefined = $state();
+	let packFileInput: HTMLInputElement | undefined = $state();
 	let scenarioFileInput: HTMLInputElement | undefined = $state();
 	let isImporting = $state(false);
 
@@ -76,6 +78,23 @@
 			toast.error(`Import failed: ${error instanceof Error ? error.message : 'invalid file'}`);
 		} finally {
 			isImporting = false;
+			input.value = '';
+		}
+	}
+
+	async function handleImportPack(event: Event) {
+		const input = event.target as HTMLInputElement;
+		const file = input.files?.[0];
+		if (!file) return;
+		try {
+			const pack = parsePackFile(await file.text());
+			ensureSeatPlaceholder(activeSeat);
+			spawnPack(pack, { ownerId: seatPlaceholderId(activeSeat) });
+			void prewarmGameState($gameStore ?? undefined, () => gameStore.updateStateSilently({}));
+			toast(`Seat ${activeSeat}: spawned pack "${pack.name}"`, { duration: 5000 });
+		} catch (error) {
+			toast.error(`Import failed: ${error instanceof Error ? error.message : 'invalid file'}`);
+		} finally {
 			input.value = '';
 		}
 	}
@@ -217,6 +236,10 @@
 			disabled={isImporting}
 			on:click={() => deckFileInput?.click()}
 		/>
+		<Button
+			title="Import pack (.tbpp.json) for seat {activeSeat}"
+			on:click={() => packFileInput?.click()}
+		/>
 		<Button title="View table from seat {activeSeat}" on:click={viewFromSeat} />
 		<Element>
 			<input
@@ -225,6 +248,13 @@
 				accept=".json,application/json"
 				class="hidden"
 				onchange={handleImportDeck}
+			/>
+			<input
+				bind:this={packFileInput}
+				type="file"
+				accept=".json,application/json"
+				class="hidden"
+				onchange={handleImportPack}
 			/>
 		</Element>
 	</Folder>
@@ -305,6 +335,6 @@
 	<Textarea
 		disabled
 		rows={4}
-		value={`Everything here is local — no lobby is touched. Spawn or import a deck per seat, place the map, arrange, then Save. Pack decks save as a pack reference plus their card order, so a stacked deck reloads exactly; tick "shuffle on load" for a draw pile. Seed a lobby from /play → Settings → Scenarios. Note: cards in YOUR hand tray are not saved; keep starting cards on the table.`}
+		value={`Everything here is local — no lobby is touched. Spawn or import a deck per seat (a TTS save, or a pack authored in /create), place the map, arrange, then Save. Pack decks save as a pack reference plus their card order, so a stacked deck reloads exactly; tick "shuffle on load" for a draw pile. Seed a lobby from /play → Settings → Scenarios. Note: cards in YOUR hand tray are not saved; keep starting cards on the table.`}
 	/>
 </Pane>


### PR DESCRIPTION
Task: tableplace-55
Closes #55

A local-only pack editor at `/create` (same posture as `/setup`: `disconnect()`, no lobby) that can author every implemented pack primitive and export a validated `.tbpp.json`. Built on the tbpp format from #54 and rebased onto the spawn API from #56.

## What it authors

- **Pack metadata** — id, name, scope (`table` / `player`, labelled in the UI the way docs/packs.md describes them).
- **Decks** — slot, name, back ref, isFaceUp, and cards (code, name, face) with add / duplicate / remove.
- **Face refs, all three schemes** — a builder for raw `https:` URLs, `gen:std52/<code>`, and `sheet:{url,cols,rows,index}` (via `makeSheetRef`), applied to either a card face or the deck back.
- **Pieces** — every implemented `PieceKind` with its per-kind fields: token image URL, color, radius, counter max value, and table position.
- **Overlays** — imageUrl, ratio, scale.

## Workflow

- **Start from an existing file** — TTS json through `ttsToPack`, or an existing `.tbpp.json` through `parsePackFile`.
- **Live 3D preview** — the draft respawns onto the table (300ms debounce) under a `preview` owner, using the existing renderers.
- **Drafts** — saved to localStorage `packs:v1`, mirroring `scenarios:v1`.
- **Export** — the file is run back through `parsePackFile` before download, so a broken pack surfaces in the editor rather than on someone else's table.

## Rebase onto #56

This PR originally carried its own `SpawnPackOptions`/`ownerId` extension to `src/lib/packs/spawn.ts`. #56 landed the same idea as a superset, so **that duplicate is deleted — `spawn.ts` is now byte-identical to main** and the preview routes through `spawnPackDeck` / `spawnPackPiece` / `spawnPackOverlay`, stamping `packOrigin` like every other spawn path.

Two behaviours the preview needs, expressed in #56's vocabulary rather than a bespoke flag:

- **Authored order.** `spawnPack` shuffles facedown decks, so the preview calls `spawnPackDeck` per deck with `shuffle: false`. (My removed `noShuffle` had no equivalent and was not re-added.)
- **Overlay cleanup.** #56 keys overlays `overlay:<packId>:<index>`, not by owner, so the owner-match sweep can't find them. The ids from the last preview are tracked and nulled explicitly.

`/setup`'s new "Import pack (.tbpp.json)" button sits alongside #56's "Spawn Standard 52" — merged, not duplicated.

### Card-order semantics did shift

Worth flagging rather than papering over. Under #56, `spawnPackDeck` builds card ids as `card:<owner>:<slot>-<code>` with no positional suffix, where this branch previously appended the array index. Two cards sharing a `code` inside one deck now collide into a single entity instead of both spawning. Nothing in the tbpp schema enforces unique codes, so a hand-written pack can trip this. I dropped my id-uniqueness assertion rather than adjust it to pass, and left the behaviour as main defines it — flagging it as a possible follow-up for #56's owner.

Deck fan direction also changed (`8.5 + index * 2.5`, previously `8.5 - index * 2.5`); the seat-placement test now asserts main's values.

## Drive-by bug fix

`Deck.svelte` read `cards?.[0].faceImageUrl` — the optional chain guards the array but not the element, so a deck spawned with an empty card list threw a TypeError. The tbpp schema puts no `minItems` on `cards`, making an empty deck a *valid* pack file, and the `/setup` pack import above makes it reachable. Fixed to `cards?.[0]?.faceImageUrl`. The editor also skips empty decks when previewing, since a pile with no cards shouldn't render at all mid-authoring.

## Verification

- `bun run test` — **202 passed / 24 files**. The round-trip suite imports the real `tts-clonetroopers.json` fixture, edits it with every primitive, exports, and re-parses; the exported file is validated against the published `static/pack.schema.json` (with a negative case proving the validator has teeth). `CreatePane.test.ts` drives the actual tweakpane controls in jsdom and asserts the draft reaches the table.
- `bun run build` — clean.
- `bun run check` — 0 new errors. One pre-existing error remains (`schemas.test.ts` `allowUnionTypes`, landed with #54: the hoisted `ajv` is v6 while package.json declares ^8, so TS picks v6's `Options` type).
- `bun run lint` — red at baseline on main; no new prettier or eslint findings in the files this PR touches.
- Browser check was attempted but the Chrome extension wasn't connected; `/create` was confirmed to render server-side (200) and the component test covers the client behaviour.

Out of scope per the ticket: dice/chips/standees (SPEC §2 kinds not yet implemented) and publishing/hosting packs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQfZig9kdZ3guJHC5ngJUT