### PR TITLE
tableplace-70: ungroup a deck, Alt-drop without snapping, fan a hovered pile

### DIFF
--- a/docs/research/deck-manipulation-primitives.md
+++ b/docs/research/deck-manipulation-primitives.md
@@ -42,10 +42,12 @@ UI surface; L = needs new interaction infra (selection, menus).
 | # | Primitive | TTS analog | Effort | Notes |
 |---|-----------|-----------|--------|-------|
 | A1 | **Group loose stack → deck** (hotkey `G` on hovered card) | `G` group | **S/M** | Everything needed exists: reuse the `resolveStackHeight` radius scan for membership, order by Y, `addDeck` at base-card XZ, delete loose card entities. Instantly gives piles draw-1 / count / return-to-top semantics for free. |
-| A2 | **Square-up on stack drop** — snap XZ to stack base | auto-align | **S** | Pure change in the drop commit; makes stacks read as intentional piles instead of drift. Optional small random jitter for feel. |
+| A2 | **Square-up on stack drop** — snap XZ to stack base | auto-align | **S** | Pure change in the drop commit; makes stacks read as intentional piles instead of drift. Optional small random jitter for feel. Holding `Alt` at release opts out (raw pointer XZ, rests on the felt), so cards can still be laid out deliberately next to each other. |
 | A3 | **Grab whole pile** (modifier-drag or long-press on a stack/deck) | RMB-drag / container drag | **M** | For decks: drag threshold on pointerdown — move = drag deck, click = draw (today drawing is the only possible outcome). |
 | A4 | **Split / take N** (drag off top with count, or cut at midpoint) | number+drag, Cut | **M** | Depends on A1 (needs real pile objects to split). |
 | A5 | **Re-settle stack Ys** when a mid-card is removed | gravity | **S** | Run the stack scan on pickup, not just drop. |
+| A6 | **Ungroup deck → loose stack** (hotkey `Shift+G` on a hovered deck) | unpack container | **S** | *Shipped.* The inverse of A1 and the only way back out of a `G` short of drawing one card at a time. `DeckDTO.cards` is already the full ordered list, so it's one patch: delete the deck, write the cards. `orderForDeck` is its own inverse, so the ordering convention survives the round trip. Own decks only (matches shuffle), and capped at `UNGROUP_MAX_CARDS` (40) so a 200-card deck can't carpet the felt. |
+| A7 | **Hover-fan a loose pile** (cascade members on hover) | — | **S** | *Shipped.* Membership comes from the same `collectStackGroup` scan `G` uses, so the fan is an honest preview of what `G` will swallow — and it's what tells a squared-up loose pile apart from a `DeckDTO` slab. Render-time only: a local hover never patches `GameDTO`. Anchored on the visual top card so fanning can't slide the pile out from under the cursor. |
 
 ### B. Deck verbs
 

--- a/src/lib/Card.svelte
+++ b/src/lib/Card.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { T } from '@threlte/core';
 	import * as THREE from 'three';
-	import { dragStart, dragStore } from './store/dragStore.svelte';
+	import { clearHover, dragStart, dragStore, setHover } from './store/dragStore.svelte';
 	import { Spring } from 'svelte/motion';
 	import { ImageMaterial } from '@threlte/extras';
 	import type { IntersectionEvent } from '@threlte/extras';
@@ -18,6 +18,7 @@
 		CARD_DRAG_Y,
 		cardBodyGeometry
 	} from '$lib/utils/constants-cards';
+	import { fanOffset } from '$lib/utils/transforms/stacking';
 	import { resolveCardImage, sheetRefCache } from '$lib/packs';
 	type Vec3Array = [number, number, number];
 
@@ -91,10 +92,29 @@
 		{ stiffness: 0.15, damping: 0.8, precision: 0.0001 }
 	);
 
+	// Hover fan: while the pointer is on any member of a multi-card loose pile,
+	// every member cascades up-screen from the top card so its title band
+	// shows — the membership preview for `G`, and what tells a loose pile
+	// apart from a deck. Purely a render offset: the store keeps the squared-up
+	// rest positions, so nothing here touches shared state.
+	const fanIndex = $derived($dragStore.hoveredStack?.indexOf(id) ?? -1);
+	const fanShift = $derived(
+		fanIndex < 0
+			? ([0, 0] as [number, number])
+			: fanOffset(
+					fanIndex,
+					$dragStore.hoveredStack?.length ?? 0,
+					// ?? 0: a yaw of undefined would land the card at NaN and fling it
+					// off the table — a fan is never worth that
+					degrees[gameActions.getMySeat()] ?? 0
+				)
+	);
+
 	$effect(() => {
 		const [x = 0, , z = 0] = cardState?.position ?? [];
+		const [fanX, fanZ] = fanShift;
 		if (isDragging) planar.set({ x, z }, { instant: true });
-		else planar.target = { x, z };
+		else planar.target = { x: x + fanX, z: z + fanZ };
 	});
 
 	// Create derived values for each component
@@ -163,12 +183,14 @@
 	function handlePointerEnter() {
 		if (!!$dragStore.isDragging) return;
 		isHovered = true;
-		$dragStore.isHovered = id;
+		// via the store action, not a direct write: it also collects the loose
+		// stack this card belongs to, which is what fans
+		setHover(id);
 	}
 
 	function handlePointerLeave() {
 		isHovered = false;
-		$dragStore.isHovered = null;
+		clearHover(id);
 	}
 </script>
 

--- a/src/lib/Table.svelte
+++ b/src/lib/Table.svelte
@@ -6,6 +6,8 @@
 	import { gameStore } from './store/game/gameStore.svelte';
 	import OverlayCustom from './table-overlay/OverlayCustom.svelte';
 	import { commitActiveDrag } from './drop/commit';
+	import { setNoSnap } from './store/dragStore.svelte';
+	import type { IntersectionEvent } from '@threlte/extras';
 	import { TABLE_TOP_Y } from './utils/constants-table';
 
 	let { mesh = $bindable() }: { mesh?: THREE.Mesh } = $props();
@@ -13,7 +15,13 @@
 	// The drop lives in drop/commit.ts — shared with the window-level release
 	// fallback, and resolved by the same pure function the DropIndicator
 	// previews with, so what the player saw while dragging is what lands.
-	const handleDragEnd = commitActiveDrag;
+	// Alt state is taken off the release itself, so a modifier let go in the
+	// same instant as the button can't leave the commit disagreeing with the
+	// preview.
+	function handleDragEnd(event: IntersectionEvent<PointerEvent>) {
+		setNoSnap(event.nativeEvent.altKey);
+		commitActiveDrag();
+	}
 
 	// Create procedural felt texture. Built synchronously: this component only
 	// mounts client-side (inside <Canvas>, behind isConnected), so the material

--- a/src/lib/TableScene.svelte
+++ b/src/lib/TableScene.svelte
@@ -12,7 +12,7 @@
 	import Hdr from './HDR.svelte';
 	import HudPreviewScene from './HUDPreview/HUDPreviewScene.svelte';
 	import RemoteCameraAvatar from './RemoteCameraAvatar.svelte';
-	import { dragStore } from '$lib/store/dragStore.svelte';
+	import { dragStore, setNoSnap } from '$lib/store/dragStore.svelte';
 	import { gameStore } from './store/game/gameStore.svelte';
 	import { gameActions } from './store/game/actions';
 	import { remoteCameraActions, remoteCameraStore } from './store/remoteCameraStore.svelte';
@@ -80,18 +80,33 @@
 	//   state. Bubble phase, so an on-table release has already committed and
 	//   this no-ops.
 	// - Esc: return the card to where it was picked up.
+	// - Alt: the no-snap modifier. Tracked from the events rather than a
+	//   keydown latch so the preview follows a press/release mid-drag, and
+	//   read off the pointer event at release so the commit agrees with what
+	//   the indicator was drawing. Blur clears it — alt-tabbing away never
+	//   delivers the keyup.
 	onMount(() => {
-		const onPointerUp = () => commitActiveDrag();
+		const onPointerUp = (event: PointerEvent) => {
+			setNoSnap(event.altKey);
+			commitActiveDrag();
+		};
 		const onKeyDown = (event: KeyboardEvent) => {
 			if (event.key === 'Escape') cancelActiveDrag();
+			setNoSnap(event.altKey);
 		};
+		const onKeyUp = (event: KeyboardEvent) => setNoSnap(event.altKey);
+		const onBlur = () => setNoSnap(false);
 		window.addEventListener('pointerup', onPointerUp);
 		window.addEventListener('pointercancel', onPointerUp);
 		window.addEventListener('keydown', onKeyDown);
+		window.addEventListener('keyup', onKeyUp);
+		window.addEventListener('blur', onBlur);
 		return () => {
 			window.removeEventListener('pointerup', onPointerUp);
 			window.removeEventListener('pointercancel', onPointerUp);
 			window.removeEventListener('keydown', onKeyDown);
+			window.removeEventListener('keyup', onKeyUp);
+			window.removeEventListener('blur', onBlur);
 		};
 	});
 

--- a/src/lib/drop/DropIndicator.svelte
+++ b/src/lib/drop/DropIndicator.svelte
@@ -25,10 +25,14 @@
 	const dragId = $derived($dragStore.isDragging);
 
 	const drop = $derived(
-		resolveDrop($gameStore, dragId, $dragStore.intersectionPoint, {
-			deckId: $dragStore.isDeckHovered,
-			tray: $dragStore.isTrayHovered
-		})
+		resolveDrop(
+			$gameStore,
+			dragId,
+			$dragStore.intersectionPoint,
+			{ deckId: $dragStore.isDeckHovered, tray: $dragStore.isTrayHovered },
+			// live: pressing or releasing Alt mid-drag redraws the preview
+			{ noSnap: $dragStore.noSnap }
+		)
 	);
 
 	// the deck / tray highlights are the cue for those targets — a table

--- a/src/lib/drop/commit.ts
+++ b/src/lib/drop/commit.ts
@@ -14,15 +14,26 @@ import { resolveDrop } from '$lib/utils/transforms/drop';
  * cleared `isDragging` by the time it fires and it no-ops.
  */
 export function commitActiveDrag() {
-	const { isDragging: id, intersectionPoint, isDeckHovered, isTrayHovered } = get(dragStore);
+	const {
+		isDragging: id,
+		intersectionPoint,
+		isDeckHovered,
+		isTrayHovered,
+		noSnap
+	} = get(dragStore);
 	if (!id) return;
 
 	// resolved by the same pure function the DropIndicator previews with, so
-	// what the player saw while dragging is what gets committed
-	const drop = resolveDrop(get(gameStore), id, intersectionPoint, {
-		deckId: isDeckHovered,
-		tray: isTrayHovered
-	});
+	// what the player saw while dragging is what gets committed — including
+	// whether Alt was down (noSnap), which the release writes into the store
+	// from the pointer event before calling in
+	const drop = resolveDrop(
+		get(gameStore),
+		id,
+		intersectionPoint,
+		{ deckId: isDeckHovered, tray: isTrayHovered },
+		{ noSnap }
+	);
 
 	if (drop?.kind === 'tray') {
 		gameActions.moveCardToTray(id, gameActions?.getMe()?.id as string);

--- a/src/lib/hotkeys/ungroup.ts
+++ b/src/lib/hotkeys/ungroup.ts
@@ -1,0 +1,33 @@
+import toast from 'svelte-french-toast';
+import { gameActions } from '$lib/store/game/actions';
+import { UNGROUP_MAX_CARDS } from '$lib/store/game/actions/deck';
+
+/**
+ * `Shift+G` on a hovered deck: spread it back into loose cards.
+ *
+ * Shared by /play and /setup so the refusal wording — the only place the
+ * card cap is visible while playing — is written once.
+ */
+export function ungroupHoveredDeck() {
+	const result = gameActions.ungroupDeck();
+	if (result.ok) return result;
+
+	switch (result.reason) {
+		// nothing under the pointer: Shift+G was aimed at a card, not a deck.
+		// Silent — a toast on every stray keypress is noise.
+		case 'no-deck':
+			break;
+		case 'not-mine':
+			toast.error("That deck isn't yours to spread");
+			break;
+		case 'empty':
+			toast.error('That deck is empty');
+			break;
+		case 'too-many':
+			toast.error(
+				`${result.count} cards is too many to spread — Shift+G is capped at ${UNGROUP_MAX_CARDS}`
+			);
+			break;
+	}
+	return result;
+}

--- a/src/lib/store/__tests__/group-stack.test.ts
+++ b/src/lib/store/__tests__/group-stack.test.ts
@@ -3,6 +3,7 @@ import { get } from 'svelte/store';
 import { gameStore } from '../game/gameStore.svelte';
 import { gameActions } from '../game/actions';
 import { dragStore } from '../dragStore.svelte';
+import { UNGROUP_MAX_CARDS } from '../game/actions/deck';
 import { CARD_REST_Y, CARD_THICKNESS } from '$lib/utils/constants-cards';
 
 const ME = 'seat0';
@@ -96,5 +97,141 @@ describe('groupStackIntoDeck', () => {
 		gameStore.updateState({ decks: { [first]: { id: first, cards: [] } } });
 		const second = gameActions.groupStackIntoDeck('top') as string;
 		expect(second).not.toBe(first);
+	});
+});
+
+describe('ungroupDeck', () => {
+	beforeEach(() => {
+		localStorage.setItem('myPlayerId', ME);
+		dragStore.set({
+			isDragging: null,
+			isHovered: null,
+			isDeckHovered: null,
+			isTrayHovered: false
+		});
+		pile();
+	});
+
+	/** ids of the spread-out pile, bottom → top by resting height */
+	function looseBottomToTop() {
+		return Object.entries(get(gameStore).cards ?? {})
+			.filter(([id]) => id !== 'elsewhere') // the card across the table, never part of the pile
+			.sort(([, a], [, b]) => (a?.position?.[1] ?? 0) - (b?.position?.[1] ?? 0))
+			.map(([id]) => id);
+	}
+
+	it('spreads the hovered deck back into loose cards at its XZ', () => {
+		const deckId = gameActions.groupStackIntoDeck('top') as string;
+		dragStore.update((s) => ({ ...s, isDeckHovered: deckId }));
+
+		const result = gameActions.ungroupDeck();
+		const state = get(gameStore);
+
+		expect(result).toMatchObject({ ok: true, deckId });
+		// deck gone and cards back in ONE patch — never both at once
+		expect(state.decks?.[deckId]).toBeUndefined();
+		expect(looseBottomToTop()).toEqual(['bottom', 'middle', 'top']);
+		// stacked at the deck's XZ, one thickness apart, bottom card on the felt
+		expect(state.cards?.bottom?.position).toEqual([0, CARD_REST_Y, 0]);
+		expect(state.cards?.middle?.position).toEqual([0, CARD_REST_Y + CARD_THICKNESS, 0]);
+		expect(state.cards?.top?.position).toEqual([0, CARD_REST_Y + 2 * CARD_THICKNESS, 0]);
+	});
+
+	it('round-trips losslessly: G → Shift+G → G gives the same deck', () => {
+		const firstId = gameActions.groupStackIntoDeck('top') as string;
+		const first = structuredClone(get(gameStore).decks?.[firstId]);
+
+		expect(gameActions.ungroupDeck(firstId).ok).toBe(true);
+		const secondId = gameActions.groupStackIntoDeck('top') as string;
+		const second = get(gameStore).decks?.[secondId];
+
+		expect(second?.cards).toEqual(first?.cards);
+		expect(second?.isFaceUp).toBe(first?.isFaceUp);
+		expect(second?.position).toEqual(first?.position);
+		expect(second?.rotation).toEqual(first?.rotation);
+	});
+
+	it('round-trips a face-up pile too, keeping the top card drawable first', () => {
+		pile(true);
+		const firstId = gameActions.groupStackIntoDeck('top') as string;
+		const first = structuredClone(get(gameStore).decks?.[firstId]);
+		expect(first?.isFaceUp).toBe(true);
+
+		gameActions.ungroupDeck(firstId);
+		// face-up deck spreads to face-up cards
+		expect(get(gameStore).cards?.top?.rotation?.[0]).toBe(0);
+		expect(looseBottomToTop()).toEqual(['bottom', 'middle', 'top']);
+
+		const secondId = gameActions.groupStackIntoDeck('top') as string;
+		const second = get(gameStore).decks?.[secondId];
+		expect(second?.cards).toEqual(first?.cards);
+		expect(gameActions.drawFromTop(secondId)?.id).toBe('top');
+	});
+
+	it('spreads a facedown deck to facedown cards', () => {
+		const deckId = gameActions.groupStackIntoDeck('top') as string;
+		gameActions.ungroupDeck(deckId);
+		expect(get(gameStore).cards?.top?.rotation?.[0]).toBe(180);
+	});
+
+	it('allocates a fresh id when the deck card id is already on the table', () => {
+		const deckId = gameActions.groupStackIntoDeck('top') as string;
+		// a card with the same id turns up on the table (drawn copy, re-spawned pack)
+		gameStore.updateState({ cards: { top: card(5, CARD_REST_Y, 5) } });
+
+		const result = gameActions.ungroupDeck(deckId);
+		expect(result.ok).toBe(true);
+		expect(result.ok && result.cardIds).toContain('top-2');
+		// the pre-existing card is left where it was
+		expect(get(gameStore).cards?.top?.position).toEqual([5, CARD_REST_Y, 5]);
+	});
+
+	it('refuses a deck that is not mine', () => {
+		const deckId = gameActions.groupStackIntoDeck('top') as string;
+		const deck = get(gameStore).decks?.[deckId];
+		gameStore.updateState({
+			decks: { [deckId]: null, 'deck:someone-else:0': { ...deck, id: 'deck:someone-else:0' } }
+		});
+		expect(gameActions.ungroupDeck('deck:someone-else:0')).toEqual({
+			ok: false,
+			reason: 'not-mine'
+		});
+	});
+
+	it('refuses an empty deck instead of deleting it', () => {
+		const deckId = gameActions.addDeck({ cards: [] } as never) as string;
+		expect(gameActions.ungroupDeck(deckId)).toEqual({ ok: false, reason: 'empty' });
+		expect(get(gameStore).decks?.[deckId]).toBeDefined();
+	});
+
+	it('refuses to carpet the table above the card cap', () => {
+		const cards = Array.from({ length: UNGROUP_MAX_CARDS + 1 }, (_, i) => ({
+			id: `bulk-${i}`,
+			faceImageUrl: 'f.png'
+		}));
+		const deckId = gameActions.addDeck({ cards } as never) as string;
+		expect(gameActions.ungroupDeck(deckId)).toEqual({
+			ok: false,
+			reason: 'too-many',
+			count: UNGROUP_MAX_CARDS + 1
+		});
+		expect(get(gameStore).decks?.[deckId]?.cards).toHaveLength(UNGROUP_MAX_CARDS + 1);
+	});
+
+	it('does nothing when no deck is hovered', () => {
+		expect(gameActions.ungroupDeck()).toEqual({ ok: false, reason: 'no-deck' });
+	});
+
+	it('keeps the tap angle across a round trip', () => {
+		gameStore.updateState({
+			cards: {
+				bottom: { rotation: [180, 0, 90] },
+				middle: { rotation: [180, 0, 90] },
+				top: { rotation: [180, 0, 90] }
+			}
+		});
+		const deckId = gameActions.groupStackIntoDeck('top') as string;
+		gameActions.ungroupDeck(deckId);
+		expect(get(gameStore).cards?.top?.rotation).toEqual([180, 0, 90]);
 	});
 });

--- a/src/lib/store/__tests__/hover-fan.test.ts
+++ b/src/lib/store/__tests__/hover-fan.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Hover fan membership: hovering a card in a loose pile has to hand the
+ * renderer the whole pile — the same set `G` would swallow — so the fan
+ * preview can never disagree with the action it previews.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import { gameStore } from '../game/gameStore.svelte';
+import { dragStore, dragActions, setHover, clearHover } from '../dragStore.svelte';
+import { CARD_REST_Y, CARD_THICKNESS } from '$lib/utils/constants-cards';
+
+const card = (x: number, y: number, z: number) => ({
+	position: [x, y, z] as [number, number, number],
+	rotation: [180, 0, 0] as [number, number, number],
+	faceImageUrl: 'face.png'
+});
+
+describe('hover fan', () => {
+	beforeEach(() => {
+		dragActions.reset();
+		gameStore.set({
+			cards: {
+				bottom: card(0, CARD_REST_Y, 0),
+				middle: card(0.1, CARD_REST_Y + CARD_THICKNESS, 0.1),
+				top: card(0.2, CARD_REST_Y + 2 * CARD_THICKNESS, 0.2),
+				elsewhere: card(9, CARD_REST_Y, 9)
+			}
+		});
+	});
+
+	it('collects the whole pile, bottom → top, from any member', () => {
+		setHover('top');
+		expect(get(dragStore).hoveredStack).toEqual(['bottom', 'middle', 'top']);
+		setHover('bottom');
+		expect(get(dragStore).hoveredStack).toEqual(['bottom', 'middle', 'top']);
+	});
+
+	it('leaves a lone card unfanned', () => {
+		setHover('elsewhere');
+		expect(get(dragStore).isHovered).toBe('elsewhere');
+		expect(get(dragStore).hoveredStack).toBeNull();
+	});
+
+	it('stays suppressed while dragging', () => {
+		dragActions.start('elsewhere', 2);
+		setHover('top');
+		expect(get(dragStore).hoveredStack).toBeNull();
+		expect(get(dragStore).isHovered).toBe('elsewhere');
+	});
+
+	it('drops the fan when the pointer leaves', () => {
+		setHover('top');
+		clearHover('top');
+		expect(get(dragStore).isHovered).toBeNull();
+		expect(get(dragStore).hoveredStack).toBeNull();
+	});
+
+	it('ignores a stale leave from a card the pointer has already left', () => {
+		// fanning moves cards, so leave(top) can arrive after enter(middle)
+		setHover('top');
+		setHover('middle');
+		clearHover('top');
+		expect(get(dragStore).isHovered).toBe('middle');
+		expect(get(dragStore).hoveredStack).toEqual(['bottom', 'middle', 'top']);
+	});
+
+	it('never writes anything into the shared game state', () => {
+		const before = structuredClone(get(gameStore));
+		setHover('top');
+		clearHover('top');
+		expect(get(gameStore)).toEqual(before);
+	});
+});

--- a/src/lib/store/dragStore.svelte.ts
+++ b/src/lib/store/dragStore.svelte.ts
@@ -1,5 +1,7 @@
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import type { Vector3 } from 'three';
+import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { collectStackGroup } from '$lib/utils/transforms/stacking';
 
 interface DragState {
 	isDragging: string | null;
@@ -9,6 +11,20 @@ interface DragState {
 	isPreview?: boolean;
 	dragHeight?: number;
 	intersectionPoint?: Vector3;
+	/**
+	 * Members of the loose stack under the pointer, bottom → top — the set
+	 * `G` would swallow — so the whole pile can fan on hover instead of only
+	 * the top card glowing. Null for a lone card and while dragging.
+	 *
+	 * Render-only: nothing here is ever patched into `GameDTO`.
+	 */
+	hoveredStack?: string[] | null;
+	/**
+	 * Alt held: the pending drop opts out of the loose-stack square-up and
+	 * commits at the raw pointer point. Read by both the drop indicator and
+	 * the commit, so preview and landing can't disagree.
+	 */
+	noSnap?: boolean;
 	/**
 	 * Where the dragged entity sat before it was picked up, so Esc can put it
 	 * back. Only set for entities that were already on the table — a card
@@ -25,7 +41,9 @@ const initialState: DragState = {
 	isPreview: false,
 	dragHeight: undefined,
 	intersectionPoint: undefined,
-	origin: undefined
+	origin: undefined,
+	hoveredStack: null,
+	noSnap: false
 };
 
 const dragStore = writable<DragState>(initialState);
@@ -37,7 +55,9 @@ function dragStart(id: string, height: number, origin?: [number, number, number]
 		isDragging: id,
 		isHovered: id,
 		dragHeight: height,
-		origin
+		origin,
+		// the pile you just picked a card out of is no longer a pile to preview
+		hoveredStack: null
 	}));
 }
 
@@ -59,13 +79,38 @@ function dragEnd() {
 	dragStore.update((state) => ({ ...state, isDragging: null, origin: undefined }));
 }
 
-// Set hover state
+// Set hover state, and with it the loose stack the hovered card belongs to —
+// membership comes from `collectStackGroup`, the same set `G` groups, so the
+// fan preview can never disagree with the action.
 function setHover(id: string | null) {
-	dragStore.update((state) => ({
-		...state,
-		// Don't update hover if we're dragging
-		isHovered: state.isDragging ? state.isHovered : id
-	}));
+	dragStore.update((state) => {
+		if (state.isDragging) return state; // hover is frozen mid-drag
+		const group = id ? collectStackGroup(get(gameStore)?.cards, id) : null;
+		return {
+			...state,
+			isHovered: id,
+			// a lone card is a valid group but has nothing to fan
+			hoveredStack: group && group.ids.length > 1 ? group.ids : null
+		};
+	});
+}
+
+/**
+ * Drop the hover when the pointer leaves `id`.
+ *
+ * Guarded on the id: fanning moves cards, so a leave can arrive after the
+ * pointer has already entered the next member of the same pile, and an
+ * unguarded clear would drop that fresh hover on the floor.
+ */
+function clearHover(id: string) {
+	dragStore.update((state) =>
+		state.isHovered === id ? { ...state, isHovered: null, hoveredStack: null } : state
+	);
+}
+
+/** Alt held — see `DragState.noSnap`. Cheap enough to write on every keypress. */
+function setNoSnap(noSnap: boolean) {
+	dragStore.update((state) => (state.noSnap === noSnap ? state : { ...state, noSnap }));
 }
 
 function setTrayHover(isTrayHovered: boolean) {
@@ -88,6 +133,7 @@ const dragActions = {
 	start: dragStart,
 	end: dragEnd,
 	hover: setHover,
+	clearHover,
 	trayHover: setTrayHover,
 	updateIntersection,
 	reset: () => dragStore.set(initialState)
@@ -99,6 +145,8 @@ export {
 	dragStart,
 	dragEnd,
 	setHover,
+	clearHover,
+	setNoSnap,
 	setDeckHover,
 	setTrayHover,
 	updateIntersection,

--- a/src/lib/store/game/actions/deck.ts
+++ b/src/lib/store/game/actions/deck.ts
@@ -4,16 +4,14 @@ import { gameStore } from '../gameStore.svelte';
 import { get } from 'svelte/store';
 import { dragStore } from '$lib/store/dragStore.svelte';
 import { collectStackGroup, orderForDeck } from '$lib/utils/transforms/stacking';
-import { deckHeightForCount } from '$lib/utils/constants-cards';
+import { CARD_REST_Y, CARD_THICKNESS, deckHeightForCount } from '$lib/utils/constants-cards';
 import { TABLE_TOP_Y } from '$lib/utils/constants-table';
 import type { GameDTO } from '../types';
 
 function getMyDecks() {
 	const myPlayerId = gameActions.getMe()?.id;
 	const decks = get(gameStore)?.decks ?? {};
-	return Object.entries(decks).filter(([key]) =>
-		key.startsWith(`deck:${myPlayerId}:`)
-	);
+	return Object.entries(decks).filter(([key]) => key.startsWith(`deck:${myPlayerId}:`));
 }
 
 type DeckProps = GameDTO['decks']['string'] & {
@@ -56,12 +54,8 @@ function buildDeck(props: DeckProps) {
 			id: deckId,
 			isFaceUp: props.isFaceUp ?? false,
 			deckBackImageUrl: props.deckBackImageUrl,
-			position:
-				props?.position ??
-				(positions[seat % positions.length] as [number, number, number]),
-			rotation:
-				props.rotation ??
-				(rotations[seat % rotations.length] as [number, number, number]),
+			position: props?.position ?? (positions[seat % positions.length] as [number, number, number]),
+			rotation: props.rotation ?? (rotations[seat % rotations.length] as [number, number, number]),
 			cards: props.cards
 		}
 	};
@@ -130,6 +124,87 @@ function groupStackIntoDeck(cardId?: string) {
 }
 
 /**
+ * Cards a single `Shift+G` will spread. A 200-card deck ungrouped would
+ * carpet the felt with cards nobody asked for and no cheap way back, so past
+ * this the ungroup refuses and says so (see `hotkeys/ungroup.ts`).
+ */
+export const UNGROUP_MAX_CARDS = 40;
+
+export type UngroupResult =
+	| { ok: true; deckId: string; cardIds: string[] }
+	| { ok: false; reason: 'no-deck' | 'not-mine' | 'empty' | 'too-many'; count?: number };
+
+/**
+ * Reuse the card's own id when nothing on the table holds it — a deck built
+ * by `G` still carries the ids its loose cards had, so a round trip lands the
+ * same entities — and fall back to a suffixed id when it's taken (the same
+ * pack slot spawned twice, or a copy already drawn out).
+ */
+function allocateCardId(preferred: string, fallback: string, taken: Set<string>) {
+	const base = preferred || fallback;
+	if (!taken.has(base)) return base;
+	let n = 2;
+	while (taken.has(`${base}-${n}`)) n++;
+	return `${base}-${n}`;
+}
+
+/**
+ * Spread a deck back into loose cards (hotkey `Shift+G` on a hovered deck) —
+ * the exact inverse of `groupStackIntoDeck`.
+ *
+ * The cards land at the deck's XZ, one `CARD_THICKNESS` apart in Y with the
+ * deck's top card on top, and the deck is deleted in the SAME patch as the
+ * cards are created, so remote clients never see both at once. Ownership
+ * matches shuffle: only your own decks.
+ */
+function ungroupDeck(deckId?: string): UngroupResult {
+	const id = deckId ?? get(dragStore).isDeckHovered;
+	if (!id) return { ok: false, reason: 'no-deck' };
+
+	const deck = get(gameStore)?.decks?.[id];
+	if (!deck) return { ok: false, reason: 'no-deck' };
+	if (!getMyDecks().some(([key]) => key === id)) return { ok: false, reason: 'not-mine' };
+
+	const deckCards = deck.cards ?? [];
+	if (deckCards.length === 0) return { ok: false, reason: 'empty' };
+	if (deckCards.length > UNGROUP_MAX_CARDS)
+		return { ok: false, reason: 'too-many', count: deckCards.length };
+
+	const isFaceUp = deck.isFaceUp ?? false;
+	// orderForDeck is its own inverse: fed the deck's array it hands back the
+	// bottom→top order the loose stack had before `G` swallowed it
+	const bottomToTop = orderForDeck(deckCards, isFaceUp);
+
+	const [x = 0, , z = 0] = deck.position ?? [];
+	// deck rotation is radians of yaw on the group; card rotation is degrees
+	// with z as the yaw Card.svelte applies as -z. Rounded so repeated
+	// group/ungroup round trips can't drift the tap angle.
+	const yaw = Math.round((-(deck.rotation?.[1] ?? 0) / DEG2RAD) * 1e6) / 1e6;
+
+	const taken = new Set(Object.keys(get(gameStore)?.cards ?? {}));
+	const cards: Record<string, GameDTO['cards'][string]> = {};
+	const cardIds: string[] = [];
+
+	bottomToTop.forEach((card, index) => {
+		const cardId = allocateCardId(card.id, `${id}:card-${index}`, taken);
+		taken.add(cardId);
+		cardIds.push(cardId);
+		cards[cardId] = {
+			faceImageUrl: card.faceImageUrl ?? '',
+			...(card.backImageUrl || deck.deckBackImageUrl
+				? { backImageUrl: card.backImageUrl ?? (deck.deckBackImageUrl as string) }
+				: {}),
+			position: [x, CARD_REST_Y + index * CARD_THICKNESS, z],
+			// a face-up deck spreads to face-up cards; 180 on x is facedown
+			rotation: [isFaceUp ? 0 : 180, 0, yaw]
+		};
+	});
+
+	gameStore.updateState({ decks: { [id]: null }, cards });
+	return { ok: true, deckId: id, cardIds };
+}
+
+/**
  * Draws from the top of the deck
  * Follows LIFO (Last In First Out)
  * When facedown (like a deck of cards), the top card = cards.length - 1
@@ -139,8 +214,7 @@ function groupStackIntoDeck(cardId?: string) {
  * */
 function drawFromTop(id: string) {
 	const { cards, isFaceUp } = get(gameStore)?.decks?.[id] ?? {};
-	if (!cards || cards.length === 0)
-		return console.error('Cannot draw from an empty deck');
+	if (!cards || cards.length === 0) return console.error('Cannot draw from an empty deck');
 
 	const card = isFaceUp ? cards.shift() : cards.pop();
 	gameStore.updateState({
@@ -193,8 +267,7 @@ export function shuffleDeck(deckId: string) {
 	const cards = deck?.cards;
 	if (!cards || cards.length === 0) return console.error('No cards to shuffle');
 	const shuffledCards = shuffleCards(cards);
-	if (!shuffledCards || shuffledCards.length === 0)
-		return console.log('Error shuffling');
+	if (!shuffledCards || shuffledCards.length === 0) return console.log('Error shuffling');
 	return gameStore.updateState({
 		decks: { [deckId]: { cards: shuffledCards } }
 	});
@@ -203,6 +276,7 @@ export function shuffleDeck(deckId: string) {
 export const deckActions = {
 	addDeck,
 	groupStackIntoDeck,
+	ungroupDeck,
 	drawFromTop,
 	getDeckLength,
 	getMyDecks,

--- a/src/lib/utils/constants-cards.ts
+++ b/src/lib/utils/constants-cards.ts
@@ -105,3 +105,10 @@ export const CARD_STACK_RADIUS = 1.7;
  * when resolving where a dropped card should rest.
  */
 export const CARD_STACK_MAX_Y = 1.0;
+
+/**
+ * Per-card cascade of a hovered loose pile (render-only, see `fanOffset`).
+ * Roughly a fifth of the card's 2-unit length: enough of the top edge to read
+ * the title band, without throwing a big pile across the felt.
+ */
+export const CARD_FAN_STEP = 0.42;

--- a/src/lib/utils/transforms/__tests__/drop.test.ts
+++ b/src/lib/utils/transforms/__tests__/drop.test.ts
@@ -144,4 +144,44 @@ describe('resolveDrop', () => {
 	it('is unfazed by an empty state', () => {
 		expect(resolveDrop(undefined, 'a', { x: 0, z: 0 })).toBeNull();
 	});
+
+	describe('noSnap (Alt held at release)', () => {
+		const overlapping = () =>
+			state({ cards: { a: card(0, 2, 0), resting: card(0.2, CARD_REST_Y, 0.2) } });
+
+		it('commits at the raw point instead of squaring up to the pile', () => {
+			const drop = resolveDrop(overlapping(), 'a', { x: 0.5, z: 0.4 }, {}, { noSnap: true });
+			expect(drop).toMatchObject({ kind: 'table', position: [0.5, CARD_REST_Y, 0.4] });
+		});
+
+		it('rests on the felt rather than on top of the card it overlaps', () => {
+			const snapped = resolveDrop(overlapping(), 'a', { x: 0.5, z: 0.4 });
+			expect(snapped?.kind).toBe('stack');
+			expect(snapped?.position[1]).toBe(CARD_REST_Y + CARD_THICKNESS);
+			expect(
+				resolveDrop(overlapping(), 'a', { x: 0.5, z: 0.4 }, {}, { noSnap: true })?.position[1]
+			).toBe(CARD_REST_Y);
+		});
+
+		it('still clamps to the felt', () => {
+			const drop = resolveDrop(overlapping(), 'a', { x: 999, z: 0 }, {}, { noSnap: true });
+			expect(drop?.position[0]).toBe(TABLE_HALF_X - EDGE_MARGIN);
+		});
+
+		it('leaves the aimed-at targets alone: deck and tray still win', () => {
+			const s = state({ cards: { a: card(0, 2, 0) }, decks: { 'deck:1': { cards: [] } } });
+			expect(resolveDrop(s, 'a', { x: 0, z: 0 }, { tray: true }, { noSnap: true })?.kind).toBe(
+				'tray'
+			);
+			expect(
+				resolveDrop(s, 'a', { x: 0, z: 0 }, { deckId: 'deck:1' }, { noSnap: true })?.kind
+			).toBe('deck');
+		});
+
+		it('changes nothing when the modifier is not held', () => {
+			expect(resolveDrop(overlapping(), 'a', { x: 0.5, z: 0.4 }, {}, { noSnap: false })).toEqual(
+				resolveDrop(overlapping(), 'a', { x: 0.5, z: 0.4 })
+			);
+		});
+	});
 });

--- a/src/lib/utils/transforms/__tests__/stacking.test.ts
+++ b/src/lib/utils/transforms/__tests__/stacking.test.ts
@@ -1,11 +1,19 @@
 import { describe, it, expect } from 'vitest';
-import { collectStackGroup, orderForDeck, resolveStack, resolveStackHeight } from '../stacking';
+import {
+	collectStackGroup,
+	fanOffset,
+	orderForDeck,
+	resolveStack,
+	resolveStackHeight
+} from '../stacking';
 import {
 	CARD_REST_Y,
 	CARD_THICKNESS,
 	CARD_STACK_RADIUS,
-	CARD_STACK_MAX_Y
+	CARD_STACK_MAX_Y,
+	CARD_FAN_STEP
 } from '$lib/utils/constants-cards';
+import { degrees } from '$lib/utils/constants-rotation';
 
 const card = (x: number, y: number, z: number) => ({
 	position: [x, y, z] as [number, number, number]
@@ -154,5 +162,37 @@ describe('orderForDeck', () => {
 		const ids = ['a', 'b'];
 		orderForDeck(ids, true);
 		expect(ids).toEqual(['a', 'b']);
+	});
+
+	it('is its own inverse, so a deck spreads back into the order it came from', () => {
+		const bottomToTop = ['bottom', 'middle', 'top'];
+		for (const isFaceUp of [true, false])
+			expect(orderForDeck(orderForDeck(bottomToTop, isFaceUp), isFaceUp)).toEqual(bottomToTop);
+	});
+});
+
+// trig leaves float dust (and the odd -0) on the axis-aligned cases
+const round = ([x, z]: [number, number]): [number, number] => [
+	Math.round(x * 1e6) / 1e6 + 0,
+	Math.round(z * 1e6) / 1e6 + 0
+];
+
+describe('fanOffset', () => {
+	it('leaves the visual top card where it rests', () => {
+		expect(round(fanOffset(2, 3, degrees[0]))).toEqual([0, 0]);
+	});
+
+	it('cascades everything under it up-screen, one step per card', () => {
+		expect(round(fanOffset(1, 3, degrees[0]))).toEqual([0, -CARD_FAN_STEP]);
+		expect(round(fanOffset(0, 3, degrees[0]))).toEqual([0, -2 * CARD_FAN_STEP]);
+	});
+
+	it('follows the seat: down-screen is -Z from the far side of the table', () => {
+		expect(round(fanOffset(0, 2, degrees[1]))).toEqual([0, CARD_FAN_STEP]);
+		expect(round(fanOffset(0, 2, degrees[2]))).toEqual([-CARD_FAN_STEP, 0]);
+	});
+
+	it('is a no-op for a lone card', () => {
+		expect(round(fanOffset(0, 1, degrees[0]))).toEqual([0, 0]);
 	});
 });

--- a/src/lib/utils/transforms/drop.ts
+++ b/src/lib/utils/transforms/drop.ts
@@ -43,6 +43,15 @@ export interface DropHover {
 	tray?: boolean;
 }
 
+export interface DropOptions {
+	/**
+	 * Alt held at release: place the card exactly where the pointer is, with
+	 * no XZ square-up onto a nearby pile and no stack-height merge. The escape
+	 * hatch for laying cards out next to each other on purpose.
+	 */
+	noSnap?: boolean;
+}
+
 /** Keep a drop a margin inside the felt edge. */
 export function clampToTable(x: number, z: number): [number, number] {
 	return [
@@ -67,7 +76,8 @@ export function resolveDrop(
 	state: Partial<GameDTO> | undefined | null,
 	dragId: string | null | undefined,
 	rawPoint: { x: number; z: number } | null | undefined,
-	hover: DropHover = {}
+	hover: DropHover = {},
+	options: DropOptions = {}
 ): DropTarget | null {
 	if (!dragId) return null;
 
@@ -113,6 +123,20 @@ export function resolveDrop(
 			targetId: hover.deckId,
 			position: [dx, CARD_REST_Y, dz],
 			rotation: (deck?.rotation ?? rotation) as [number, number, number],
+			footprint,
+			footprintY: CARD_REST_Y
+		};
+	}
+
+	// Alt beats the pile: commit at the pointer, resting on the felt rather
+	// than merging into whatever the card happens to overlap. Checked after
+	// the deck and tray, which are aimed-at targets rather than a side effect
+	// of proximity.
+	if (options.noSnap) {
+		return {
+			kind: 'table',
+			position: [x, CARD_REST_Y, z],
+			rotation,
 			footprint,
 			footprintY: CARD_REST_Y
 		};

--- a/src/lib/utils/transforms/stacking.ts
+++ b/src/lib/utils/transforms/stacking.ts
@@ -3,7 +3,8 @@ import {
 	CARD_REST_Y,
 	CARD_THICKNESS,
 	CARD_STACK_RADIUS,
-	CARD_STACK_MAX_Y
+	CARD_STACK_MAX_Y,
+	CARD_FAN_STEP
 } from '$lib/utils/constants-cards';
 
 export interface StackResolution {
@@ -128,7 +129,36 @@ export function collectStackGroup(
  * facedown deck's top card is the LAST element, a face-up pile's is the
  * FIRST. Either way the card that was on top of the loose stack must be the
  * card the deck draws first.
+ *
+ * A reverse is its own inverse, so this maps both ways: feed it a deck's
+ * `cards` and it hands back the bottom→top order to spread them out in
+ * (`ungroupDeck`). Generic on the element so the ungroup can re-order the
+ * `CardInDeck` objects, not just their ids.
  */
-export function orderForDeck(ids: string[], isFaceUp: boolean): string[] {
-	return isFaceUp ? [...ids].reverse() : [...ids];
+export function orderForDeck<T>(items: T[], isFaceUp: boolean): T[] {
+	return isFaceUp ? [...items].reverse() : [...items];
+}
+
+/**
+ * Screen-down offset for the `index`-th member (bottom → top) of a pile of
+ * `count` cards being fanned on hover.
+ *
+ * The cascade is anchored on the visual TOP card: it keeps its resting spot
+ * and everything under it slides up-screen, so each member's top edge — and
+ * with it the title band — peeks out above the card covering it, solitaire
+ * tableau style. Anchoring on the top card (rather than on the hovered one)
+ * also keeps the card under the pointer still, so fanning can't slide the
+ * pile out from under the cursor and thrash the hover.
+ *
+ * `seatYaw` is the local player's seat rotation in radians (`degrees[seat]`):
+ * "down-screen" is +Z for seat 0 and rotates with the seat.
+ */
+export function fanOffset(
+	index: number,
+	count: number,
+	seatYaw: number,
+	step = CARD_FAN_STEP
+): [number, number] {
+	const distance = (index - (count - 1)) * step; // ≤ 0 — the top card holds still
+	return [Math.sin(seatYaw) * distance, Math.cos(seatYaw) * distance];
 }

--- a/src/routes/play/+page.svelte
+++ b/src/routes/play/+page.svelte
@@ -7,6 +7,7 @@
 	import { initWrappers } from '$lib/websocket/storeIntegration';
 	import { initWebsocket } from '$lib/websocket';
 	import { gameActions } from '$lib/store/game/actions';
+	import { ungroupHoveredDeck } from '$lib/hotkeys/ungroup';
 	import { startAutoClaim } from '$lib/scenario/autoClaim';
 	import Pane from './Pane.svelte';
 	import { page } from '$app/state';
@@ -22,7 +23,10 @@
 		if (event.code === 'KeyC') cameraTransforms.resetView();
 		if (event.code === 'KeyT') gameActions.tapCard();
 		if (event.code === 'KeyR') gameActions.tapCard(true);
-		if (event.code === 'KeyG') gameActions.groupStackIntoDeck();
+		// G groups the hovered pile into a deck; Shift+G spreads a hovered deck
+		// back into loose cards
+		if (event.code === 'KeyG' && event.shiftKey) ungroupHoveredDeck();
+		else if (event.code === 'KeyG') gameActions.groupStackIntoDeck();
 		if (event.code === 'ArrowUp') gameActions.incrementHeight(0.01);
 		if (event.code === 'ArrowDown') gameActions.incrementHeight(-0.01);
 	}

--- a/src/routes/play/Pane.svelte
+++ b/src/routes/play/Pane.svelte
@@ -16,6 +16,7 @@
 	import { purgeUndefinedValues } from '$lib/utils/transforms/data';
 	import type { GameDTO } from '$lib/store/game/types';
 	import { gameActions } from '$lib/store/game/actions';
+	import { UNGROUP_MAX_CARDS } from '$lib/store/game/actions/deck';
 	import { connectionStore } from '$lib/store/connectionStore.svelte';
 	import {
 		listScenarios,
@@ -180,6 +181,8 @@
 		<Text label="Reverse Tap card" value="R" disabled />
 		<Text label="Flip card" value="F" disabled />
 		<Text label="Group stack into deck" value="G" disabled />
+		<Text label="Ungroup deck (max {UNGROUP_MAX_CARDS} cards)" value="Shift + G" disabled />
+		<Text label="Drop without snapping" value="hold Alt" disabled />
 		<Text label="Cancel drag" value="Esc" disabled />
 		<Text label="Nudge card higher" value="Arrow Up" disabled />
 		<Text label="Nudge card lower" value="Arrow Up" disabled />

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -5,6 +5,7 @@
 	import { cameraTransforms } from '$lib/utils/transforms/camera';
 	import { onMount } from 'svelte';
 	import { gameActions } from '$lib/store/game/actions';
+	import { ungroupHoveredDeck } from '$lib/hotkeys/ungroup';
 	import { disconnect } from '$lib/websocket/connection';
 	import SetupPane from './SetupPane.svelte';
 
@@ -14,7 +15,10 @@
 		if (event.code === 'KeyC') cameraTransforms.resetView();
 		if (event.code === 'KeyT') gameActions.tapCard();
 		if (event.code === 'KeyR') gameActions.tapCard(true);
-		if (event.code === 'KeyG') gameActions.groupStackIntoDeck();
+		// G groups the hovered pile into a deck; Shift+G spreads a hovered deck
+		// back into loose cards
+		if (event.code === 'KeyG' && event.shiftKey) ungroupHoveredDeck();
+		else if (event.code === 'KeyG') gameActions.groupStackIntoDeck();
 		if (event.code === 'ArrowUp') gameActions.incrementHeight(0.01);
 		if (event.code === 'ArrowDown') gameActions.incrementHeight(-0.01);
 	}


### PR DESCRIPTION
Task: tableplace-70

The pile bundle: make a pile, see a pile, unmake a pile. All three are
client-side state/render patches over the files PR #63 touched — no server or
protocol changes.

## `Shift+G` ungroups a deck (#70)

`G` was one-way: undoing an accidental group on a twelve-card pile meant twelve
clicks and twelve drops. `ungroupDeck` is its exact inverse — `DeckDTO.cards` is
already the full ordered list, so it is one patch.

- Cards land at the deck's XZ, one `CARD_THICKNESS` apart in Y, visual top card
  on top; an `isFaceUp` deck spreads to face-up cards.
- `orderForDeck` turns out to be its own inverse (it's a reverse), so the
  ordering convention — facedown top = last, face-up top = first — survives the
  round trip. `G → Shift+G → G` yields the identical deck; tested.
- The deck delete and the card creation are in the **same** `GameDTO` patch, the
  rule #63 set for grouping, so remote clients never see both at once.
- Card ids reuse the `CardInDeck` id when nothing on the table holds it (so a
  round trip lands the same entities) and fall back to a suffixed id otherwise.
- Ownership matches shuffle (`getMyDecks`). Empty decks are refused rather than
  silently deleted.
- Capped at `UNGROUP_MAX_CARDS` (40): above that it refuses with a toast naming
  the cap, so a 200-card deck can't carpet the felt.

## `Alt` opts out of the square-up snap (#68)

Held at release, the drop commits at the raw pointer point: no XZ square-up onto
a nearby pile, and `resolveStackHeight` skipped so the card rests at
`CARD_REST_Y` instead of on top of what it overlaps. Two loose cards a
card-width apart are a normal layout again.

The modifier is tracked live from key events *and* read off the pointer event at
release, so the `DropIndicator` preview and the commit always agree — pressing or
releasing Alt mid-drag redraws the preview. Blur clears it (alt-tab never
delivers the keyup). Deck and tray stay untouched: those are aimed-at targets,
not proximity effects.

## Hovering a loose pile fans it (#69)

Hovering a multi-card loose stack now cascades the whole stack solitaire-style
instead of glowing whichever card the raycast hit. Membership comes from
`collectStackGroup` — the exact set `G` would swallow — so the preview cannot
disagree with the action, and a loose pile finally reads differently from a
`DeckDTO` slab.

The cascade is anchored on the visual top card: it holds its spot and everything
under it slides up-screen (seat-aware), so fanning can never slide the pile out
from under the cursor. Springs animate it both ways. **Render-time only** — no
`updateState`, nothing over the socket, and the raycast targets the fanned
position, which is the honest one.

`Shift+G` and `Alt` are both in the keybinds legend in the play pane, and all
three work on `/play` and `/setup`. The two new primitives are added to the
table in `docs/research/deck-manipulation-primitives.md` (A6, A7) and A2 notes
its new escape hatch.

## Verification

`bun run test` 277 passed (28 files, up from 251) — 11 new ungroup cases
including both round trips, 5 new `noSnap` drop cases, 4 `fanOffset` cases and 6
hover-fan store cases (including "never writes anything into the shared game
state"). `bun run check` 0 errors. `bun run build` clean. `eslint` adds no new
errors; `prettier --check` is red on `main` at baseline and none of the touched
source files are in that list.

Not verified in a live browser — the Chrome extension wasn't connected in this
environment, so the render-side fan is covered by unit tests and review only.

Closes #70
Closes #68
Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AyvLxSfuEu3ECdfcjtfjS