### PR TITLE
tableplace-71: /create — flip, visible new cards, inline face authoring, four panes, no tray

### DIFF
--- a/src/lib/TableScene.svelte
+++ b/src/lib/TableScene.svelte
@@ -12,7 +12,8 @@
 	import Hdr from './HDR.svelte';
 	import HudPreviewScene from './HUDPreview/HUDPreviewScene.svelte';
 	import RemoteCameraAvatar from './RemoteCameraAvatar.svelte';
-	import { dragStore } from '$lib/store/dragStore.svelte';
+	import { dragStore, setTrayHover } from '$lib/store/dragStore.svelte';
+	import { setTableFeatures, TABLE_FEATURES_DEFAULT } from '$lib/store/tableFeatures';
 	import { gameStore } from './store/game/gameStore.svelte';
 	import { gameActions } from './store/game/actions';
 	import { remoteCameraActions, remoteCameraStore } from './store/remoteCameraStore.svelte';
@@ -26,6 +27,20 @@
 	import { TABLE_TOP_Y } from '$lib/utils/constants-table';
 	import type { GameDTO } from './store/game/types';
 	type CardDTO = GameDTO['cards'][string];
+
+	/**
+	 * `hand={false}` leaves the local hand tray off the table (the pack editor:
+	 * a pack has no way to represent a hand). It also has to reach the drop
+	 * resolver — the tray hover flag is module-global and can arrive stale from
+	 * a previous /play visit, so an unmounted tray must not win a drop.
+	 */
+	let { hand = true }: { hand?: boolean } = $props();
+
+	$effect(() => {
+		setTableFeatures({ hand });
+		if (!hand) setTrayHover(false);
+		return () => setTableFeatures(TABLE_FEATURES_DEFAULT);
+	});
 
 	const isDragging = $derived($dragStore.isDragging !== null);
 	let mesh: THREE.Mesh | undefined = $state();
@@ -126,9 +141,11 @@
 <!-- soft fill so vertical faces (card edges, deck sides) aren't pitch black -->
 <T.AmbientLight intensity={0.5} />
 
-<HUD>
-	<HudTrayScene />
-</HUD>
+{#if hand}
+	<HUD>
+		<HudTrayScene />
+	</HUD>
+{/if}
 
 <HUD>
 	<HudPreviewScene />

--- a/src/lib/drop/DropIndicator.svelte
+++ b/src/lib/drop/DropIndicator.svelte
@@ -4,6 +4,7 @@
 	import { DEG2RAD } from 'three/src/math/MathUtils.js';
 	import { dragStore } from '$lib/store/dragStore.svelte';
 	import { gameStore } from '$lib/store/game/gameStore.svelte';
+	import { tableFeatures } from '$lib/store/tableFeatures';
 	import { resolveDrop } from '$lib/utils/transforms/drop';
 	import { resolveCardImage, sheetRefCache } from '$lib/packs';
 	import DropFootprint from './DropFootprint.svelte';
@@ -25,10 +26,13 @@
 	const dragId = $derived($dragStore.isDragging);
 
 	const drop = $derived(
-		resolveDrop($gameStore, dragId, $dragStore.intersectionPoint, {
-			deckId: $dragStore.isDeckHovered,
-			tray: $dragStore.isTrayHovered
-		})
+		resolveDrop(
+			$gameStore,
+			dragId,
+			$dragStore.intersectionPoint,
+			{ deckId: $dragStore.isDeckHovered, tray: $dragStore.isTrayHovered },
+			$tableFeatures
+		)
 	);
 
 	// the deck / tray highlights are the cue for those targets — a table

--- a/src/lib/drop/commit.ts
+++ b/src/lib/drop/commit.ts
@@ -2,6 +2,7 @@ import { get } from 'svelte/store';
 import { dragEnd, dragStore } from '$lib/store/dragStore.svelte';
 import { gameStore } from '$lib/store/game/gameStore.svelte';
 import { gameActions } from '$lib/store/game/actions';
+import { tableFeatures } from '$lib/store/tableFeatures';
 import { resolveDrop } from '$lib/utils/transforms/drop';
 
 /**
@@ -19,10 +20,13 @@ export function commitActiveDrag() {
 
 	// resolved by the same pure function the DropIndicator previews with, so
 	// what the player saw while dragging is what gets committed
-	const drop = resolveDrop(get(gameStore), id, intersectionPoint, {
-		deckId: isDeckHovered,
-		tray: isTrayHovered
-	});
+	const drop = resolveDrop(
+		get(gameStore),
+		id,
+		intersectionPoint,
+		{ deckId: isDeckHovered, tray: isTrayHovered },
+		get(tableFeatures)
+	);
 
 	if (drop?.kind === 'tray') {
 		gameActions.moveCardToTray(id, gameActions?.getMe()?.id as string);

--- a/src/lib/store/tableFeatures.ts
+++ b/src/lib/store/tableFeatures.ts
@@ -1,0 +1,23 @@
+import { writable } from 'svelte/store';
+
+/**
+ * Which table surfaces the current route mounts.
+ *
+ * `TableScene` publishes this from its props so the pieces that resolve a drop
+ * (`commit.ts`, `DropIndicator`) can't offer a target the route never rendered.
+ * The pack editor is the case that needs it: `/create` has no hand — a hand
+ * holds cards no pack can represent, and a card dropped there would survive
+ * every preview respawn invisibly.
+ */
+export interface TableFeatures {
+	/** whether the local hand tray is mounted, and so may win a drop */
+	hand: boolean;
+}
+
+export const TABLE_FEATURES_DEFAULT: TableFeatures = { hand: true };
+
+export const tableFeatures = writable<TableFeatures>({ ...TABLE_FEATURES_DEFAULT });
+
+export function setTableFeatures(patch: Partial<TableFeatures>) {
+	tableFeatures.set({ ...TABLE_FEATURES_DEFAULT, ...patch });
+}

--- a/src/lib/utils/transforms/__tests__/drop.test.ts
+++ b/src/lib/utils/transforms/__tests__/drop.test.ts
@@ -141,6 +141,24 @@ describe('resolveDrop', () => {
 		);
 	});
 
+	it('refuses a tray drop on a route with no hand, landing the card on the table', () => {
+		// the pack editor: the tray isn't mounted, and a hover flag can arrive
+		// stale from a previous /play visit
+		const s = state({ cards: { a: card(0, 2, 0) } });
+		const drop = resolveDrop(s, 'a', { x: 3, z: -1 }, { tray: true }, { hand: false });
+		expect(drop?.kind).toBe('table');
+		expect(drop?.position).toEqual([3, CARD_REST_Y, -1]);
+	});
+
+	it('still lets a deck win when there is no hand', () => {
+		const s = state({
+			cards: { a: card(0, 2, 0) },
+			decks: { 'deck:1': { position: [8, 0.4, 4], cards: [] } }
+		});
+		const hover = { tray: true, deckId: 'deck:1' };
+		expect(resolveDrop(s, 'a', { x: 0, z: 0 }, hover, { hand: false })?.kind).toBe('deck');
+	});
+
 	it('is unfazed by an empty state', () => {
 		expect(resolveDrop(undefined, 'a', { x: 0, z: 0 })).toBeNull();
 	});

--- a/src/lib/utils/transforms/drop.ts
+++ b/src/lib/utils/transforms/drop.ts
@@ -1,4 +1,5 @@
 import type { GameDTO } from '$lib/store/game/types';
+import { TABLE_FEATURES_DEFAULT, type TableFeatures } from '$lib/store/tableFeatures';
 import { CARD_WIDTH, CARD_HEIGHT, CARD_REST_Y } from '$lib/utils/constants-cards';
 import { PIECE_DEFAULT_RADIUS, PIECE_REST_Y } from '$lib/utils/constants-pieces';
 import { EDGE_MARGIN, TABLE_HALF_X, TABLE_HALF_Z, TABLE_TOP_Y } from '$lib/utils/constants-table';
@@ -62,13 +63,19 @@ export function clampToTable(x: number, z: number): [number, number] {
  * `rawPoint` is the unclamped table raycast hit; when it's missing (pointer
  * off the table plane) the entity's own position is used instead so a drag
  * keeps previewing.
+ *
+ * `features` is what the current route actually mounted (see
+ * `store/tableFeatures`): a target that isn't on screen can't win a drop, even
+ * if a stale hover flag from another route says the pointer is over it.
  */
 export function resolveDrop(
 	state: Partial<GameDTO> | undefined | null,
 	dragId: string | null | undefined,
 	rawPoint: { x: number; z: number } | null | undefined,
-	hover: DropHover = {}
+	hover: DropHover = {},
+	features: Partial<TableFeatures> = {}
 ): DropTarget | null {
+	const hasHand = features.hand ?? TABLE_FEATURES_DEFAULT.hand;
 	if (!dragId) return null;
 
 	const isPiece = dragId.startsWith('piece:');
@@ -94,8 +101,9 @@ export function resolveDrop(
 	const footprint = { shape: 'rect', w: CARD_WIDTH, h: CARD_HEIGHT } as const;
 
 	// the tray wins over a deck: dropping into your hand is the more explicit
-	// gesture, and the two hover states can briefly overlap
-	if (hover.tray) {
+	// gesture, and the two hover states can briefly overlap. No hand on this
+	// route (the pack editor) and the card just lands on the table instead.
+	if (hover.tray && hasHand) {
 		return {
 			kind: 'tray',
 			position: [x, CARD_REST_Y, z],

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -8,8 +8,38 @@
 	import { disconnect } from '$lib/websocket/connection';
 	import CreatePane from './CreatePane.svelte';
 
+	/**
+	 * Authoring is mostly typing — codes, names, image URLs — and the editor's
+	 * gestures are bare letters. A key that lands in a pane field is text, not
+	 * a table command.
+	 */
+	function isTyping(target: EventTarget | null) {
+		const element = target as HTMLElement | null;
+		if (!element) return false;
+		return (
+			element.tagName === 'INPUT' ||
+			element.tagName === 'TEXTAREA' ||
+			element.tagName === 'SELECT' ||
+			element.isContentEditable
+		);
+	}
+
+	// same gestures as /setup, so a card pulled out of a preview pile can be
+	// inspected (flip) and arranged without leaving the editor
 	function handleKeyDown(event: KeyboardEvent) {
+		if (isTyping(event.target)) return;
+		if (event.code === 'Space') cameraTransforms.togglePreviewHud(true);
+		if (event.code === 'KeyF') gameActions.flipCard();
 		if (event.code === 'KeyC') cameraTransforms.resetView();
+		if (event.code === 'KeyT') gameActions.tapCard();
+		if (event.code === 'KeyR') gameActions.tapCard(true);
+		if (event.code === 'ArrowUp') gameActions.incrementHeight(0.01);
+		if (event.code === 'ArrowDown') gameActions.incrementHeight(-0.01);
+	}
+
+	function handleKeyUp(event: KeyboardEvent) {
+		if (isTyping(event.target)) return;
+		if (event.code === 'Space') cameraTransforms.togglePreviewHud(false);
 	}
 
 	let isReady = $state(false);
@@ -27,14 +57,16 @@
 	<meta name="description" content="Author a table.place game pack (.tbpp.json) locally" />
 </svelte:head>
 
-<svelte:window on:keydown={handleKeyDown} />
+<svelte:window on:keydown={handleKeyDown} on:keyup|preventDefault={handleKeyUp} />
 
 <CreatePane />
 
 <div class="h-screen w-screen overflow-clip bg-gray-700">
 	<Canvas toneMapping={ACESFilmicToneMapping}>
 		{#if isReady}
-			<TableScene />
+			<!-- no hand in the pack editor: a card dropped into the tray lands in
+			     state no pack can represent, and survives every preview respawn -->
+			<TableScene hand={false} />
 		{/if}
 	</Canvas>
 </div>

--- a/src/routes/create/CreatePane.svelte
+++ b/src/routes/create/CreatePane.svelte
@@ -14,7 +14,7 @@
 	} from 'svelte-tweakpane-ui';
 	import { get } from 'svelte/store';
 	import { gameStore } from '$lib/store/game/gameStore.svelte';
-	import { makeSheetRef } from '$lib/packs/resolve.svelte';
+	import { gameActions } from '$lib/store/game/actions';
 	import { prewarmGameState } from '$lib/packs/prewarm-state';
 	import { spawnPackDeck, spawnPackPiece, spawnPackOverlay } from '$lib/packs/spawn';
 	import { CARD_BACK_DEFAULT } from '$lib/packs/standard52';
@@ -30,6 +30,7 @@
 		PIECE_COLOR_DEFAULT,
 		type EditorPack
 	} from './normalize';
+	import FaceRef from './FaceRef.svelte';
 	import toast from 'svelte-french-toast';
 
 	/** Everything the /create preview spawns is owned by this placeholder id */
@@ -40,6 +41,14 @@
 		'Everything here is local — no lobby is touched, and drafts stay in this browser. ' +
 		'The table previews the pack live as you edit. Export validates against the tbpp ' +
 		'format (docs/packs.md), then /setup spawns the file onto a seat.';
+
+	const TABLE_HELP_TEXT =
+		'Preview table: drag a card off a pile to look at it. It arrives showing the ' +
+		'side the deck starts on, so use "Flip cards on table" (or hover a card and ' +
+		'press F) to turn it over. T / R tap, ↑ / ↓ lift, C recentres the camera, hold ' +
+		'Space for a close-up. Moving cards here is inspection only — nothing on the ' +
+		'table is written back into the pack. The durable start face is the deck’s ' +
+		'"Face up" box.';
 
 	function emptyPack(): EditorPack {
 		return withEditorDefaults({
@@ -117,7 +126,14 @@
 
 	function addCard() {
 		if (!deck) return toast.error('Add a deck first');
-		deck.cards.push({ code: `card-${deck.cards.length}`, name: '', face: '' });
+		// the deck's back, not an empty ref: an empty face resolves to '' and
+		// renders nothing, so a brand new card would be invisible on the table
+		// until someone found the face controls
+		deck.cards.push({
+			code: `card-${deck.cards.length}`,
+			name: '',
+			face: deck.back || CARD_BACK_DEFAULT
+		});
 		cardCursor = deck.cards.length - 1;
 	}
 
@@ -170,43 +186,18 @@
 		overlayCursor = Math.max(0, overlayIndex - 1);
 	}
 
-	// ——— face-ref builder: raw url / gen:std52 / sheet:{…} ———
-	type FaceScheme = 'url' | 'gen' | 'sheet';
-	const schemeOptions: Record<string, FaceScheme> = {
-		'Image URL (https:)': 'url',
-		'Generated (gen:std52)': 'gen',
-		'Sprite sheet (sheet:)': 'sheet'
-	};
-	let faceScheme: FaceScheme = $state('url');
-	let faceUrl = $state('');
-	let genCode = $state('AS');
-	let sheetUrl = $state('');
-	let sheetCols = $state(10);
-	let sheetRows = $state(7);
-	let sheetIndex = $state(0);
-
-	const builtFaceRef = $derived.by(() => {
-		if (faceScheme === 'url') return faceUrl.trim();
-		if (faceScheme === 'gen') return `gen:std52/${genCode.trim()}`;
-		if (!sheetUrl.trim()) return '';
-		return makeSheetRef({
-			url: sheetUrl.trim(),
-			cols: Math.max(1, Math.round(sheetCols)),
-			rows: Math.max(1, Math.round(sheetRows)),
-			index: Math.max(0, Math.round(sheetIndex))
-		});
-	});
-
-	function applyFaceToCard() {
-		if (!card) return toast.error('Select a card first');
-		if (!builtFaceRef) return toast.error('Face ref is empty');
-		card.face = builtFaceRef;
-	}
-
-	function applyFaceToBack() {
-		if (!deck) return toast.error('Select a deck first');
-		if (!builtFaceRef) return toast.error('Face ref is empty');
-		deck.back = builtFaceRef;
+	/**
+	 * Flip whatever the preview spawned onto the table, so the flip gesture is
+	 * reachable without hovering a card and knowing about `F`. Every card the
+	 * editor puts on the table belongs to the preview owner, and the flip is
+	 * inspection only — the next edit respawns the pack and it's gone.
+	 */
+	function flipTableCards() {
+		const ids = Object.keys(get(gameStore)?.cards ?? {}).filter((id) =>
+			id.includes(`:${PREVIEW_OWNER}:`)
+		);
+		if (!ids.length) return toast('Drag a card off a pile first');
+		for (const id of ids) gameActions.flipCard(id);
 	}
 
 	// ——— live preview: respawn the pack under the preview owner on every edit ———
@@ -354,65 +345,83 @@
 	}
 </script>
 
+<!--
+	Four panes, not one: each carries a single concern and remembers its own
+	position and collapse state (`localStoreId`). Authoring a card — the thing
+	this editor is for — is one pane deep, and Save / Export never hides under
+	another section.
+-->
+
 <Pane
 	position="draggable"
-	title="Pack Editor (local)"
+	title="Pack (local)"
 	expanded={true}
-	y={0}
-	x={0}
-	width={340}
-	localStoreId="create-pane"
+	y={8}
+	x={8}
+	width={320}
+	localStoreId="create-pane-pack"
 >
-	<Folder title="Pack" expanded={true}>
-		<Text label="Id" bind:value={pack.id} />
-		<Text label="Name" bind:value={pack.name} />
-		<List
-			label="Scope"
-			bind:value={pack.scope}
-			options={{ 'player (one seat brings it)': 'player', 'table (the shared game)': 'table' }}
-		/>
-	</Folder>
+	<Text label="Id" bind:value={pack.id} />
+	<Text label="Name" bind:value={pack.name} />
+	<List
+		label="Scope"
+		bind:value={pack.scope}
+		options={{ 'player (one seat brings it)': 'player', 'table (the shared game)': 'table' }}
+	/>
+	<Textarea disabled rows={5} value={HELP_TEXT} />
+</Pane>
 
-	<Folder title="Decks ({pack.decks.length})" expanded={true}>
-		<List label="Deck" bind:value={deckCursor} options={deckOptions} />
-		<Button title="Add deck" on:click={addDeck} />
-		{#if deck}
+<Pane
+	position="draggable"
+	title="Decks & Cards"
+	expanded={true}
+	y={190}
+	x={8}
+	width={320}
+	localStoreId="create-pane-decks"
+>
+	<List label="Deck" bind:value={deckCursor} options={deckOptions} />
+	<Button title="Add deck" on:click={addDeck} />
+	{#if deck}
+		<Folder title="Deck ({deck.slot})" expanded={true}>
 			<Text label="Slot" bind:value={deck.slot} />
 			<Text label="Name" bind:value={deck.name} />
-			<Text label="Back ref" bind:value={deck.back} />
 			<Checkbox label="Face up" bind:value={deck.isFaceUp} />
 			<Button title="Remove deck" on:click={removeDeck} />
-			<Folder title="Cards ({deck.cards.length})" expanded={true}>
-				<List label="Card" bind:value={cardCursor} options={cardOptions} />
-				<Button title="Add card" on:click={addCard} />
-				{#if card}
-					<Text label="Code" bind:value={card.code} />
-					<Text label="Name" bind:value={card.name} />
-					<Text label="Face ref" bind:value={card.face} />
-					<Button title="Duplicate card" on:click={duplicateCard} />
-					<Button title="Remove card" on:click={removeCard} />
-				{/if}
-			</Folder>
-		{/if}
-	</Folder>
+			<!-- keyed on the cursor: a fresh editor for whichever deck is selected -->
+			{#key deckIndex}
+				<FaceRef title="Deck back" value={deck.back} onchange={(ref) => (deck.back = ref)} />
+			{/key}
+		</Folder>
 
-	<Folder title="Face ref builder" expanded={false}>
-		<List label="Scheme" bind:value={faceScheme} options={schemeOptions} />
-		{#if faceScheme === 'url'}
-			<Text label="Image URL" bind:value={faceUrl} />
-		{:else if faceScheme === 'gen'}
-			<Text label="Code (AS…KC, back)" bind:value={genCode} />
-		{:else}
-			<Text label="Sheet URL" bind:value={sheetUrl} />
-			<AutoValue label="Columns" bind:value={sheetCols} />
-			<AutoValue label="Rows" bind:value={sheetRows} />
-			<AutoValue label="Cell index" bind:value={sheetIndex} />
-		{/if}
-		<Text label="Result" value={builtFaceRef} disabled />
-		<Button title="Set as card face" on:click={applyFaceToCard} />
-		<Button title="Set as deck back" on:click={applyFaceToBack} />
-	</Folder>
+		<Folder title="Cards ({deck.cards.length})" expanded={true}>
+			<List label="Card" bind:value={cardCursor} options={cardOptions} />
+			<Button title="Add card" on:click={addCard} />
+			{#if card}
+				<Text label="Code" bind:value={card.code} />
+				<Text label="Name" bind:value={card.name} />
+				<Button title="Duplicate card" on:click={duplicateCard} />
+				<Button title="Remove card" on:click={removeCard} />
+				{#key `${deckIndex}:${cardIndex}`}
+					<FaceRef title="Card face" value={card.face} onchange={(ref) => (card.face = ref)} />
+				{/key}
+			{/if}
+		</Folder>
+	{/if}
 
+	<Button title="Flip cards on table (F)" on:click={flipTableCards} />
+	<Textarea disabled rows={6} value={TABLE_HELP_TEXT} />
+</Pane>
+
+<Pane
+	position="draggable"
+	title="Board"
+	expanded={true}
+	y={8}
+	x={344}
+	width={320}
+	localStoreId="create-pane-board"
+>
 	<Folder title="Pieces ({pack.pieces.length})" expanded={false}>
 		<List label="New kind" bind:value={newPieceKind} options={kindOptions} />
 		<Button title="Add {newPieceKind}" on:click={addPiece} />
@@ -452,7 +461,22 @@
 			<Button title="Remove overlay" on:click={removeOverlay} />
 		{/if}
 	</Folder>
+</Pane>
 
+<Pane
+	position="draggable"
+	title="Drafts / File"
+	expanded={true}
+	y={190}
+	x={344}
+	width={320}
+	localStoreId="create-pane-file"
+>
+	<Button title="Save draft" on:click={handleSaveDraft} />
+	<List label="Saved" bind:value={selectedDraft} options={draftOptions} />
+	<Button title="Load selected" on:click={handleLoadDraft} />
+	<Button title="Delete selected" on:click={handleDeleteDraft} />
+	<Button title="Export pack (.tbpp.json)" on:click={handleExport} />
 	<Folder title="Start from an existing file" expanded={false}>
 		<Button title="Import TTS json → pack" on:click={() => ttsFileInput?.click()} />
 		<Button title="Open a pack (.tbpp.json)" on:click={() => packFileInput?.click()} />
@@ -473,14 +497,4 @@
 			/>
 		</Element>
 	</Folder>
-
-	<Folder title="Drafts / Export" expanded={true}>
-		<Button title="Save draft" on:click={handleSaveDraft} />
-		<List label="Saved" bind:value={selectedDraft} options={draftOptions} />
-		<Button title="Load selected" on:click={handleLoadDraft} />
-		<Button title="Delete selected" on:click={handleDeleteDraft} />
-		<Button title="Export pack (.tbpp.json)" on:click={handleExport} />
-	</Folder>
-
-	<Textarea disabled rows={5} value={HELP_TEXT} />
 </Pane>

--- a/src/routes/create/FaceRef.svelte
+++ b/src/routes/create/FaceRef.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import { untrack } from 'svelte';
+	import { AutoValue, Folder, List, Text } from 'svelte-tweakpane-ui';
+	import { buildFaceRef, parseFaceRef, FACE_SCHEME_OPTIONS, type FaceDraft } from './face-ref';
+
+	/**
+	 * Inline face authoring for whatever the pane is editing right now — a
+	 * card's `face` or a deck's `back`. Pick the scheme, fill the fields, and
+	 * the ref is written straight back: there is no apply button, and nothing
+	 * to know about a builder somewhere else in the editor.
+	 *
+	 * State is seeded from `value` once, so the parent must key this component
+	 * on the entity being edited (`{#key deckIndex + ':' + cardIndex}`) to
+	 * re-seed it when the cursor moves. Writes are guarded against the value it
+	 * last produced, so a ref changed from outside never gets clobbered by a
+	 * stale field.
+	 */
+	let {
+		value,
+		title = 'Face',
+		onchange
+	}: { value: string; title?: string; onchange: (ref: string) => void } = $props();
+
+	// deliberately read once: these fields are seeded from the ref, then own it
+	const initial = untrack(() => parseFaceRef(value));
+	let scheme = $state(initial.scheme);
+	let url = $state(initial.url);
+	let genCode = $state(initial.genCode);
+	let sheetUrl = $state(initial.sheetUrl);
+	let sheetCols = $state(initial.sheetCols);
+	let sheetRows = $state(initial.sheetRows);
+	let sheetIndex = $state(initial.sheetIndex);
+
+	const draft: FaceDraft = $derived({
+		scheme,
+		url,
+		genCode,
+		sheetUrl,
+		sheetCols,
+		sheetRows,
+		sheetIndex,
+		sheetExtra: initial.sheetExtra
+	});
+	const built = $derived(buildFaceRef(draft));
+
+	let lastBuilt = buildFaceRef(initial);
+	$effect(() => {
+		if (built === lastBuilt) return;
+		lastBuilt = built;
+		onchange(built);
+	});
+</script>
+
+<Folder {title} expanded={true}>
+	<List label="Scheme" bind:value={scheme} options={FACE_SCHEME_OPTIONS} />
+	{#if scheme === 'url'}
+		<Text label="Image URL" bind:value={url} />
+	{:else if scheme === 'gen'}
+		<Text label="Code (AS…KC, back)" bind:value={genCode} />
+	{:else}
+		<Text label="Sheet URL" bind:value={sheetUrl} />
+		<AutoValue label="Columns" bind:value={sheetCols} />
+		<AutoValue label="Rows" bind:value={sheetRows} />
+		<AutoValue label="Cell index" bind:value={sheetIndex} />
+	{/if}
+	<Text label="Ref" value={built} disabled />
+</Folder>

--- a/src/routes/create/__tests__/CreatePane.test.ts
+++ b/src/routes/create/__tests__/CreatePane.test.ts
@@ -8,6 +8,7 @@ import { render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import CreatePane from '../CreatePane.svelte';
 import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { CARD_BACK_DEFAULT } from '$lib/packs/standard52';
 
 // the draggable Pane observes its own size; jsdom has no ResizeObserver
 globalThis.ResizeObserver ??= class {
@@ -25,6 +26,28 @@ const button = (container: HTMLElement, label: string) =>
 
 const labels = (container: HTMLElement) =>
 	[...container.querySelectorAll('.tp-lblv_l')].map((el) => el.textContent);
+
+/** the text input of the (single) row carrying this label */
+const input = (container: HTMLElement, label: string) =>
+	[...container.querySelectorAll('.tp-lblv_l')]
+		.find((el) => el.textContent === label)
+		?.parentElement?.querySelector('input');
+
+/** every face-scheme picker on screen, in DOM order (deck back, then card face) */
+const schemePickers = (container: HTMLElement) =>
+	[...container.querySelectorAll('select')].filter((s) =>
+		[...s.options].some((o) => o.textContent?.includes('Sprite sheet'))
+	);
+
+function choose(select: HTMLSelectElement, text: string) {
+	select.selectedIndex = [...select.options].findIndex((o) => o.textContent?.includes(text));
+	select.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+function type(element: HTMLInputElement, value: string) {
+	element.value = value;
+	element.dispatchEvent(new Event('change', { bubbles: true }));
+}
 
 async function mount() {
 	const { container } = render(CreatePane);
@@ -105,6 +128,63 @@ describe('CreatePane', () => {
 
 		// an empty deck has no cards[0] for Deck.svelte to render
 		expect(Object.keys(get(gameStore).decks ?? {})).toEqual(['deck:preview:main']);
+	});
+
+	it('gives a new card the deck back as its face, so it renders immediately', async () => {
+		const container = await mount();
+		button(container, 'Add card')!.click();
+		await settlePreview();
+
+		const cards = get(gameStore).decks?.['deck:preview:main'].cards ?? [];
+		expect(cards).toHaveLength(2);
+		// starter deck's back — a blank face resolves to '' and shows nothing
+		expect(cards[1].faceImageUrl).toBe(CARD_BACK_DEFAULT);
+	});
+
+	it('sets the selected card face inline, without a separate builder', async () => {
+		const container = await mount();
+		// one face editor for the deck back, one for the selected card
+		const pickers = schemePickers(container);
+		expect(pickers).toHaveLength(2);
+
+		choose(pickers[1], 'Image URL');
+		await settle();
+		type(input(container, 'Image URL')!, 'https://example.test/ace.png');
+		await settlePreview();
+
+		const cards = get(gameStore).decks?.['deck:preview:main'].cards ?? [];
+		expect(cards[0].faceImageUrl).toBe('https://example.test/ace.png');
+	});
+
+	it('sets the deck back inline from the deck section', async () => {
+		const container = await mount();
+		choose(schemePickers(container)[0], 'Image URL');
+		await settle();
+		type(input(container, 'Image URL')!, 'https://example.test/back.png');
+		await settlePreview();
+
+		expect(get(gameStore).decks?.['deck:preview:main'].deckBackImageUrl).toBe(
+			'https://example.test/back.png'
+		);
+	});
+
+	it('flips the cards on the preview table from the pane, no keyboard needed', async () => {
+		const container = await mount();
+		await settlePreview();
+
+		gameStore.updateState({
+			cards: {
+				'card:preview:main-AS': {
+					position: [0, 0.3, 0],
+					rotation: [180, 0, 0], // as it arrives off a facedown pile
+					faceImageUrl: 'gen:std52/AS'
+				}
+			}
+		});
+		button(container, 'Flip cards on table')!.click();
+		await settle();
+
+		expect(get(gameStore).cards?.['card:preview:main-AS'].rotation).toEqual([0, 0, 0]);
 	});
 
 	it('previews only under the preview owner, leaving other entities alone', async () => {

--- a/src/routes/create/__tests__/face-ref.test.ts
+++ b/src/routes/create/__tests__/face-ref.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { buildFaceRef, parseFaceRef } from '../face-ref';
+
+const roundtrip = (ref: string) => buildFaceRef(parseFaceRef(ref));
+
+describe('parseFaceRef', () => {
+	it('reads a generated ref back as its card code', () => {
+		expect(parseFaceRef('gen:std52/AS')).toMatchObject({ scheme: 'gen', genCode: 'AS' });
+	});
+
+	it('reads a plain image url', () => {
+		expect(parseFaceRef('https://example.test/ace.png')).toMatchObject({
+			scheme: 'url',
+			url: 'https://example.test/ace.png'
+		});
+	});
+
+	it('reads a sheet ref back into its cells', () => {
+		const ref = 'sheet:{"url":"https://example.test/sheet.png","cols":10,"rows":7,"index":3}';
+		expect(parseFaceRef(ref)).toMatchObject({
+			scheme: 'sheet',
+			sheetUrl: 'https://example.test/sheet.png',
+			sheetCols: 10,
+			sheetRows: 7,
+			sheetIndex: 3
+		});
+	});
+
+	it('keeps a sheet payload the editor has no control for', () => {
+		const ref =
+			'sheet:{"url":"https://example.test/s.png","cols":2,"rows":2,"index":1,"name":"Ace"}';
+		expect(parseFaceRef(ref).sheetExtra).toEqual({ name: 'Ace' });
+		expect(roundtrip(ref)).toContain('"name":"Ace"');
+	});
+
+	it('leaves an unparseable sheet ref alone rather than blanking the card', () => {
+		expect(parseFaceRef('sheet:not json')).toMatchObject({
+			scheme: 'url',
+			url: 'sheet:not json'
+		});
+	});
+
+	it('starts empty for a card with no face yet', () => {
+		expect(parseFaceRef('')).toMatchObject({ scheme: 'url', url: '' });
+		expect(buildFaceRef(parseFaceRef(''))).toBe('');
+	});
+});
+
+describe('buildFaceRef', () => {
+	it('round-trips every scheme, so the inline editor never rewrites a ref it just read', () => {
+		for (const ref of [
+			'gen:std52/AS',
+			'gen:std52/back',
+			'https://example.test/ace.png',
+			'sheet:{"url":"https://example.test/sheet.png","cols":10,"rows":7,"index":3}'
+		]) {
+			expect(roundtrip(ref)).toBe(ref);
+		}
+	});
+
+	it('builds a sheet ref from whole, in-range cells', () => {
+		const draft = parseFaceRef('');
+		expect(
+			buildFaceRef({
+				...draft,
+				scheme: 'sheet',
+				sheetUrl: ' https://example.test/s.png ',
+				sheetCols: 4.4,
+				sheetRows: 0,
+				sheetIndex: -2
+			})
+		).toBe('sheet:{"url":"https://example.test/s.png","cols":4,"rows":1,"index":0}');
+	});
+
+	it('is empty rather than half-built when the inputs are', () => {
+		const draft = parseFaceRef('');
+		expect(buildFaceRef({ ...draft, scheme: 'sheet' })).toBe('');
+		expect(buildFaceRef({ ...draft, scheme: 'gen', genCode: '  ' })).toBe('');
+	});
+});

--- a/src/routes/create/face-ref.ts
+++ b/src/routes/create/face-ref.ts
@@ -1,0 +1,113 @@
+/**
+ * Face refs, in the two directions the editor needs them.
+ *
+ * A tbpp face is one opaque string (`https://…`, `gen:std52/AS`,
+ * `sheet:{…}`). The pane edits it as fields, so it has to be able to take a
+ * ref apart as well as build one — `parseFaceRef` picks the scheme a stored
+ * ref was written in, `buildFaceRef` puts the fields back together.
+ * Round-tripping a ref through both is a no-op, which is what lets the inline
+ * editor sit directly on a card without a separate "apply" step.
+ */
+
+import { makeSheetRef } from '$lib/packs/resolve.svelte';
+
+export type FaceScheme = 'url' | 'gen' | 'sheet';
+
+export const FACE_SCHEME_OPTIONS: Record<string, FaceScheme> = {
+	'Image URL (https:)': 'url',
+	'Generated (gen:std52)': 'gen',
+	'Sprite sheet (sheet:)': 'sheet'
+};
+
+/** `sheet:` payload — mirrors resolve.svelte's private shape */
+export type SheetPayload = {
+	url: string;
+	cols: number;
+	rows: number;
+	index: number;
+	name?: string;
+	back?: boolean;
+};
+
+export interface FaceDraft {
+	scheme: FaceScheme;
+	/** raw ref for the `url` scheme (anything the resolver passes through) */
+	url: string;
+	/** card code for the `gen:std52/` scheme */
+	genCode: string;
+	sheetUrl: string;
+	sheetCols: number;
+	sheetRows: number;
+	sheetIndex: number;
+	/**
+	 * The rest of an imported sheet payload (`name`, `back`), kept so editing
+	 * one cell index doesn't throw away a TTS import's dead-art fallback.
+	 */
+	sheetExtra: Partial<SheetPayload>;
+}
+
+export const SHEET_DEFAULTS = { cols: 10, rows: 7, index: 0 } as const;
+
+function emptyDraft(scheme: FaceScheme): FaceDraft {
+	return {
+		scheme,
+		url: '',
+		genCode: 'AS',
+		sheetUrl: '',
+		sheetCols: SHEET_DEFAULTS.cols,
+		sheetRows: SHEET_DEFAULTS.rows,
+		sheetIndex: SHEET_DEFAULTS.index,
+		sheetExtra: {}
+	};
+}
+
+/** Split a stored face ref into editable fields. Unparseable refs stay raw. */
+export function parseFaceRef(ref: string | undefined | null): FaceDraft {
+	const value = (ref ?? '').trim();
+	if (!value) return emptyDraft('url');
+
+	if (value.startsWith('gen:std52/')) {
+		return { ...emptyDraft('gen'), genCode: value.slice('gen:std52/'.length) };
+	}
+
+	if (value.startsWith('sheet:')) {
+		try {
+			const { url, cols, rows, index, ...rest } = JSON.parse(
+				value.slice('sheet:'.length)
+			) as Partial<SheetPayload>;
+			return {
+				...emptyDraft('sheet'),
+				sheetUrl: url ?? '',
+				sheetCols: cols ?? SHEET_DEFAULTS.cols,
+				sheetRows: rows ?? SHEET_DEFAULTS.rows,
+				sheetIndex: index ?? SHEET_DEFAULTS.index,
+				sheetExtra: rest
+			};
+			// a hand-written sheet ref that isn't JSON is still a valid string to
+			// keep — surface it as-is rather than silently blanking the card
+		} catch {
+			return { ...emptyDraft('url'), url: value };
+		}
+	}
+
+	return { ...emptyDraft('url'), url: value };
+}
+
+/** Put the fields back together into the ref that goes in the pack. */
+export function buildFaceRef(draft: FaceDraft): string {
+	if (draft.scheme === 'url') return draft.url.trim();
+	if (draft.scheme === 'gen') {
+		const code = draft.genCode.trim();
+		return code ? `gen:std52/${code}` : '';
+	}
+	if (!draft.sheetUrl.trim()) return '';
+	// the spread is last on purpose: `sheetExtra` never holds the four fields
+	// above (parse takes them out), so this only appends `name` / `back`
+	return makeSheetRef({
+		url: draft.sheetUrl.trim(),
+		cols: Math.max(1, Math.round(draft.sheetCols)),
+		rows: Math.max(1, Math.round(draft.sheetRows)),
+		index: Math.max(0, Math.round(draft.sheetIndex)),
+		...draft.sheetExtra
+	});
+}


### PR DESCRIPTION
Task: tableplace-71

Closes #71

Authoring a card in `/create` was close to undiscoverable — *"I drag a card out of the deck and there's no face — only a cardback."* Four things compounded into that, all fixed here. **No tbpp format change**: `types.ts`, `file.ts`, `static/pack.schema.json` and `docs/packs.md` are untouched.

## 1. Flip, and the rest of the editor gestures

`/create` now wires `F` flip, `T`/`R` tap, `↑`/`↓` lift and `Space` preview alongside the `C` it already had, matching `/setup`. A card dragged off a (facedown) preview pile can finally be turned over.

Two additions beyond parity:

- **Flip is reachable without the keyboard** — a `Flip cards on table` button in the Decks & Cards pane, plus the keys spelled out in that pane's help text. `/create` is the newcomer-facing surface.
- Keys are ignored when the event target is a pane field. The editor is mostly typing (codes, names, image URLs) and its gestures are bare letters; an `f` in a URL is text, not a command.

Flipping stays inspection-only, as the issue asks: nothing on the table is written back into the draft, and the durable start face is still the deck's `Face up` box.

## 2. A new card is visible

`Add card` defaults `face` to the deck's `back` (falling back to `CARD_BACK_DEFAULT` for a deck with no back yet), so the card renders the moment it exists instead of resolving to `''`.

## 3. Face authoring is inline

The detached `Face ref builder` folder and its `Set as card face` / `Set as deck back` buttons are gone. `FaceRef.svelte` sits directly under the selected card, and again under the deck's back: pick the scheme (image URL / `gen:std52` / `sheet:`), fill the fields, and the ref is written straight through — no apply step, nothing to know about a builder elsewhere.

`face-ref.ts` is the new both-directions helper: `parseFaceRef` takes a stored ref apart (including a TTS import's `sheet:` payload, whose `name`/`back` keys survive an edit), `buildFaceRef` puts it back together. Round-tripping is a no-op for every scheme, which is what lets the editor sit on a live value without rewriting it.

## 4. Four panes instead of one

`Pack` · `Decks & Cards` · `Board` (pieces + overlays) · `Drafts / File`, each draggable with its own `localStoreId`. Card editing is one pane deep instead of three folders deep, and Save/Export isn't buried under anything.

## 5. No hand tray in `/create`

`TableScene` takes `hand` (default `true`) and publishes it via the new `store/tableFeatures`, which `resolveDrop` consults. The gate is in the resolver, not just the markup: `isTrayHovered` is module-global and can arrive stale from a `/play` visit, so an unmounted tray must not win a drop. A card dropped into the tray here would have landed in `players.preview.tray` — state no pack can represent, invisible to `exportable`, and surviving every 300ms respawn. `/play` and `/setup` are unchanged.

## Verification

`bun run test` (266 passed, 28 files), `bun run check` (0 errors), `bun run build` clean. `bun run lint` is red at baseline on `main`; `prettier --check` and `eslint` report nothing for any file in this diff.

New tests:

- `create/__tests__/CreatePane.test.ts` — the `addCard` face default; setting a card face and a deck back inline through the real tweakpane widgets; the pane's flip button turning a facedown preview card over.
- `create/__tests__/face-ref.test.ts` — parse/build per scheme, round-trip, preserved sheet payload, unparseable refs kept rather than blanked.
- `utils/transforms/__tests__/drop.test.ts` — a tray drop refused with `hand: false` (lands on the table instead), and a deck still winning in that mode.

Not verified in a browser: the extension wasn't connected in this session, so the four panes' initial on-screen placement is unconfirmed — the jsdom tests drive the real tweakpane DOM, so mounting and wiring are covered, but layout isn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NteWxLUfLb7RKoBWJjNGus