### PR TITLE
tableplace-74: fix pile pointerdown lifting every intersected card

### DIFF
--- a/src/lib/Card.svelte
+++ b/src/lib/Card.svelte
@@ -20,6 +20,7 @@
 	} from '$lib/utils/constants-cards';
 	import { fanOffset } from '$lib/utils/transforms/stacking';
 	import { resolveCardImage, sheetRefCache } from '$lib/packs';
+	import { claimPointerDown } from '$lib/utils/single-hit-pointerdown';
 	type Vec3Array = [number, number, number];
 
 	let { id }: { id: string } = $props();
@@ -46,12 +47,24 @@
 		precision: 0.0001
 	});
 
-	// Single source of truth for resting height: stays lifted while a flip is
+	// Single source of truth for height: entirely derived from this card's own
+	// drag ownership and store state, so nothing outside this effect ever
+	// writes height.target. That makes an orphaned card impossible — even a
+	// handler that misfires and starts a drag this card never actually wins
+	// (dragStore.isDragging goes to some other id) leaves isDragging false
+	// here, so this effect keeps settling it at restY instead of leaving
+	// whatever height a stray handler last poked it to.
+	// While dragging: brief overshoot bounce, then settle on CARD_DRAG_Y — the
+	// same height the store records mid-drag, so the drop indicator's
+	// connector meets the card. Otherwise: stays lifted while a flip is
 	// mid-rotation (so the card can't clip the table), settles to the store's
-	// stack height once the rotation completes. Replaces the old setTimeout
-	// settle hack and the per-frame sync effect that fought it.
+	// stack height once the rotation completes.
 	$effect(() => {
-		if (isDragging) return; // drag handlers own the height while dragging
+		if (isDragging) {
+			height.target = CARD_DRAG_Y + 0.2;
+			const handle = setTimeout(() => (height.target = CARD_DRAG_Y), 150);
+			return () => clearTimeout(handle);
+		}
 		const flipping = Math.abs(rotation.current - rotation.target) > 2;
 		const restY = cardState?.position?.[1] ?? CARD_REST_Y;
 		height.target = flipping ? Math.max(1.5, restY) : restY;
@@ -144,12 +157,6 @@
 		// origin is the store position from before the lift, so Esc can put the
 		// card back exactly where it was
 		dragStart(id, position[1], (cardState?.position as Vec3Array) ?? undefined);
-
-		// Animate to raised height with some extra bounce. Settles on
-		// CARD_DRAG_Y — the same height the store records mid-drag, so the drop
-		// indicator's connector meets the card instead of stopping short.
-		height.target = CARD_DRAG_Y + 0.2;
-		setTimeout(() => (height.target = CARD_DRAG_Y), 150);
 	}
 
 	// Defer the lift until the pointer actually travels: a plain click used to
@@ -172,9 +179,9 @@
 	$effect(() => cancelPendingDrag);
 
 	function handleDragStart(e: IntersectionEvent<PointerEvent>) {
-		if (e.nativeEvent.button !== 0) return; // right-click is contextmenu, not drag
-		// keep OrbitControls from rotating during the pre-threshold pixels
-		e.stopImmediatePropagation();
+		// claims the pointerdown for the topmost card in a pile — see
+		// claimPointerDown — so the rest of the stack never sees this event
+		if (!claimPointerDown(e)) return;
 		pendingDrag = { x: e.nativeEvent.clientX, y: e.nativeEvent.clientY };
 		window.addEventListener('pointermove', onPendingMove);
 		window.addEventListener('pointerup', cancelPendingDrag);

--- a/src/lib/Piece.svelte
+++ b/src/lib/Piece.svelte
@@ -7,6 +7,7 @@
 	import { gameStore } from './store/game/gameStore.svelte';
 	import { gameActions } from './store/game/actions';
 	import { resolveCardImage, sheetRefCache } from '$lib/packs';
+	import { claimPointerDown } from '$lib/utils/single-hit-pointerdown';
 	import {
 		PIECE_DEFAULT_RADIUS,
 		PIECE_DRAG_Y,
@@ -33,9 +34,11 @@
 		precision: 0.0001
 	});
 
+	// Entirely derived from this piece's own drag ownership and store state —
+	// see the matching comment on Card's height effect — so a piece that
+	// starts a drag it never actually wins can't stay stuck airborne.
 	$effect(() => {
-		if (isDragging) return;
-		height.target = piece?.position?.[1] ?? REST_Y;
+		height.target = isDragging ? PIECE_DRAG_Y : (piece?.position?.[1] ?? REST_Y);
 	});
 
 	// Horizontal glide: remote drags only arrive every ~200ms (network throttle),
@@ -67,7 +70,6 @@
 	function liftIntoDrag() {
 		// origin (pre-lift store position) is what Esc returns the piece to
 		dragStart(id, position[1], piece?.position as [number, number, number] | undefined);
-		height.target = PIECE_DRAG_Y;
 	}
 
 	// Counters defer the lift until the pointer actually travels, so a plain
@@ -90,13 +92,13 @@
 	$effect(() => cancelPendingDrag);
 
 	function handlePointerDown(e: IntersectionEvent<PointerEvent>) {
-		if (e.nativeEvent.button !== 0) return; // right-click is contextmenu, not drag
+		// claims the pointerdown for the topmost piece in a pile — see
+		// claimPointerDown — so the rest of the stack never sees this event
+		if (!claimPointerDown(e)) return;
 		if (kind !== 'counter') {
 			liftIntoDrag();
 			return;
 		}
-		// keep OrbitControls from rotating during the pre-threshold pixels
-		e.stopImmediatePropagation();
 		dragMoved = false;
 		pendingDrag = { x: e.nativeEvent.clientX, y: e.nativeEvent.clientY };
 		window.addEventListener('pointermove', onPendingMove);

--- a/src/lib/__tests__/single-hit-pointerdown.test.ts
+++ b/src/lib/__tests__/single-hit-pointerdown.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Grabbing an ungrouped pile used to lift every card the ray intersected,
+ * because Threlte's interactivity() dispatches pointerdown to every hit,
+ * near → far, unless a handler stops propagation (see setupInteractivity in
+ * @threlte/extras: it loops `for (const hit of hits)` and only `break`s once
+ * a handler calls `stopPropagation()`). Card and Piece pointerdown handlers
+ * both route through `claimPointerDown` for this reason.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+import type { IntersectionEvent } from '@threlte/extras';
+import { dragActions, dragStore } from '../store/dragStore.svelte';
+import { claimPointerDown } from '../utils/single-hit-pointerdown';
+
+type FakeEvent = IntersectionEvent<PointerEvent>;
+
+function fakeEvent(button: number, onStop: () => void): FakeEvent {
+	return {
+		nativeEvent: { button } as PointerEvent,
+		stopPropagation: onStop,
+		stopImmediatePropagation: () => {}
+	} as unknown as FakeEvent;
+}
+
+/**
+ * Mirrors @threlte/extras's real dispatch loop: hits are visited near → far
+ * and the loop breaks as soon as a handler's stopPropagation() is called,
+ * so farther hits never see the event.
+ */
+function dispatchPointerDown(hits: { onpointerdown: (e: FakeEvent) => void }[], button: number) {
+	let stopped = false;
+	for (const hit of hits) {
+		if (stopped) break;
+		hit.onpointerdown(
+			fakeEvent(button, () => {
+				stopped = true;
+			})
+		);
+	}
+}
+
+describe('claimPointerDown', () => {
+	beforeEach(() => dragActions.reset());
+
+	it('claims a left-click and stops it from reaching farther hits', () => {
+		let stopped = false;
+		const claimed = claimPointerDown(
+			fakeEvent(0, () => {
+				stopped = true;
+			})
+		);
+
+		expect(claimed).toBe(true);
+		expect(stopped).toBe(true);
+	});
+
+	it('lets a right-click pass through unclaimed', () => {
+		let stopped = false;
+		const claimed = claimPointerDown(
+			fakeEvent(2, () => {
+				stopped = true;
+			})
+		);
+
+		expect(claimed).toBe(false);
+		expect(stopped).toBe(false);
+	});
+
+	it('two overlapping cards + one pointerdown starts exactly one drag', () => {
+		const dragStartSpy = vi.fn();
+		const cardHandler = (cardId: string) => (e: FakeEvent) => {
+			if (!claimPointerDown(e)) return;
+			dragStartSpy(cardId);
+			dragActions.start(cardId, 2);
+		};
+
+		// near → far, same order Threlte's raycaster would report the hits in
+		const topCard = { onpointerdown: cardHandler('card:top') };
+		const bottomCard = { onpointerdown: cardHandler('card:bottom') };
+
+		dispatchPointerDown([topCard, bottomCard], 0);
+
+		expect(dragStartSpy).toHaveBeenCalledTimes(1);
+		expect(dragStartSpy).toHaveBeenCalledWith('card:top');
+		expect(get(dragStore).isDragging).toBe('card:top');
+	});
+});

--- a/src/lib/utils/single-hit-pointerdown.ts
+++ b/src/lib/utils/single-hit-pointerdown.ts
@@ -1,0 +1,22 @@
+import type { IntersectionEvent } from '@threlte/extras';
+
+/**
+ * Threlte's interactivity() dispatches a pointerdown to every mesh the ray
+ * intersects, near → far, not just the closest — unless a handler stops
+ * propagation. Card and Piece pointerdown handlers call this first so an
+ * overlapping pile only ever starts a drag on the topmost hit, matching
+ * what the hover highlight shows.
+ *
+ * stopPropagation() halts Threlte's own dispatch to farther hits;
+ * stopImmediatePropagation() additionally halts the native DOM event so
+ * OrbitControls doesn't rotate during the pre-threshold pixels.
+ *
+ * Returns false for non-primary buttons (right-click is contextmenu, not
+ * drag) without claiming the event, so farther hits still see it.
+ */
+export function claimPointerDown(e: IntersectionEvent<PointerEvent>): boolean {
+	if (e.nativeEvent.button !== 0) return false;
+	e.stopPropagation();
+	e.stopImmediatePropagation();
+	return true;
+}


### PR DESCRIPTION
## Summary
- Threlte's `interactivity()` dispatches pointerdown to every mesh the ray intersects, near→far, unless a handler calls `stopPropagation()`. `Card.svelte`'s `handleDragStart` only called `stopImmediatePropagation()` (which just forwards to the native DOM event, for OrbitControls), never the intersection-level `stopPropagation()` — so a pointerdown over an overlapping loose pile started a pending drag on every card underneath the cursor, not just the top one. `Piece.svelte`'s non-counter path (pawns/tokens) had the same gap, worse: no propagation guard at all.
- Added a shared `claimPointerDown()` helper (`src/lib/utils/single-hit-pointerdown.ts`) used by both `Card.svelte` and `Piece.svelte`: it calls `stopPropagation()` to stop Threlte's dispatch to farther hits, and `stopImmediatePropagation()` to keep OrbitControls from rotating during the pre-threshold pixels. `Deck.svelte` already did the equivalent (`e.stopPropagation()`) and needed no change.
- Made card/piece height fully declarative: `height.target` is now only ever written from inside the reactive effect keyed on that entity's own `isDragging`, never imperatively from the lift handler. Previously `liftIntoDrag()` imperatively bumped `height.target`, and a card that started a drag it never actually won (because another card's `dragStart` overwrote the store's single `isDragging` id) had no reactive dependency change left to re-run the settle effect — it was permanently stuck airborne. Now, since nothing writes height outside the effect, a losing card's `isDragging` simply stays `false` and nothing ever bumps it in the first place — and even if a future handler misfires, there's no imperative write left to leave orphaned.

## Acceptance criteria
1. Pointerdown on an ungrouped pile starts a drag on exactly one card (the topmost intersection) — fixed via `claimPointerDown`'s `stopPropagation()`.
2. No card is ever left above `CARD_REST_Y` after a drag ends or is cancelled (pointerup off-table, pointercancel included) — height is now fully derived from `isDragging`/store state; `TableScene`'s window-level `pointerup`/`pointercancel` listeners already funnel through `commitActiveDrag`/`dragEnd` unconditionally.
3. Deck draw and piece drag keep working; the same guard is applied to `Piece.svelte`'s non-counter path.
4. Resting height is declarative — see above.
5. Unit test added: `src/lib/__tests__/single-hit-pointerdown.test.ts` covers two overlapping cards + one pointerdown → exactly one `dragStart` call (mirrors Threlte's real near→far dispatch-with-break loop, confirmed against the installed `@threlte/extras@9.21.0` source).

## Test plan
- [x] `bun run test` — 295 tests pass (including 3 new)
- [x] `bun run lint` — no new errors on touched files (pre-existing baseline prettier/eslint issues elsewhere untouched)
- [x] `bun run check` — 0 errors (pre-existing `state_referenced_locally` warnings unchanged, confirmed via git stash comparison)
- [x] `bun run build` — succeeds

Task: tableplace-74
Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaEYPxkvVqgQuw5k2mJj7h