### PR TITLE
tableplace-75: /create — bulk-add cards from a sprite sheet, unique card codes

### DIFF
--- a/docs/packs.md
+++ b/docs/packs.md
@@ -70,7 +70,7 @@ Field notes:
 
 - **`id`** — stable identity for the pack (`standard-52`, `imported:<slug>`…).
 - **`scope`** — `'table'` (the shared game: board, communal decks; loaded once per lobby by the host) or `'player'` (what one player brings, spawned per seat — a deck-builder export is a player pack). See SPEC.md §4d.
-- **`decks[].slot`** — stable id within the pack; **`cards[].code`** — stable id within the deck. Both survive re-exports, so external tools can reference cards as `<pack>/<slot>/<code>`.
+- **`decks[].slot`** — stable id within the pack; **`cards[].code`** — stable id within the deck, and **unique within it**: spawning builds table entity ids as `card:<owner>:<slot>-<code>`, so two cards sharing a code collapse into one entity. /create allocates every code through `allocateCode` (`src/routes/create/bulk-sheet.ts`) — a taken `AS` becomes `AS-2`, then `AS-3`. Both survive re-exports, so external tools can reference cards as `<pack>/<slot>/<code>`.
 - **`pieces`** (optional) — tokens, pawns, and counters: `{ kind: 'token'|'pawn'|'counter', name, color?, imageUrl?, radius?, maxValue?, position: [x, z] }`.
 - **`overlays`** (optional) — board/map images: `{ imageUrl, ratio, scale }` (`ratio` = width/height).
 - **`source`** (optional) — provenance stamp written by converters (currently only `"tts"`). Native packs omit it.
@@ -93,6 +93,8 @@ Card `face`/`back` (and piece/overlay `imageUrl`) are **refs** — tiny strings 
 | `back`  | boolean | no       | if true, fall back to the generated card back instead of a named placeholder |
 
 Resolution is asynchronous and failure is non-fatal — an unreachable sheet falls back to a placeholder rather than breaking the table. Mostly produced by the TTS importer; prefer plain URLs when authoring by hand.
+
+Two producers in this repo emit these, and both follow the table above: the TTS importer, and /create's "Bulk add from sheet" pane, which enumerates a whole `cols × rows` grid into one card per cell (`src/routes/create/bulk-sheet.ts`). Excluding a cell in that pane simply omits its card — `cols`/`rows` stay the sheet's real dimensions and the remaining `index` values keep their absolute positions, because an index is only meaningful against the grid it was cut from. A 1×1 grid is not written as a `sheet:` ref at all; it degrades to the plain-URL case below.
 
 **`https://…`** — a plain image URL, creator-hosted (imgur, GitHub raw, your own site), used verbatim. table.place hosts no assets, so it must be publicly reachable, CORS-readable and hotlinkable. Any ref matching neither prefix above is treated as a literal URL.
 

--- a/src/lib/tts/to-pack.ts
+++ b/src/lib/tts/to-pack.ts
@@ -26,7 +26,7 @@ function slugify(name: string, fallback: string): string {
 }
 
 /** Whole-image cells become plain URLs; real sheet cells become `sheet:` refs. */
-function cellToRef(cell: SheetCell, opts: { name?: string; back?: boolean } = {}): string {
+export function cellToRef(cell: SheetCell, opts: { name?: string; back?: boolean } = {}): string {
 	if (cell.cols === 1 && cell.rows === 1) return cell.url;
 	return makeSheetRef({ ...cell, ...opts });
 }

--- a/src/routes/create/BulkSheet.svelte
+++ b/src/routes/create/BulkSheet.svelte
@@ -1,0 +1,225 @@
+<script lang="ts">
+	import { Button, Element, Folder, Pane, Stepper, Text, Textarea } from 'svelte-tweakpane-ui';
+	import toast from 'svelte-french-toast';
+	import { sliceCell } from '$lib/tts/slice';
+	import type { PackCardDef } from '$lib/packs/types';
+	import { SHEET_DEFAULTS } from './face-ref';
+	import {
+		applyBulkNames,
+		buildBulkCards,
+		enumerateCells,
+		planCodes,
+		BULK_CODE_PREFIX,
+		BULK_MAX_CELLS,
+		type BulkCell
+	} from './bulk-sheet';
+
+	/**
+	 * Bulk add: define a sheet's grid once, then add every cell as a card.
+	 *
+	 * The pane owns the grid it loaded (`loaded`), not the fields above it —
+	 * retyping the columns doesn't silently re-index the thumbnails you're
+	 * looking at, you press "Load grid" again. Slicing is preview only: a cell
+	 * that can't be read is still a valid ref, so it stays addable and the
+	 * table falls back exactly as it would at play time.
+	 */
+	let {
+		deckSlot,
+		takenCodes = [],
+		onadd
+	}: {
+		/** slot of the deck the cards land in, for the button's label */
+		deckSlot?: string;
+		/** codes already used in that deck — the batch de-duplicates against them */
+		takenCodes?: string[];
+		onadd: (cards: PackCardDef[]) => void;
+	} = $props();
+
+	const NAMES_PLACEHOLDER =
+		'One name per line, top-left first.\nCells you type into keep their own name.';
+
+	let url = $state('');
+	let cols = $state(SHEET_DEFAULTS.cols);
+	let rows = $state(SHEET_DEFAULTS.rows);
+	let codePrefix = $state(BULK_CODE_PREFIX);
+	let namesText = $state('');
+	let rangeFrom = $state(0);
+	let rangeTo = $state(0);
+
+	/** the grid as it was loaded — the source of truth for every built ref */
+	let loaded: { url: string; cols: number; rows: number } | null = $state(null);
+	let cells: BulkCell[] = $state([]);
+	/** bumped per load so a slower previous load can't write over a newer grid */
+	let generation = 0;
+
+	const resolved = $derived(applyBulkNames(cells, namesText));
+	const planned = $derived(planCodes(resolved, { prefix: codePrefix, taken: takenCodes }));
+	const included = $derived(resolved.filter((cell) => cell.include).length);
+
+	async function loadGrid() {
+		const sheetUrl = url.trim();
+		if (!sheetUrl) return toast.error('Paste a sheet URL first');
+
+		const c = Math.max(1, Math.round(cols));
+		const r = Math.max(1, Math.round(rows));
+		if (c * r > BULK_MAX_CELLS) {
+			return toast.error(`${c}×${r} is ${c * r} cells — ${BULK_MAX_CELLS} is the most at once`);
+		}
+
+		loaded = { url: sheetUrl, cols: c, rows: r };
+		cells = enumerateCells(c, r);
+		rangeFrom = 0;
+		rangeTo = c * r - 1;
+
+		// a few at a time: the memory + IndexedDB caches make a re-load instant,
+		// but a cold 70-cell sheet should not open 70 canvases in one frame
+		const gen = ++generation;
+		let cursor = 0;
+		let failed = 0;
+		const worker = async () => {
+			while (cursor < c * r) {
+				const index = cursor++;
+				const thumb = await sliceCell({ url: sheetUrl, cols: c, rows: r, index });
+				if (gen !== generation) return;
+				cells[index].thumb = thumb;
+				cells[index].loading = false;
+				if (!thumb) failed++;
+			}
+		};
+		await Promise.all(Array.from({ length: Math.min(8, c * r) }, worker));
+		if (gen !== generation) return;
+
+		if (failed > 0) {
+			toast(
+				`${failed} of ${c * r} cells couldn't be previewed — the host blocks canvas reads, or ` +
+					`the link is dead. They're still addable; the table falls back the same way.`,
+				{ duration: 7000 }
+			);
+		}
+	}
+
+	function setAll(include: boolean) {
+		for (const cell of cells) cell.include = include;
+	}
+
+	/** include exactly `rangeFrom … rangeTo` — the fast way past a dead last row */
+	function includeRangeOnly() {
+		const from = Math.min(rangeFrom, rangeTo);
+		const to = Math.max(rangeFrom, rangeTo);
+		for (const cell of cells) cell.include = cell.index >= from && cell.index <= to;
+	}
+
+	function addCards() {
+		if (!loaded) return toast.error('Load the grid first');
+		const cards = buildBulkCards({
+			...loaded,
+			cells: resolved,
+			prefix: codePrefix,
+			taken: takenCodes
+		});
+		if (!cards.length) return toast.error('No cells are included');
+		onadd(cards);
+	}
+</script>
+
+<Pane
+	position="draggable"
+	title="Bulk add from sheet"
+	expanded={true}
+	y={8}
+	x={680}
+	width={340}
+	localStoreId="create-pane-bulk"
+>
+	<Text label="Sheet URL" bind:value={url} />
+	<Stepper label="Columns" bind:value={cols} min={1} step={1} />
+	<Stepper label="Rows" bind:value={rows} min={1} step={1} />
+	<Button title="Load grid" on:click={loadGrid} />
+
+	<!--
+		One `Element` blade, always mounted, its contents driven by expressions:
+		an `{#if}` that swaps one blade for another tears the pane down (tweakpane
+		owns that DOM, Svelte doesn't). Adding blades — the folders below — is
+		fine; replacing them is not.
+	-->
+	<Element>
+		<div class={cells.length ? 'hidden' : 'p-1 font-sans text-[11px] leading-snug text-white/50'}>
+			Paste a sprite sheet, say how many columns and rows it has, and every cell becomes a card —
+			named in bulk, one per line. Cells that can't be previewed still import.
+		</div>
+		<div class={cells.length ? 'max-h-64 overflow-y-auto rounded bg-black/25 p-1' : 'hidden'}>
+			<div class="grid gap-1" style="grid-template-columns: repeat(auto-fill, minmax(84px, 1fr));">
+				{#each cells as cell, i (cell.index)}
+					<div
+						class="rounded border p-1 font-sans {cell.include
+							? 'border-white/25 bg-white/5'
+							: 'border-transparent opacity-40'}"
+					>
+						<label class="relative block cursor-pointer">
+							<input
+								type="checkbox"
+								class="absolute top-1 right-1 z-10 h-3 w-3 accent-emerald-400"
+								data-testid="bulk-include-{cell.index}"
+								bind:checked={cell.include}
+							/>
+							<!-- the thumb is a background image so the tile keeps its shape
+									 whether or not the cell could be sliced -->
+
+							<div
+								class="flex aspect-[3/4] w-full items-center justify-center rounded bg-white/10 bg-cover bg-center px-1 text-center text-[9px] leading-tight text-white/50"
+								data-testid="bulk-thumb-{cell.index}"
+								style={cell.thumb ? `background-image: url("${cell.thumb}")` : ''}
+							>
+								{cell.thumb ? '' : cell.loading ? 'slicing…' : 'no preview'}
+							</div>
+							<span
+								class="absolute top-0 left-0 rounded-br bg-black/70 px-1 font-mono text-[9px] text-white/80"
+								>{cell.index}</span
+							>
+						</label>
+						<input
+							class="mt-1 w-full rounded bg-black/40 px-1 py-0.5 font-mono text-[10px] text-white/90"
+							placeholder="code"
+							data-testid="bulk-code-{cell.index}"
+							value={planned.get(cell.index) ?? ''}
+							oninput={(event) => {
+								cell.code = event.currentTarget.value;
+								cell.codeTouched = true;
+							}}
+						/>
+						<input
+							class="mt-0.5 w-full rounded bg-black/40 px-1 py-0.5 text-[10px] text-white/90"
+							placeholder="name"
+							data-testid="bulk-name-{cell.index}"
+							value={resolved[i]?.name ?? ''}
+							oninput={(event) => {
+								cell.name = event.currentTarget.value;
+								cell.nameTouched = true;
+							}}
+						/>
+					</div>
+				{/each}
+			</div>
+		</div>
+	</Element>
+
+	{#if cells.length}
+		<Folder title="Include ({included} of {cells.length})" expanded={true}>
+			<Button title="Include all" on:click={() => setAll(true)} />
+			<Button title="Include none" on:click={() => setAll(false)} />
+			<Stepper label="From cell" bind:value={rangeFrom} min={0} step={1} />
+			<Stepper label="To cell" bind:value={rangeTo} min={0} step={1} />
+			<Button title="Include only this range" on:click={includeRangeOnly} />
+		</Folder>
+
+		<Folder title="Names & codes" expanded={true}>
+			<Textarea bind:value={namesText} rows={5} placeholder={NAMES_PLACEHOLDER} />
+			<Text label="Code prefix" bind:value={codePrefix} />
+		</Folder>
+
+		<Button
+			title="Add {included} card{included === 1 ? '' : 's'} to {deckSlot ?? '(no deck)'}"
+			on:click={addCards}
+		/>
+	{/if}
+</Pane>

--- a/src/routes/create/CreatePane.svelte
+++ b/src/routes/create/CreatePane.svelte
@@ -31,6 +31,9 @@
 		type EditorPack
 	} from './normalize';
 	import FaceRef from './FaceRef.svelte';
+	import BulkSheet from './BulkSheet.svelte';
+	import { allocateCode } from './bulk-sheet';
+	import type { PackCardDef } from '$lib/packs/types';
 	import toast from 'svelte-french-toast';
 
 	/** Everything the /create preview spawns is owned by this placeholder id */
@@ -124,13 +127,20 @@
 		deckCursor = Math.max(0, deckIndex - 1);
 	}
 
+	/**
+	 * Codes in play in the selected deck. `code` is the entity-id component
+	 * (`card:<owner>:<slot>-<code>`), so a repeat collapses two cards into one
+	 * table entity — every code minted below is allocated against this set.
+	 */
+	const takenCodes = $derived(deck?.cards.map((c) => c.code) ?? []);
+
 	function addCard() {
 		if (!deck) return toast.error('Add a deck first');
 		// the deck's back, not an empty ref: an empty face resolves to '' and
 		// renders nothing, so a brand new card would be invisible on the table
 		// until someone found the face controls
 		deck.cards.push({
-			code: `card-${deck.cards.length}`,
+			code: allocateCode(`card-${deck.cards.length}`, new Set(takenCodes)),
 			name: '',
 			face: deck.back || CARD_BACK_DEFAULT
 		});
@@ -139,8 +149,20 @@
 
 	function duplicateCard() {
 		if (!deck || !card) return;
-		deck.cards.splice(cardIndex + 1, 0, { ...card, code: `${card.code}-copy` });
+		// `AS` duplicated twice gives `AS-2` then `AS-3`, never two of either
+		deck.cards.splice(cardIndex + 1, 0, {
+			...card,
+			code: allocateCode(card.code, new Set(takenCodes))
+		});
 		cardCursor = cardIndex + 1;
+	}
+
+	/** Append a bulk-sheet batch to the selected deck (codes already allocated). */
+	function addBulkCards(cards: PackCardDef[]) {
+		if (!deck) return toast.error('Add a deck first');
+		deck.cards.push(...cards.map((c) => ({ ...c, name: c.name ?? '' })));
+		cardCursor = deck.cards.length - 1;
+		toast(`Added ${cards.length} card${cards.length === 1 ? '' : 's'} to ${deck.slot}`);
 	}
 
 	function removeCard() {
@@ -498,3 +520,10 @@
 		</Element>
 	</Folder>
 </Pane>
+
+<!--
+	A fifth pane rather than a folder under "Decks & Cards": the grid it shows
+	is wider than a card's controls, and burying it would push Save / Export
+	back under a section (#71 §4).
+-->
+<BulkSheet deckSlot={deck?.slot} takenCodes={[...takenCodes]} onadd={addBulkCards} />

--- a/src/routes/create/__tests__/BulkSheet.test.ts
+++ b/src/routes/create/__tests__/BulkSheet.test.ts
@@ -1,0 +1,164 @@
+/**
+ * The bulk pane itself, driven through its real controls with `sliceCell`
+ * mocked — the enumeration is tested pure in bulk-sheet.test.ts, this is
+ * about the wiring: load a grid, see thumbnails (and a placeholder where the
+ * sheet can't be read), exclude a cell, and hand a batch of cards back.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+import BulkSheet from '../BulkSheet.svelte';
+import { parseFaceRef } from '../face-ref';
+import type { PackCardDef } from '$lib/packs/types';
+
+/** cell 3 is the CORS-tainted one: `sliceCell` resolves null, not a throw */
+vi.mock('$lib/tts/slice', () => ({
+	sliceCell: vi.fn(async ({ index }: { index: number }) =>
+		index === 3 ? null : `data:image/png;base64,cell${index}`
+	)
+}));
+
+// the draggable Pane observes its own size; jsdom has no ResizeObserver
+globalThis.ResizeObserver ??= class {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+} as unknown as typeof ResizeObserver;
+
+const SHEET = 'https://example.test/sheet.png';
+
+const settle = (ms = 60) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const button = (container: HTMLElement, label: string) =>
+	[...container.querySelectorAll('button')].find((b) => b.textContent?.includes(label));
+
+const input = (container: HTMLElement, label: string) =>
+	[...container.querySelectorAll('.tp-lblv_l')]
+		.find((el) => el.textContent === label)
+		?.parentElement?.querySelector('input');
+
+function type(element: HTMLInputElement, value: string) {
+	element.value = value;
+	element.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+function typeInto(element: HTMLInputElement | HTMLTextAreaElement, value: string) {
+	element.value = value;
+	element.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+/** paste a sheet and load a cols×rows grid, thumbnails and all */
+async function loadGrid(cols = 3, rows = 2, props: Record<string, unknown> = {}) {
+	const added: PackCardDef[][] = [];
+	const { container } = render(BulkSheet, {
+		props: { deckSlot: 'main', onadd: (cards: PackCardDef[]) => added.push(cards), ...props }
+	});
+	await settle();
+
+	// one at a time: a tweakpane blade commits on the next flush, and two
+	// changes dispatched back-to-back lose the first
+	type(input(container, 'Sheet URL')!, SHEET);
+	await settle();
+	type(input(container, 'Columns')!, String(cols));
+	await settle();
+	type(input(container, 'Rows')!, String(rows));
+	await settle();
+	button(container, 'Load grid')!.click();
+	await settle(150);
+
+	return { container, added };
+}
+
+const tile = (container: HTMLElement, kind: 'include' | 'code' | 'name', index: number) =>
+	container.querySelector<HTMLInputElement>(`[data-testid="bulk-${kind}-${index}"]`)!;
+
+describe('BulkSheet', () => {
+	it('turns a grid into one card per cell, row-major', async () => {
+		const { container, added } = await loadGrid();
+
+		expect(container.querySelectorAll('[data-testid^="bulk-include-"]')).toHaveLength(6);
+		button(container, 'Add 6 cards to main')!.click();
+
+		expect(added).toHaveLength(1);
+		expect(added[0].map((c) => parseFaceRef(c.face).sheetIndex)).toEqual([0, 1, 2, 3, 4, 5]);
+		expect(added[0].every((c) => parseFaceRef(c.face).sheetUrl === SHEET)).toBe(true);
+		expect(added[0][0]).toMatchObject({ code: 'card-1' });
+	});
+
+	it('shows a thumbnail per cell, and a placeholder where the slice failed', async () => {
+		const { container } = await loadGrid();
+
+		const thumbs = [...container.querySelectorAll('[data-testid^="bulk-thumb-"]')];
+		expect(thumbs).toHaveLength(6);
+		expect(thumbs[0].getAttribute('style')).toContain('data:image/png;base64,cell0');
+		// cell 3 came back null — a placeholder tile, not a missing one
+		expect(thumbs[3].getAttribute('style')).toBe('');
+		expect(thumbs[3].textContent?.trim()).toBe('no preview');
+	});
+
+	it('still adds a cell that could not be sliced', async () => {
+		const { container, added } = await loadGrid();
+		button(container, 'Add 6 cards')!.click();
+
+		expect(added[0].map((c) => parseFaceRef(c.face).sheetIndex)).toContain(3);
+	});
+
+	it('excludes a cell before adding', async () => {
+		const { container, added } = await loadGrid();
+
+		tile(container, 'include', 4).click();
+		await settle();
+		button(container, 'Add 5 cards')!.click();
+
+		expect(added[0].map((c) => parseFaceRef(c.face).sheetIndex)).toEqual([0, 1, 2, 3, 5]);
+	});
+
+	it('includes only a range, so a dead trailing row is one gesture', async () => {
+		const { container, added } = await loadGrid();
+
+		type(input(container, 'To cell')!, '3');
+		await settle();
+		button(container, 'Include only this range')!.click();
+		await settle();
+		button(container, 'Add 4 cards')!.click();
+
+		expect(added[0].map((c) => parseFaceRef(c.face).sheetIndex)).toEqual([0, 1, 2, 3]);
+	});
+
+	it('names cells in bulk and lets a per-cell edit win', async () => {
+		const { container, added } = await loadGrid();
+
+		const names = container.querySelector('textarea')!;
+		typeInto(names, 'Ace\nKing\nQueen');
+		await settle();
+		expect(tile(container, 'name', 1).value).toBe('King');
+		expect(tile(container, 'code', 1).value).toBe('king');
+
+		typeInto(tile(container, 'name', 1), 'Hand-typed');
+		await settle();
+		button(container, 'Add 6 cards')!.click();
+
+		expect(added[0].map((c) => c.name)).toEqual([
+			'Ace',
+			'Hand-typed',
+			'Queen',
+			undefined,
+			undefined,
+			undefined
+		]);
+		expect(added[0].map((c) => c.code)).toEqual([
+			'ace',
+			'hand-typed',
+			'queen',
+			'card-4',
+			'card-5',
+			'card-6'
+		]);
+	});
+
+	it('never reuses a code the deck already has', async () => {
+		const { container, added } = await loadGrid(2, 1, { takenCodes: ['card-1'] });
+
+		button(container, 'Add 2 cards')!.click();
+		expect(added[0].map((c) => c.code)).toEqual(['card-2', 'card-3']);
+	});
+});

--- a/src/routes/create/__tests__/CreatePane.test.ts
+++ b/src/routes/create/__tests__/CreatePane.test.ts
@@ -33,6 +33,17 @@ const input = (container: HTMLElement, label: string) =>
 		.find((el) => el.textContent === label)
 		?.parentElement?.querySelector('input');
 
+/**
+ * The card picker's options, which are labelled `<index>: <code>` — the deck
+ * picker is labelled the same way and comes first, so this takes the second.
+ */
+const cardCodes = (container: HTMLElement) => {
+	const select = [...container.querySelectorAll('select')].filter((s) =>
+		[...s.options].some((o) => /^\d+: /.test(o.textContent ?? ''))
+	)[1];
+	return [...(select?.options ?? [])].map((o) => (o.textContent ?? '').replace(/^\d+: /, ''));
+};
+
 /** every face-scheme picker on screen, in DOM order (deck back, then card face) */
 const schemePickers = (container: HTMLElement) =>
 	[...container.querySelectorAll('select')].filter((s) =>
@@ -139,6 +150,62 @@ describe('CreatePane', () => {
 		expect(cards).toHaveLength(2);
 		// starter deck's back — a blank face resolves to '' and shows nothing
 		expect(cards[1].faceImageUrl).toBe(CARD_BACK_DEFAULT);
+	});
+
+	it('gives every card a distinct code — duplicating twice never repeats one', async () => {
+		const container = await mount();
+		// the starter deck holds `AS`; `code` is the entity-id component, so a
+		// repeat would collapse two cards into one table entity
+		button(container, 'Duplicate card')!.click();
+		await settle();
+		expect(cardCodes(container)).toEqual(['AS', 'AS-2']);
+
+		// duplicate the original again: the copy can't be `AS-2` a second time
+		button(container, 'Duplicate card')!.click();
+		await settle();
+		expect(cardCodes(container)).toEqual(['AS', 'AS-2', 'AS-3']);
+	});
+
+	it('does not reuse a `card-N` code after a card is removed', async () => {
+		const container = await mount();
+		button(container, 'Add card')!.click(); // card-1
+		await settle();
+		button(container, 'Add card')!.click(); // card-2
+		await settle();
+		button(container, 'Remove card')!.click();
+		await settle();
+		// `card-${cards.length}` is `card-2` again here, and it's still in use —
+		// the old code minted the collision, this one steps past it
+		button(container, 'Add card')!.click();
+		await settle();
+
+		const codes = cardCodes(container);
+		expect(codes).toHaveLength(3);
+		expect(new Set(codes).size).toBe(3);
+	});
+
+	it('bulk-adds a sheet grid into the selected deck', async () => {
+		const container = await mount();
+
+		// the bulk pane's own controls: URL, columns, rows, then Load grid
+		type(input(container, 'Sheet URL')!, 'https://example.test/sheet.png');
+		await settle();
+		type(input(container, 'Columns')!, '2');
+		await settle();
+		type(input(container, 'Rows')!, '2');
+		await settle();
+		button(container, 'Load grid')!.click();
+		await settle();
+
+		button(container, 'Add 4 cards to main')!.click();
+		await settlePreview();
+
+		const cards = get(gameStore).decks?.['deck:preview:main'].cards ?? [];
+		expect(cards).toHaveLength(5); // the starter Ace plus the grid
+		expect(
+			cards.slice(1).map((c) => JSON.parse(c.faceImageUrl!.slice('sheet:'.length)).index)
+		).toEqual([0, 1, 2, 3]);
+		expect(cardCodes(container)).toEqual(['AS', 'card-1', 'card-2', 'card-3', 'card-4']);
 	});
 
 	it('sets the selected card face inline, without a separate builder', async () => {

--- a/src/routes/create/__tests__/bulk-sheet.test.ts
+++ b/src/routes/create/__tests__/bulk-sheet.test.ts
@@ -1,0 +1,229 @@
+/**
+ * The bulk sprite-sheet path, without a network or a canvas: enumerating a
+ * grid, excluding cells, allocating codes, and the ref round-trip that says a
+ * generated card lands on the cell the grid showed.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+	allocateCode,
+	applyBulkNames,
+	buildBulkCards,
+	enumerateCells,
+	planCodes,
+	slugifyCode,
+	type BulkCell
+} from '../bulk-sheet';
+import { parseFaceRef } from '../face-ref';
+import { parsePackFile, serializePackFile } from '$lib/packs/file';
+import { CARD_BACK_DEFAULT } from '$lib/packs/standard52';
+
+const SHEET = 'https://example.test/sheet.png';
+
+/** the grid as the pane would hand it over, with names filled per cell */
+function cellsWith(cols: number, rows: number, edits: Partial<BulkCell>[] = []): BulkCell[] {
+	const cells = enumerateCells(cols, rows);
+	edits.forEach((edit, i) => Object.assign(cells[i], edit));
+	return cells;
+}
+
+describe('enumerateCells', () => {
+	it('is row-major with index 0 at the top-left', () => {
+		const cells = enumerateCells(3, 2);
+		expect(cells.map((c) => c.index)).toEqual([0, 1, 2, 3, 4, 5]);
+		expect(cells[0]).toMatchObject({ index: 0, row: 0, col: 0 });
+		expect(cells[2]).toMatchObject({ index: 2, row: 0, col: 2 }); // end of row 0
+		expect(cells[3]).toMatchObject({ index: 3, row: 1, col: 0 }); // start of row 1
+		expect(cells[5]).toMatchObject({ index: 5, row: 1, col: 2 });
+	});
+
+	it('includes every cell by default and clamps a nonsense grid to 1×1', () => {
+		expect(enumerateCells(4, 4).every((c) => c.include)).toBe(true);
+		expect(enumerateCells(0, -3)).toHaveLength(1);
+	});
+});
+
+describe('allocateCode', () => {
+	it('keeps a free code and suffixes a taken one', () => {
+		expect(allocateCode('AS', new Set())).toBe('AS');
+		expect(allocateCode('AS', new Set(['AS']))).toBe('AS-2');
+	});
+
+	it('bumps a numeric suffix instead of stacking one — AS, AS-2, AS-3', () => {
+		const taken = new Set(['AS']);
+		const first = allocateCode('AS', taken);
+		taken.add(first);
+		const second = allocateCode('AS', taken);
+		expect([first, second]).toEqual(['AS-2', 'AS-3']);
+
+		// duplicating the copy, not the original, lands in the same series
+		taken.add(second);
+		expect(allocateCode('AS-2', taken)).toBe('AS-4');
+	});
+
+	it('fixes the `card-N` collision a removal used to create', () => {
+		// two cards left after removing the middle one: card-0, card-2
+		const taken = new Set(['card-0', 'card-2']);
+		expect(allocateCode('card-2', taken)).toBe('card-3'); // addCard's preferred code
+	});
+
+	it('never returns an empty code', () => {
+		expect(allocateCode('   ', new Set())).toBe('card');
+	});
+});
+
+describe('slugifyCode', () => {
+	it('slugifies names and gives up on codeless ones', () => {
+		expect(slugifyCode('Ace of Spades')).toBe('ace-of-spades');
+		expect(slugifyCode('  —  ')).toBe('');
+	});
+});
+
+describe('applyBulkNames', () => {
+	it('applies one name per line, row-major, to the included cells', () => {
+		const cells = cellsWith(2, 2);
+		const named = applyBulkNames(cells, 'Ace\nKing\nQueen\nJack');
+		expect(named.map((c) => c.name)).toEqual(['Ace', 'King', 'Queen', 'Jack']);
+	});
+
+	it('skips excluded cells so the list lines up with what the grid shows', () => {
+		const cells = cellsWith(2, 2, [{}, { include: false }]);
+		expect(applyBulkNames(cells, 'Ace\nKing\nQueen').map((c) => c.name)).toEqual([
+			'Ace',
+			'', // excluded — consumed no line
+			'King',
+			'Queen'
+		]);
+	});
+
+	it('lets a per-cell edit win, without shifting the rest of the list', () => {
+		const cells = cellsWith(2, 2, [{}, { name: 'Hand-typed', nameTouched: true }]);
+		expect(applyBulkNames(cells, 'Ace\nKing\nQueen\nJack').map((c) => c.name)).toEqual([
+			'Ace',
+			'Hand-typed',
+			'Queen',
+			'Jack'
+		]);
+	});
+
+	it('leaves cells past the end of the list unnamed', () => {
+		expect(applyBulkNames(cellsWith(2, 2), 'Ace').map((c) => c.name)).toEqual(['Ace', '', '', '']);
+	});
+});
+
+describe('planCodes', () => {
+	it('derives codes from names, deduping repeats within the batch', () => {
+		const cells = cellsWith(3, 1, [{ name: 'Ace' }, { name: 'Ace' }, { name: 'King' }]);
+		expect([...planCodes(cells).values()]).toEqual(['ace', 'ace-2', 'king']);
+	});
+
+	it('falls back to prefix + a running number when names are blank', () => {
+		const cells = cellsWith(2, 2, [{}, {}, { name: 'Named' }]);
+		expect([...planCodes(cells, { prefix: 'troop' }).values()]).toEqual([
+			'troop-1',
+			'troop-2',
+			'named',
+			'troop-4'
+		]);
+	});
+
+	it('numbers only the included cells and never plans an excluded one', () => {
+		const cells = cellsWith(2, 2, [{}, { include: false }]);
+		const planned = planCodes(cells);
+		expect(planned.has(1)).toBe(false);
+		expect([...planned.entries()]).toEqual([
+			[0, 'card-1'],
+			[2, 'card-2'],
+			[3, 'card-3']
+		]);
+	});
+
+	it('avoids the codes the deck already uses', () => {
+		const cells = cellsWith(2, 1, [{ name: 'Ace' }, { name: 'King' }]);
+		expect([...planCodes(cells, { taken: ['ace', 'ace-2'] }).values()]).toEqual(['ace-3', 'king']);
+	});
+
+	it('honours a hand-edited code over the derived one', () => {
+		const cells = cellsWith(2, 1, [
+			{ name: 'Ace', code: 'AS', codeTouched: true },
+			{ name: 'Ace' }
+		]);
+		expect([...planCodes(cells).values()]).toEqual(['AS', 'ace']);
+	});
+});
+
+describe('buildBulkCards', () => {
+	it('adds one card per cell, row-major, each pointing at its own cell', () => {
+		const cards = buildBulkCards({
+			url: SHEET,
+			cols: 3,
+			rows: 2,
+			cells: cellsWith(3, 2),
+			namesText: 'Ace\nKing\nQueen\nJack\nTen\nNine'
+		});
+
+		expect(cards).toHaveLength(6);
+		expect(cards.map((c) => c.name)).toEqual(['Ace', 'King', 'Queen', 'Jack', 'Ten', 'Nine']);
+		expect(cards.map((c) => parseFaceRef(c.face).sheetIndex)).toEqual([0, 1, 2, 3, 4, 5]);
+		expect(new Set(cards.map((c) => c.code)).size).toBe(6);
+	});
+
+	it('skips excluded cells — a partial last row is not a special case', () => {
+		const cells = cellsWith(3, 2, [{}, {}, {}, {}, { include: false }, { include: false }]);
+		const cards = buildBulkCards({ url: SHEET, cols: 3, rows: 2, cells });
+
+		expect(cards).toHaveLength(4);
+		expect(cards.map((c) => parseFaceRef(c.face).sheetIndex)).toEqual([0, 1, 2, 3]);
+		// the grid the refs describe is still the whole sheet, holes and all
+		expect(cards.every((c) => parseFaceRef(c.face).sheetRows === 2)).toBe(true);
+	});
+
+	it('keeps codes unique against the deck the cards are landing in', () => {
+		const cells = cellsWith(2, 1, [{ name: 'Ace' }, { name: 'Ace' }]);
+		const cards = buildBulkCards({ url: SHEET, cols: 2, rows: 1, cells, taken: ['ace'] });
+		expect(cards.map((c) => c.code)).toEqual(['ace-2', 'ace-3']);
+	});
+
+	it('degrades a 1×1 grid to a plain URL, like the TTS importer', () => {
+		const cards = buildBulkCards({ url: SHEET, cols: 1, rows: 1, cells: cellsWith(1, 1) });
+		expect(cards.map((c) => c.face)).toEqual([SHEET]);
+	});
+
+	it('ships no `name` key for an unnamed cell', () => {
+		const [card] = buildBulkCards({ url: SHEET, cols: 1, rows: 2, cells: cellsWith(1, 2) });
+		expect(card.name).toBeUndefined();
+		expect(card.code).toBe('card-1');
+	});
+});
+
+describe('exported bulk cards survive a pack round-trip', () => {
+	it('re-parses every generated ref back to the same cell', () => {
+		const cols = 4;
+		const rows = 3;
+		const cards = buildBulkCards({
+			url: SHEET,
+			cols,
+			rows,
+			cells: cellsWith(cols, rows),
+			namesText: 'Ace\nKing'
+		});
+
+		const reparsed = parsePackFile(
+			serializePackFile({
+				id: 'sheet-pack',
+				name: 'Sheet Pack',
+				scope: 'player',
+				decks: [{ slot: 'main', name: 'Main', back: CARD_BACK_DEFAULT, cards }]
+			})
+		);
+
+		expect(reparsed.decks[0].cards).toEqual(cards);
+		reparsed.decks[0].cards.forEach((card, i) => {
+			const draft = parseFaceRef(card.face);
+			expect(draft.scheme).toBe('sheet');
+			expect(draft.sheetUrl).toBe(SHEET);
+			expect(draft.sheetCols).toBe(cols);
+			expect(draft.sheetRows).toBe(rows);
+			expect(draft.sheetIndex).toBe(i); // row-major, 0 = top-left
+		});
+	});
+});

--- a/src/routes/create/bulk-sheet.ts
+++ b/src/routes/create/bulk-sheet.ts
@@ -1,0 +1,178 @@
+/**
+ * Bulk sprite-sheet authoring: one cols×rows grid → one card per cell.
+ *
+ * A `sheet:` ref already names a single cell of a grid
+ * (`sheet:{url,cols,rows,index}`, row-major, index 0 = top-left — docs/packs.md).
+ * What was missing is anything that enumerates the whole grid, which is what
+ * turned authoring a sheet into duplicate-and-increment-the-index.
+ *
+ * Everything here is pure: thumbnails (`sliceCell`) are a preview concern
+ * layered on top in `BulkSheet.svelte`, so index/name/code logic stays
+ * testable without a network, a canvas, or IndexedDB.
+ */
+
+import type { PackCardDef } from '$lib/packs/types';
+import { cellToRef } from '$lib/tts/to-pack';
+
+/** One cell of the loaded grid, as the pane edits it. */
+export type BulkCell = {
+	/** row-major position in the sheet — this is the `index` of the ref */
+	index: number;
+	row: number;
+	col: number;
+	/** included cells become cards; sheets routinely have dead trailing cells */
+	include: boolean;
+	/** per-cell override; only meaningful with `codeTouched` */
+	code: string;
+	name: string;
+	/** a hand-edited field wins over any bulk fill */
+	codeTouched: boolean;
+	nameTouched: boolean;
+	/** sliced data URL, or null when the sheet can't be read (CORS/dead link) */
+	thumb: string | null;
+	/** the slice is still in flight */
+	loading: boolean;
+};
+
+export const BULK_CODE_PREFIX = 'card';
+
+/**
+ * Ceiling on one bulk add. Sheets in the wild top out around 10×7; this is
+ * a guard against a fat-fingered 1000×1000, not a considered limit.
+ */
+export const BULK_MAX_CELLS = 400;
+
+function grid(cols: number, rows: number): { cols: number; rows: number } {
+	return {
+		cols: Math.max(1, Math.round(cols || 0)),
+		rows: Math.max(1, Math.round(rows || 0))
+	};
+}
+
+/** Enumerate `cols × rows` cells, row-major, index 0 = top-left. */
+export function enumerateCells(cols: number, rows: number): BulkCell[] {
+	const size = grid(cols, rows);
+	return Array.from({ length: size.cols * size.rows }, (_, index) => ({
+		index,
+		row: Math.floor(index / size.cols),
+		col: index % size.cols,
+		include: true,
+		code: '',
+		name: '',
+		codeTouched: false,
+		nameTouched: false,
+		thumb: null,
+		loading: true
+	}));
+}
+
+/** `Ace of Spades` → `ace-of-spades`; empty when nothing survives. */
+export function slugifyCode(name: string): string {
+	return name
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '');
+}
+
+/**
+ * A code that is free in `taken`. `code` is the entity-id component
+ * (`card:<owner>:<slot>-<code>`, spawn.ts), so two cards sharing one collide
+ * into a single table entity — every code the editor mints goes through here.
+ *
+ * A numeric suffix is bumped rather than stacked, so duplicating `AS` gives
+ * `AS-2` and duplicating that gives `AS-3` (not `AS-2-2`). Same shape as
+ * `allocateCardId` (store/game/actions/deck.ts) and `nextPieceId` (piece.ts).
+ */
+export function allocateCode(preferred: string, taken: ReadonlySet<string>): string {
+	const wanted = preferred.trim() || BULK_CODE_PREFIX;
+	if (!taken.has(wanted)) return wanted;
+
+	const match = /^(.+)-(\d+)$/.exec(wanted);
+	const base = match ? match[1] : wanted;
+	let n = match ? Number(match[2]) + 1 : 2;
+	while (taken.has(`${base}-${n}`)) n++;
+	return `${base}-${n}`;
+}
+
+/**
+ * Apply a name-per-line list to the included cells, row-major.
+ *
+ * Hand-edited cells keep their name but still consume their line, so the
+ * pasted list stays lined up with what the grid shows. Excluded cells are
+ * skipped entirely — a name list is written for the cards you're adding.
+ */
+export function applyBulkNames(cells: BulkCell[], text: string): BulkCell[] {
+	const lines = (text ?? '').split('\n').map((line) => line.trim());
+	let position = 0;
+	return cells.map((cell) => {
+		if (!cell.include) return { ...cell };
+		const line = lines[position++] ?? '';
+		if (cell.nameTouched || !line) return { ...cell };
+		return { ...cell, name: line };
+	});
+}
+
+export type CodePlanOptions = {
+	/** used when a cell has no name — `prefix-1`, `prefix-2`, … */
+	prefix?: string;
+	/** codes already spoken for, e.g. the cards already in the deck */
+	taken?: Iterable<string>;
+};
+
+/**
+ * The code each included cell would get, keyed by cell index: a per-cell
+ * edit, else the name slugified, else `prefix-N` — then de-duplicated
+ * against `taken` and against the rest of the batch.
+ */
+export function planCodes(cells: BulkCell[], options: CodePlanOptions = {}): Map<number, string> {
+	const taken = new Set(options.taken ?? []);
+	const prefix = (options.prefix ?? '').trim() || BULK_CODE_PREFIX;
+	const planned = new Map<number, string>();
+
+	let running = 0;
+	for (const cell of cells) {
+		if (!cell.include) continue;
+		running++;
+		const preferred =
+			(cell.codeTouched && cell.code.trim()) || slugifyCode(cell.name) || `${prefix}-${running}`;
+		const code = allocateCode(preferred, taken);
+		taken.add(code);
+		planned.set(cell.index, code);
+	}
+	return planned;
+}
+
+export type BulkAddOptions = CodePlanOptions & {
+	url: string;
+	cols: number;
+	rows: number;
+	cells: BulkCell[];
+	/** name-per-line list; omit when the cells already carry resolved names */
+	namesText?: string;
+};
+
+/**
+ * One `PackCardDef` per included cell, in row-major order, each pointing at
+ * its own cell of the sheet. A 1×1 grid degrades to a plain URL ref, the same
+ * shortcut the TTS importer takes.
+ */
+export function buildBulkCards(options: BulkAddOptions): PackCardDef[] {
+	const size = grid(options.cols, options.rows);
+	const url = options.url.trim();
+	const cells =
+		options.namesText === undefined
+			? options.cells
+			: applyBulkNames(options.cells, options.namesText);
+	const codes = planCodes(cells, { prefix: options.prefix, taken: options.taken });
+
+	return cells
+		.filter((cell) => cell.include)
+		.map((cell) => {
+			const name = cell.name.trim();
+			return {
+				code: codes.get(cell.index) ?? '',
+				...(name ? { name } : {}),
+				face: cellToRef({ url, cols: size.cols, rows: size.rows, index: cell.index })
+			};
+		});
+}


### PR DESCRIPTION
Task: tableplace-75

Closes #75

## What

Authoring a sheet-backed deck in `/create` meant adding one card, setting its face ref to `sheet:` with `index: 0`, then duplicating and hand-editing the index for every remaining cell. Everything needed to do it in one gesture already existed — the ref format, the slicer, `cellToRef`, the editor round-trip — but nothing enumerated a grid.

**A fifth pane, "Bulk add from sheet"** (`src/routes/create/BulkSheet.svelte`):

1. Sheet URL + Columns + Rows → **Load grid** (defaults from `SHEET_DEFAULTS`).
2. A thumbnail tile per cell (`sliceCell`, 8 at a time; the memory + IndexedDB caches make a re-load instant), each with an include toggle, a code and a name.
3. Include all / none, or *include only this range* — a dead trailing row is one gesture, not twelve checkboxes.
4. A names textarea, one per line, applied row-major to the **included** cells; a hand-edited cell keeps its name but still consumes its line, so the list stays lined up with the grid. Codes derive from names (slugified) or from a code prefix + running number.
5. **Add N cards to `<slot>`** appends one `PackCardDef` per included cell, in row-major order.

Cells that can't be sliced (CORS-tainted canvas → `sliceCell` returns `null`) render as placeholder tiles, stay importable, and say so in a toast — the ref is valid even when the thumbnail isn't, and `resolveCardImage` degrades the same way at play time.

The enumeration lives in `src/routes/create/bulk-sheet.ts` as pure functions (`enumerateCells`, `applyBulkNames`, `planCodes`, `buildBulkCards`, `allocateCode`), so index order, exclusion and code allocation are testable without a network, a canvas, or IndexedDB.

## Also: card codes are now unique

`code` is the entity-id component (`card:<owner>:<slot>-<code>`, `spawn.ts`), so two cards sharing one collapse into a single table entity. `card-${cards.length}` collided after any removal, and duplicating a card twice produced two `AS-copy`s. `addCard`, `duplicateCard` and the bulk add all allocate through `allocateCode`, which bumps a numeric suffix instead of stacking one: `AS` → `AS-2` → `AS-3`.

## Acceptance criteria

- [x] One button turns a URL + cols + rows into `cols × rows` cards with the correct row-major `sheet:` refs
- [x] Sliced thumbnail per cell; unsliceable cells show a placeholder and are still importable
- [x] Cells can be excluded; a partial last row is not a special case
- [x] Bulk names (one per line, row-major) + per-cell edits; codes derived and unique within the deck
- [x] `addCard` / `duplicateCard` produce unique codes
- [x] The preview respawns with the new cards and `prewarmGameState` resolves their `sheet:` refs
- [x] Round-trip: export → `parsePackFile` → `parseFaceRef` returns the same cell
- [x] Tests in `src/routes/create/__tests__/` — enumeration, exclusion, code allocation, ref round-trip, plus the pane driven through its real controls with `slice.ts` mocked

## Verification

`bun run test` — 324 pass (was 292; +32 new across `bulk-sheet.test.ts`, `BulkSheet.test.ts`, `CreatePane.test.ts`). `bun run build` clean, `bun run check` 0 errors, `eslint` clean on the touched files (the repo's `lint` script is red at baseline on unrelated files). Not verified in a real browser — the browser-automation extension wasn't reachable in this session; the pane is covered by jsdom component tests that drive its actual controls.

## Note for the next person in `BulkSheet.svelte`

Two tweakpane landmines found the hard way: an `{#if}` that **replaces** a blade (e.g. swapping one `<Element>` for another) tears the whole pane down — tweakpane owns that DOM, Svelte doesn't — and `AutoValue` blades don't survive siblings being added later. Hence one always-mounted `<Element>` whose contents are expression-driven, `Stepper` instead of `AutoValue`, and a background-image thumbnail instead of an `{#if}`-swapped `<img>`. Adding blades (the folders) is fine; replacing them is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKadZ7PKbGgHdxZqbSQHk7