### PR TITLE
tableplace-76: /create — lay a deck's cards out side by side (Deck/Spread toggle)

### DIFF
--- a/src/lib/Card.svelte
+++ b/src/lib/Card.svelte
@@ -19,6 +19,7 @@
 		cardBodyGeometry
 	} from '$lib/utils/constants-cards';
 	import { fanOffset } from '$lib/utils/transforms/stacking';
+	import { pickCard } from './store/cardPick';
 	import { resolveCardImage, sheetRefCache } from '$lib/packs';
 	import { claimPointerDown } from '$lib/utils/single-hit-pointerdown';
 	type Vec3Array = [number, number, number];
@@ -187,6 +188,18 @@
 		window.addEventListener('pointerup', cancelPendingDrag);
 	}
 
+	// A click that never became a drag. Inert unless something registered a
+	// handler (only /create does — see store/cardPick.ts).
+	function handleClick(e: IntersectionEvent<MouseEvent>) {
+		if (e.delta > DRAG_THRESHOLD_PX) return; // was a drag, not a click
+		// threlte dispatches click to every hit near → far, same as pointerdown
+		// (see claimPointerDown): stop here so overlapping cards pick the topmost
+		// rather than whichever happened to be furthest. Not
+		// stopImmediatePropagation — the native click is nobody else's problem.
+		e.stopPropagation();
+		pickCard(id);
+	}
+
 	function handlePointerEnter() {
 		if (!!$dragStore.isDragging) return;
 		isHovered = true;
@@ -208,6 +221,7 @@
 	onpointerdown={handleDragStart}
 	onpointerleave={handlePointerLeave}
 	onpointerenter={handlePointerEnter}
+	onclick={handleClick}
 >
 	<!-- card body: visible paper edge between the two faces (unlit so side faces
 	     never go black). Rounded to match the face's corner radius — a square box

--- a/src/lib/packs/spawn.ts
+++ b/src/lib/packs/spawn.ts
@@ -3,8 +3,9 @@ import { gameActions } from '$lib/store/game/actions';
 import { gameStore } from '$lib/store/game/gameStore.svelte';
 import { PIECE_REST_Y } from '$lib/utils/constants-pieces';
 import { BUILTIN_PACKS, PACK_SOURCE_BUILTIN } from './builtin';
+import type { SpreadTile } from './spread';
 import type { GamePackDef, PackDeckDef } from './types';
-import type { PackOrigin } from '$lib/store/game/types';
+import type { CardDTO, PackOrigin } from '$lib/store/game/types';
 
 export type SpawnPackOptions = {
 	/** entity owner — defaults to the local player (the scenario editor passes `seat0`…`seat3`) */
@@ -112,6 +113,50 @@ export function spawnPackDeck(pack: GamePackDef, deck: PackDeckDef, opts: SpawnD
 			}
 		}
 	});
+}
+
+export type SpawnDeckSpreadOptions = SpawnPackOptions & {
+	/** where each card lands — `spreadLayout(pack.decks)[deckIndex]` */
+	tiles: SpreadTile[];
+};
+
+/**
+ * Spawn one of a pack's decks as loose, face-up cards on a grid instead of a
+ * pile — the /create preview's Spread mode.
+ *
+ * Same card ids as `spawnPackDeck`, so `clearPreview`'s `:preview:` sweep
+ * keeps working and a spread respawn replaces exactly what the last one put
+ * down. Face-up regardless of the deck's `isFaceUp`: the point of a spread is
+ * to see the faces, and `isFaceUp` stays the durable start-face for play.
+ * Positions come from the caller because the grid is a function of the WHOLE
+ * pack (decks stack into blocks), not of one deck. No `packOrigin` either:
+ * a loose CardDTO has nowhere to carry it, and a spread is inspection only.
+ *
+ * Returns the card ids it wrote, in tile order, so a caller can map a card on
+ * the table back to the tile (and the pack card) it came from.
+ */
+export function spawnPackDeckSpread(deck: PackDeckDef, opts: SpawnDeckSpreadOptions): string[] {
+	const ownerId = opts.ownerId ?? gameActions.getMyId();
+	if (!ownerId) {
+		console.error('Cannot spawn a spread without an owner id');
+		return [];
+	}
+
+	const ids: string[] = [];
+	const cards: Record<string, Partial<CardDTO>> = {};
+	for (const tile of opts.tiles) {
+		const id = `card:${ownerId}:${deck.slot}-${tile.card.code}`;
+		ids.push(id);
+		cards[id] = {
+			faceImageUrl: tile.card.face,
+			...(deck.back ? { backImageUrl: deck.back } : {}),
+			position: tile.position,
+			rotation: [0, 0, 0]
+		};
+	}
+	// one update per deck, matching spawnPackDeck: keeps each patch small
+	if (ids.length) gameStore.updateState({ cards });
+	return ids;
 }
 
 export type SpawnPieceOptions = SpawnPackOptions & {

--- a/src/lib/packs/spread.ts
+++ b/src/lib/packs/spread.ts
@@ -1,0 +1,138 @@
+/**
+ * Spread layout: a pack's cards laid out side by side, derived purely from
+ * (deck index, card index).
+ *
+ * The /create preview respawns every entity it owns on every keystroke, so any
+ * hand-placed layout dies 300ms after you make it. A layout that is a pure
+ * function of the draft turns that respawn into a visual no-op instead:
+ * renaming a card leaves every tile exactly where it was, adding one appends a
+ * tile at the end, removing one closes the gap. Nothing is preserved because
+ * nothing needs to be.
+ */
+import { CARD_HEIGHT, CARD_REST_Y, CARD_WIDTH } from '$lib/utils/constants-cards';
+import { EDGE_MARGIN, TABLE_HALF_Z } from '$lib/utils/constants-table';
+import type { PackCardDef, PackDeckDef } from './types';
+
+/**
+ * Gap between neighbouring tiles. Bigger than it needs to look, because
+ * `collectStackGroup` treats any two resting cards within
+ * `CARD_STACK_RADIUS` (1.7) of each other as ONE loose pile — tighter tiles
+ * would fan a whole row on hover and snap a dropped card onto its neighbour.
+ * Both pitches below have to clear that radius (spread.test.ts asserts it).
+ */
+export const SPREAD_GAP = 0.4;
+
+/** Extra breathing room between one deck's block and the next */
+export const SPREAD_DECK_GAP = 1;
+
+export const SPREAD_PITCH_X = CARD_WIDTH + SPREAD_GAP;
+export const SPREAD_PITCH_Z = CARD_HEIGHT + SPREAD_GAP;
+
+/**
+ * Width the grid wraps within — not the felt's 60 units. The default camera
+ * (y = 25, fov 35) frames roughly 28 units of X and 16 of Z, and the felt's
+ * full width would fit 33 columns nobody could read. 18 keeps 10 columns
+ * comfortably inside the shot.
+ */
+export const SPREAD_WIDTH = 18;
+
+/** Columns the grid wraps at, auto-fitted to `SPREAD_WIDTH` */
+export const SPREAD_COLS = Math.max(1, Math.floor(SPREAD_WIDTH / SPREAD_PITCH_X));
+
+/** Centre of the leftmost column: fixed, so the left edge never drifts */
+export const SPREAD_ORIGIN_X = -((SPREAD_COLS - 1) * SPREAD_PITCH_X) / 2;
+
+/**
+ * Centre of the first row. Fixed at the far edge of the shot and growing
+ * towards the near one: a centred grid would shift every tile each time a new
+ * row opened, which is exactly the re-laying-out this layout exists to avoid.
+ */
+export const SPREAD_ORIGIN_Z = -6;
+
+/**
+ * Cards a spread will lay out. Past this it carpets the felt with tiles too
+ * small to read, so the editor falls back to piles and says so — the same
+ * bargain `UNGROUP_MAX_CARDS` (40) strikes for `Shift+G` on the table, with a
+ * wider limit because 60 cards is still 10×6 at the default camera.
+ */
+export const SPREAD_MAX_CARDS = 60;
+
+/**
+ * Deepest a row may sit and still be on the felt. The card cap alone doesn't
+ * bound this: 20 decks of 3 cards is only 60 cards but 20 blocks, which would
+ * march the last one off the table's near edge (a TTS import can look exactly
+ * like that).
+ */
+export const SPREAD_MAX_Z = TABLE_HALF_Z - EDGE_MARGIN - CARD_HEIGHT / 2;
+
+export type SpreadTile = {
+	/** the card this tile shows, by reference into the deck's array */
+	card: PackCardDef;
+	row: number;
+	col: number;
+	position: [number, number, number];
+};
+
+type SpreadDeck = Pick<PackDeckDef, 'cards'>;
+
+/** Total cards a spread of these decks would put on the table */
+export function spreadCardCount(decks: SpreadDeck[]): number {
+	return decks.reduce((total, deck) => total + (deck.cards?.length ?? 0), 0);
+}
+
+/** Why a spread refused, for the fallback's toast; null = go ahead */
+export type SpreadRefusal = 'too-many' | 'too-deep';
+
+export function spreadRefusal(decks: SpreadDeck[]): SpreadRefusal | null {
+	if (spreadCardCount(decks) > SPREAD_MAX_CARDS) return 'too-many';
+	if (spreadExtentZ(decks) > SPREAD_MAX_Z) return 'too-deep';
+	return null;
+}
+
+/** False when the spread would carpet the felt or run off it */
+export function canSpread(decks: SpreadDeck[]): boolean {
+	return spreadRefusal(decks) === null;
+}
+
+/**
+ * Z of the last tile the layout would place — the row-major order and the
+ * downward block stacking make that the deepest one.
+ */
+export function spreadExtentZ(decks: SpreadDeck[]): number {
+	const tiles = spreadLayout(decks).flat();
+	return tiles.at(-1)?.position[2] ?? SPREAD_ORIGIN_Z;
+}
+
+/**
+ * Tile positions for every card of every deck, as one array per deck (aligned
+ * with `decks`, so an empty deck is simply an empty block).
+ *
+ * Row-major within a deck, wrapping at `SPREAD_COLS`; decks stack down the
+ * table as separate blocks. Deterministic: same draft in, same positions out.
+ */
+export function spreadLayout(decks: SpreadDeck[]): SpreadTile[][] {
+	let blockZ = SPREAD_ORIGIN_Z;
+
+	return decks.map((deck) => {
+		const cards = deck.cards ?? [];
+		const tiles = cards.map((card, index) => {
+			const row = Math.floor(index / SPREAD_COLS);
+			const col = index % SPREAD_COLS;
+			return {
+				card,
+				row,
+				col,
+				position: [
+					SPREAD_ORIGIN_X + col * SPREAD_PITCH_X,
+					CARD_REST_Y,
+					blockZ + row * SPREAD_PITCH_Z
+				] as [number, number, number]
+			};
+		});
+		// an empty deck takes no vertical room, so it can't push the next block
+		// off the table while someone is halfway through authoring it
+		const rows = Math.ceil(cards.length / SPREAD_COLS);
+		if (rows > 0) blockZ += rows * SPREAD_PITCH_Z + SPREAD_DECK_GAP;
+		return tiles;
+	});
+}

--- a/src/lib/store/cardPick.ts
+++ b/src/lib/store/cardPick.ts
@@ -1,0 +1,24 @@
+/**
+ * Click-to-select on a table card.
+ *
+ * A single registered handler rather than a store every `Card.svelte`
+ * subscribes to: only the /create editor wants a click verb on a card (jump
+ * the pane's cursors to the tile you clicked), and /play must keep a plain
+ * click meaning nothing at all. No handler registered = clicks stay inert.
+ */
+type CardPickHandler = (id: string) => void;
+
+let handler: CardPickHandler | null = null;
+
+/** Register the handler; returns an unregister for the caller's cleanup. */
+export function onCardPick(next: CardPickHandler): () => void {
+	handler = next;
+	return () => {
+		if (handler === next) handler = null;
+	};
+}
+
+/** Called by Card.svelte for a click that wasn't a drag. */
+export function pickCard(id: string) {
+	handler?.(id);
+}

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -7,6 +7,8 @@
 	import { gameActions } from '$lib/store/game/actions';
 	import { disconnect } from '$lib/websocket/connection';
 	import CreatePane from './CreatePane.svelte';
+	import { togglePreviewLayout } from './preview-layout';
+	import toast from 'svelte-french-toast';
 
 	/**
 	 * Authoring is mostly typing — codes, names, image URLs — and the editor's
@@ -35,6 +37,10 @@
 		if (event.code === 'KeyR') gameActions.tapCard(true);
 		if (event.code === 'ArrowUp') gameActions.incrementHeight(0.01);
 		if (event.code === 'ArrowDown') gameActions.incrementHeight(-0.01);
+		// L for layout — editor-only, the pane's Layout list without reaching for
+		// the mouse. Toasted because the pane can be collapsed or dragged away.
+		if (event.code === 'KeyL')
+			toast(togglePreviewLayout() === 'spread' ? 'Spread: cards side by side' : 'Deck: piles');
 	}
 
 	function handleKeyUp(event: KeyboardEvent) {

--- a/src/routes/create/CreatePane.svelte
+++ b/src/routes/create/CreatePane.svelte
@@ -16,7 +16,20 @@
 	import { gameStore } from '$lib/store/game/gameStore.svelte';
 	import { gameActions } from '$lib/store/game/actions';
 	import { prewarmGameState } from '$lib/packs/prewarm-state';
-	import { spawnPackDeck, spawnPackPiece, spawnPackOverlay } from '$lib/packs/spawn';
+	import {
+		spawnPackDeck,
+		spawnPackDeckSpread,
+		spawnPackPiece,
+		spawnPackOverlay
+	} from '$lib/packs/spawn';
+	import {
+		spreadCardCount,
+		spreadLayout,
+		spreadRefusal,
+		SPREAD_MAX_CARDS
+	} from '$lib/packs/spread';
+	import { onCardPick } from '$lib/store/cardPick';
+	import { previewLayout, type PreviewLayout } from './preview-layout';
 	import { CARD_BACK_DEFAULT } from '$lib/packs/standard52';
 	import { parsePackFile, serializePackFile, packFileName } from '$lib/packs/file';
 	import { listPackDrafts, getPackDraft, savePackDraft, deletePackDraft } from '$lib/packs/drafts';
@@ -46,12 +59,14 @@
 		'format (docs/packs.md), then /setup spawns the file onto a seat.';
 
 	const TABLE_HELP_TEXT =
-		'Preview table: drag a card off a pile to look at it. It arrives showing the ' +
-		'side the deck starts on, so use "Flip cards on table" (or hover a card and ' +
-		'press F) to turn it over. T / R tap, ↑ / ↓ lift, C recentres the camera, hold ' +
-		'Space for a close-up. Moving cards here is inspection only — nothing on the ' +
-		'table is written back into the pack. The durable start face is the deck’s ' +
-		'"Face up" box.';
+		'Preview table: "Deck" shows one pile per deck — drag a card off to look at ' +
+		'it, then F (or "Flip cards on table") to turn it over. "Spread" (or L) lays ' +
+		'every card out face-up and clicking one selects it here; that grid is ' +
+		'DERIVED from the draft, so editing or adding a card never re-lays it out. ' +
+		'Either way the table is inspection only: flips, taps (T / R), lifts (↑ / ↓) ' +
+		'and anything you drag are neither saved into the pack nor kept — the next ' +
+		'edit respawns the preview from the draft. C recentres the camera, hold Space ' +
+		'for a close-up. The durable start face is the deck’s "Face up" box.';
 
 	function emptyPack(): EditorPack {
 		return withEditorDefaults({
@@ -249,17 +264,56 @@
 		gameStore.updateState(update as Parameters<typeof gameStore.updateState>[0]);
 	}
 
-	function respawnPreview() {
+	/**
+	 * Preview card id → the cursors that select it, rebuilt by every spread
+	 * respawn (and empty in Deck mode, where a card on the table was dragged
+	 * off a pile rather than laid out from a known slot). Not $state: only the
+	 * click handler reads it.
+	 */
+	let spreadCursors: Record<string, { deck: number; card: number }> = {};
+
+	function respawnPreview(mode: PreviewLayout) {
 		clearPreview();
+		spreadCursors = {};
 		const preview = exportable;
-		// spawned per entity rather than through spawnPack: the preview must show
-		// the deck in AUTHORED order (spawnPack shuffles facedown decks), and an
-		// empty deck mid-authoring has no cards[0] for Deck.svelte to render
-		preview.decks
-			.filter((deck) => deck.cards.length > 0)
-			.forEach((deck, index) =>
-				spawnPackDeck(preview, deck, { ownerId: PREVIEW_OWNER, index, shuffle: false })
+
+		// carpeting the felt with tiles too small to read is worse than a pile,
+		// so past the cap the spread refuses and the CONTROL follows the table —
+		// which also means the toast fires once, not on every keystroke after
+		const refusal = mode === 'spread' ? spreadRefusal(preview.decks) : null;
+		if (refusal) {
+			previewLayout.set('deck');
+			toast(
+				refusal === 'too-many'
+					? `${spreadCardCount(preview.decks)} cards is more than a spread shows ` +
+							`(max ${SPREAD_MAX_CARDS}) — showing piles instead`
+					: `${preview.decks.length} decks would spread off the table — showing piles instead`
 			);
+			mode = 'deck';
+		}
+
+		if (mode === 'spread') {
+			// no empty-deck filter here: with no pile to render, an empty deck is
+			// simply an empty block
+			const layout = spreadLayout(preview.decks);
+			preview.decks.forEach((deck, index) => {
+				const ids = spawnPackDeckSpread(deck, {
+					ownerId: PREVIEW_OWNER,
+					tiles: layout[index]
+				});
+				ids.forEach((id, card) => (spreadCursors[id] = { deck: index, card }));
+			});
+		} else {
+			// spawned per entity rather than through spawnPack: the preview must show
+			// the deck in AUTHORED order (spawnPack shuffles facedown decks), and an
+			// empty deck mid-authoring has no cards[0] for Deck.svelte to render
+			preview.decks
+				.filter((deck) => deck.cards.length > 0)
+				.forEach((deck, index) =>
+					spawnPackDeck(preview, deck, { ownerId: PREVIEW_OWNER, index, shuffle: false })
+				);
+		}
+
 		preview.pieces?.forEach((_, index) =>
 			spawnPackPiece(preview, index, { ownerId: PREVIEW_OWNER })
 		);
@@ -272,9 +326,24 @@
 
 	$effect(() => {
 		JSON.stringify(pack); // subscribe to every field of the draft
-		const timer = setTimeout(respawnPreview, 300);
+		const mode = $previewLayout;
+		const timer = setTimeout(() => respawnPreview(mode), 300);
 		return () => clearTimeout(timer);
 	});
+
+	/**
+	 * Click a laid-out card to select it — with the cards on the table, that's
+	 * the obvious gesture, and it saves hunting the same card down in the Card
+	 * list. Ignores ids no spread put there (a card dragged off a pile).
+	 */
+	$effect(() =>
+		onCardPick((id) => {
+			const cursors = spreadCursors[id];
+			if (!cursors) return;
+			deckCursor = cursors.deck;
+			cardCursor = cursors.card;
+		})
+	);
 
 	// ——— drafts (localStorage packs:v1) ———
 	let selectedDraft = $state(listPackDrafts()[0]?.pack.id ?? '');
@@ -402,6 +471,12 @@
 	width={320}
 	localStoreId="create-pane-decks"
 >
+	<!-- first row, above the cursors: it decides what the whole table shows -->
+	<List
+		label="Layout"
+		bind:value={$previewLayout}
+		options={{ 'Deck — a pile per deck': 'deck', 'Spread — cards side by side (L)': 'spread' }}
+	/>
 	<List label="Deck" bind:value={deckCursor} options={deckOptions} />
 	<Button title="Add deck" on:click={addDeck} />
 	{#if deck}
@@ -432,7 +507,7 @@
 	{/if}
 
 	<Button title="Flip cards on table (F)" on:click={flipTableCards} />
-	<Textarea disabled rows={6} value={TABLE_HELP_TEXT} />
+	<Textarea disabled rows={8} value={TABLE_HELP_TEXT} />
 </Pane>
 
 <Pane

--- a/src/routes/create/__tests__/CreatePane.test.ts
+++ b/src/routes/create/__tests__/CreatePane.test.ts
@@ -9,6 +9,10 @@ import { get } from 'svelte/store';
 import CreatePane from '../CreatePane.svelte';
 import { gameStore } from '$lib/store/game/gameStore.svelte';
 import { CARD_BACK_DEFAULT } from '$lib/packs/standard52';
+import { previewLayout } from '../preview-layout';
+import { pickCard } from '$lib/store/cardPick';
+import { SPREAD_MAX_CARDS, SPREAD_PITCH_X } from '$lib/packs/spread';
+import type { GamePackDef } from '$lib/packs/types';
 
 // the draggable Pane observes its own size; jsdom has no ResizeObserver
 globalThis.ResizeObserver ??= class {
@@ -27,11 +31,20 @@ const button = (container: HTMLElement, label: string) =>
 const labels = (container: HTMLElement) =>
 	[...container.querySelectorAll('.tp-lblv_l')].map((el) => el.textContent);
 
-/** the text input of the (single) row carrying this label */
-const input = (container: HTMLElement, label: string) =>
+/** the text inputs of every row carrying this label, in DOM order */
+const inputs = (container: HTMLElement, label: string) =>
 	[...container.querySelectorAll('.tp-lblv_l')]
-		.find((el) => el.textContent === label)
-		?.parentElement?.querySelector('input');
+		.filter((el) => el.textContent === label)
+		.map((el) => el.parentElement?.querySelector('input'));
+
+/** the text input of the (first) row carrying this label */
+const input = (container: HTMLElement, label: string) => inputs(container, label)[0];
+
+/** the (single) list offering this option — lists render as <select> */
+const listWith = (container: HTMLElement, option: string) =>
+	[...container.querySelectorAll('select')].find((s) =>
+		[...s.options].some((o) => o.textContent?.includes(option))
+	)!;
 
 /**
  * The card picker's options, which are labelled `<index>: <code>` — the deck
@@ -70,6 +83,7 @@ describe('CreatePane', () => {
 	beforeEach(() => {
 		gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {}, overlays: {} });
 		localStorage.clear();
+		previewLayout.set('deck'); // module state: the last test's choice would leak
 	});
 
 	it('mounts with a starter pack and previews it on the table', async () => {
@@ -252,6 +266,137 @@ describe('CreatePane', () => {
 		await settle();
 
 		expect(get(gameStore).cards?.['card:preview:main-AS'].rotation).toEqual([0, 0, 0]);
+	});
+
+	describe('Spread layout', () => {
+		/** switch the preview to Spread through the real pane control */
+		async function spread(container: HTMLElement) {
+			choose(listWith(container, 'Spread'), 'Spread');
+			await settlePreview();
+		}
+
+		it('lays every card of every deck out face-up, with no piles left', async () => {
+			const container = await mount();
+			button(container, 'Add deck')!.click();
+			await settle();
+			button(container, 'Add card')!.click();
+			await settle();
+			await spread(container);
+
+			const state = get(gameStore);
+			expect(Object.keys(state.decks ?? {})).toEqual([]);
+			expect(Object.keys(state.cards ?? {}).sort()).toEqual([
+				'card:preview:deck-1-card-0',
+				'card:preview:main-AS'
+			]);
+			// face-up regardless of the decks' isFaceUp (both start facedown)
+			expect(Object.values(state.cards ?? {}).every((c) => c.rotation?.[0] === 0)).toBe(true);
+			// separate blocks: each deck starts its own grid at the same left column
+			const [a, b] = Object.keys(state.cards ?? {})
+				.sort()
+				.map((id) => state.cards![id].position!);
+			expect(a[0]).toBeCloseTo(b[0]);
+			expect(a[2]).not.toBeCloseTo(b[2]);
+		});
+
+		it('leaves the other tiles in place when a card is added or edited', async () => {
+			const container = await mount();
+			await spread(container);
+			const before = get(gameStore).cards!['card:preview:main-AS'].position;
+
+			button(container, 'Add card')!.click();
+			await settlePreview();
+
+			const cards = get(gameStore).cards!;
+			expect(Object.keys(cards)).toHaveLength(2);
+			expect(cards['card:preview:main-AS'].position).toEqual(before);
+			// the new card is appended one column across, not re-laid out
+			expect(cards['card:preview:main-card-1'].position![0] - before![0]).toBeCloseTo(
+				SPREAD_PITCH_X
+			);
+
+			// third Name row: pack, deck, then the selected card (DOM order) — the
+			// draft check below is what proves it was the card's
+			type(inputs(container, 'Name')[2]!, 'renamed');
+			await settlePreview();
+			expect(get(gameStore).cards!['card:preview:main-AS'].position).toEqual(before);
+			expect(cards['card:preview:main-card-1'].position).toEqual(
+				get(gameStore).cards!['card:preview:main-card-1'].position
+			);
+
+			button(container, 'Save draft')!.click();
+			await settle();
+			const saved = JSON.parse(localStorage.getItem('packs:v1') ?? '{}');
+			expect(saved['my-pack'].pack.decks[0].cards[1].name).toBe('renamed');
+		});
+
+		it('re-forms the piles when switched back to Deck', async () => {
+			const container = await mount();
+			await spread(container);
+			const spreadPositions = get(gameStore).cards!['card:preview:main-AS'].position;
+
+			choose(listWith(container, 'Spread'), 'Deck');
+			await settlePreview();
+			expect(Object.keys(get(gameStore).decks ?? {})).toEqual(['deck:preview:main']);
+			expect(Object.keys(get(gameStore).cards ?? {})).toEqual([]);
+
+			await spread(container);
+			expect(Object.keys(get(gameStore).decks ?? {})).toEqual([]);
+			expect(get(gameStore).cards!['card:preview:main-AS'].position).toEqual(spreadPositions);
+		});
+
+		it('falls back to Deck mode past the card cap', async () => {
+			const pack: GamePackDef = {
+				id: 'big',
+				name: 'Big',
+				scope: 'player',
+				decks: [
+					{
+						slot: 'main',
+						name: 'Main',
+						back: CARD_BACK_DEFAULT,
+						cards: Array.from({ length: SPREAD_MAX_CARDS + 1 }, (_, i) => ({
+							code: `c${i}`,
+							face: CARD_BACK_DEFAULT
+						}))
+					}
+				]
+			};
+			localStorage.setItem('packs:v1', JSON.stringify({ big: { updatedAt: 1, pack } }));
+
+			const container = await mount();
+			await spread(container);
+			button(container, 'Load selected')!.click();
+			await settlePreview();
+
+			// piles, not 61 tiles — and the control follows the table
+			expect(get(previewLayout)).toBe('deck');
+			expect(Object.keys(get(gameStore).cards ?? {})).toEqual([]);
+			expect(get(gameStore).decks?.['deck:preview:main'].cards).toHaveLength(SPREAD_MAX_CARDS + 1);
+		});
+
+		it('selects the clicked card in the pane', async () => {
+			const container = await mount();
+			await spread(container);
+			button(container, 'Add card')!.click(); // cursor follows the new card
+			await settlePreview();
+			expect(input(container, 'Code')!.value).toBe('card-1');
+
+			pickCard('card:preview:main-AS'); // what Card.svelte calls on a click
+			await settle();
+			expect(input(container, 'Code')!.value).toBe('AS');
+		});
+
+		it('ignores a click on a card no spread laid out', async () => {
+			const container = await mount();
+			await settlePreview(); // Deck mode: cards come off a pile by hand
+			button(container, 'Add card')!.click();
+			await settlePreview();
+
+			pickCard('card:preview:main-AS');
+			await settle();
+			expect(input(container, 'Code')!.value).toBe('card-1'); // cursor unmoved
+		});
 	});
 
 	it('previews only under the preview owner, leaving other entities alone', async () => {

--- a/src/routes/create/__tests__/preview-layout.test.ts
+++ b/src/routes/create/__tests__/preview-layout.test.ts
@@ -1,0 +1,38 @@
+/**
+ * The Deck/Spread choice outlives the page, like the panes' own positions —
+ * so the module is re-imported here rather than reset, which is the closest a
+ * test gets to a reload.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { PREVIEW_LAYOUT_KEY } from '../preview-layout';
+
+async function reload() {
+	vi.resetModules();
+	return import('../preview-layout');
+}
+
+describe('previewLayout', () => {
+	beforeEach(() => localStorage.clear());
+
+	it('starts a fresh editor in Deck mode', async () => {
+		const { previewLayout } = await reload();
+		expect(get(previewLayout)).toBe('deck');
+	});
+
+	it('remembers Spread across a reload', async () => {
+		const first = await reload();
+		expect(first.togglePreviewLayout()).toBe('spread');
+		expect(localStorage.getItem(PREVIEW_LAYOUT_KEY)).toBe('spread');
+
+		const second = await reload();
+		expect(get(second.previewLayout)).toBe('spread');
+		expect(second.togglePreviewLayout()).toBe('deck');
+		expect(get((await reload()).previewLayout)).toBe('deck');
+	});
+
+	it('falls back to Deck on a junk stored value', async () => {
+		localStorage.setItem(PREVIEW_LAYOUT_KEY, 'sideways');
+		expect(get((await reload()).previewLayout)).toBe('deck');
+	});
+});

--- a/src/routes/create/__tests__/spread.test.ts
+++ b/src/routes/create/__tests__/spread.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The spread layout is the /create preview's answer to "my layout keeps dying":
+ * it is a pure function of the draft, so the respawn that used to wipe a
+ * hand-made layout is now visually a no-op. These tests pin that property —
+ * same draft ⇒ same positions, an edit moves nothing, an add appends — plus the
+ * two geometric constraints the grid has to respect.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+	canSpread,
+	spreadCardCount,
+	spreadExtentZ,
+	spreadLayout,
+	spreadRefusal,
+	SPREAD_COLS,
+	SPREAD_MAX_CARDS,
+	SPREAD_MAX_Z,
+	SPREAD_PITCH_X,
+	SPREAD_PITCH_Z
+} from '$lib/packs/spread';
+import { CARD_REST_Y, CARD_STACK_RADIUS } from '$lib/utils/constants-cards';
+import type { PackDeckDef } from '$lib/packs/types';
+
+const deck = (slot: string, count: number, from = 0): PackDeckDef => ({
+	slot,
+	name: slot,
+	back: 'gen:std52/back',
+	cards: Array.from({ length: count }, (_, i) => ({
+		code: `c${from + i}`,
+		name: `card ${from + i}`,
+		face: `gen:std52/${from + i}`
+	}))
+});
+
+const positions = (decks: PackDeckDef[]) =>
+	spreadLayout(decks).map((tiles) => tiles.map((tile) => tile.position));
+
+describe('spreadLayout', () => {
+	it('is a pure function of the draft — same draft, same positions', () => {
+		const draft = [deck('main', 7), deck('discard', 3)];
+		// two independent copies, so nothing is shared between the two calls
+		expect(positions(draft)).toEqual(positions(structuredClone(draft)));
+	});
+
+	it('lays a deck out row-major, wrapping at the column count', () => {
+		const [tiles] = spreadLayout([deck('main', SPREAD_COLS + 2)]);
+
+		expect(tiles.map((t) => [t.row, t.col]).slice(0, 2)).toEqual([
+			[0, 0],
+			[0, 1]
+		]);
+		expect(tiles[SPREAD_COLS]).toMatchObject({ row: 1, col: 0 });
+		// one column pitch across, one row pitch down, all resting on the table
+		expect(tiles[1].position[0] - tiles[0].position[0]).toBeCloseTo(SPREAD_PITCH_X);
+		expect(tiles[SPREAD_COLS].position[2] - tiles[0].position[2]).toBeCloseTo(SPREAD_PITCH_Z);
+		expect(tiles[SPREAD_COLS].position[0]).toBeCloseTo(tiles[0].position[0]);
+		expect(tiles.every((t) => t.position[1] === CARD_REST_Y)).toBe(true);
+	});
+
+	it('keeps neighbouring tiles clear of the loose-stack radius', () => {
+		// tighter than this and collectStackGroup reads the row as one pile:
+		// hovering would fan it and a dropped card would snap onto its neighbour
+		expect(SPREAD_PITCH_X).toBeGreaterThan(CARD_STACK_RADIUS);
+		expect(SPREAD_PITCH_Z).toBeGreaterThan(CARD_STACK_RADIUS);
+	});
+
+	it('leaves every other tile in place when a card is edited', () => {
+		const before = [deck('main', 5)];
+		const after = structuredClone(before);
+		after[0].cards[2] = { code: 'renamed', name: 'Renamed', face: 'https://example.test/x.png' };
+
+		expect(positions(after)).toEqual(positions(before));
+	});
+
+	it('appends a tile when a card is added, moving nothing before it', () => {
+		const before = [deck('main', 5)];
+		const after = [deck('main', 6)];
+
+		expect(positions(after)[0].slice(0, 5)).toEqual(positions(before)[0]);
+		expect(positions(after)[0]).toHaveLength(6);
+	});
+
+	it('closes the gap when a card is removed', () => {
+		const before = [deck('main', 5)];
+		const after = structuredClone(before);
+		after[0].cards.splice(2, 1);
+		const [tiles] = spreadLayout(after);
+
+		// the tail slides one slot back, and each tile still shows its own card
+		expect(tiles.map((t) => t.position)).toEqual(positions(before)[0].slice(0, 4));
+		expect(tiles.map((t) => t.card.code)).toEqual(['c0', 'c1', 'c3', 'c4']);
+	});
+
+	it('stacks decks as separate blocks, and gives an empty deck no room', () => {
+		const [main, empty, discard] = spreadLayout([
+			deck('main', 2),
+			deck('empty', 0),
+			deck('cut', 2)
+		]);
+
+		expect(empty).toEqual([]);
+		// same row-major geometry inside each block, but further down the table
+		expect(main.map((t) => t.position[0])).toEqual(discard.map((t) => t.position[0]));
+		expect(discard[0].position[2]).toBeGreaterThan(main[0].position[2] + SPREAD_PITCH_Z);
+	});
+
+	it('refuses to spread past the card cap', () => {
+		const under = [deck('a', SPREAD_MAX_CARDS)];
+		const over = [deck('a', SPREAD_MAX_CARDS), deck('b', 1, SPREAD_MAX_CARDS)];
+
+		expect(spreadCardCount(over)).toBe(SPREAD_MAX_CARDS + 1);
+		expect(canSpread(under)).toBe(true);
+		expect(spreadRefusal(under)).toBe(null);
+		expect(canSpread(over)).toBe(false);
+		expect(spreadRefusal(over)).toBe('too-many');
+	});
+
+	it('refuses when many small decks would stack off the felt', () => {
+		// 20×3 is only 60 cards — under the cap — but 20 blocks deep
+		const many = Array.from({ length: 20 }, (_, i) => deck(`d${i}`, 3));
+
+		expect(spreadCardCount(many)).toBeLessThanOrEqual(SPREAD_MAX_CARDS);
+		expect(spreadExtentZ(many)).toBeGreaterThan(SPREAD_MAX_Z);
+		expect(spreadRefusal(many)).toBe('too-deep');
+	});
+
+	it('keeps a full 52-card deck on the felt', () => {
+		expect(spreadRefusal([deck('main', 52)])).toBe(null);
+		expect(spreadExtentZ([deck('main', 52)])).toBeLessThanOrEqual(SPREAD_MAX_Z);
+	});
+});

--- a/src/routes/create/preview-layout.ts
+++ b/src/routes/create/preview-layout.ts
@@ -1,0 +1,41 @@
+/**
+ * How the /create preview renders a pack's decks. A store rather than pane
+ * state because two things drive it: the "Decks & Cards" pane control and the
+ * `L` hotkey in +page.svelte, which is a sibling of the pane.
+ *
+ * Persisted next to the panes' own layout (`localStoreId`), so reopening the
+ * editor puts the table back the way you left it.
+ */
+import { writable } from 'svelte/store';
+
+export type PreviewLayout =
+	/** one pile per deck — what /play sees, and the default */
+	| 'deck'
+	/** every card side by side on a derived grid (see packs/spread.ts) */
+	| 'spread';
+
+export const PREVIEW_LAYOUT_KEY = 'create-pane-layout';
+
+function read(): PreviewLayout {
+	try {
+		return localStorage.getItem(PREVIEW_LAYOUT_KEY) === 'spread' ? 'spread' : 'deck';
+	} catch {
+		return 'deck'; // no localStorage (SSR / prerender)
+	}
+}
+
+export const previewLayout = writable<PreviewLayout>(read());
+
+previewLayout.subscribe((mode) => {
+	try {
+		localStorage.setItem(PREVIEW_LAYOUT_KEY, mode);
+	} catch {
+		/* nothing to persist to */
+	}
+});
+
+export function togglePreviewLayout(): PreviewLayout {
+	let next: PreviewLayout = 'deck';
+	previewLayout.update((mode) => (next = mode === 'deck' ? 'spread' : 'deck'));
+	return next;
+}


### PR DESCRIPTION
Task: tableplace-76
Closes #76

The `/create` preview showed a deck as a pile, so seeing what you authored meant dragging cards off it one at a time — and 300ms after the next keystroke `respawnPreview` wiped the layout and you laid them out again.

## Approach: derive the layout, don't preserve it

Rather than teaching the respawn to keep hand-placed cards, **Spread** mode makes position a pure function of `(deck index, card index)`. The respawn then becomes visually a no-op: renaming a card leaves every tile where it was, adding a card appends one tile, removing one closes the gap. No preservation logic, no new pack fields — `PackCardDef` still has no `position`, and the table is still inspection only.

| Mode | Render |
|---|---|
| **Deck** (default, unchanged) | one pile per deck via `spawnPackDeck` |
| **Spread** | every card as a loose, face-up `CardDTO` on a grid |

## What's here

- **`src/lib/packs/spread.ts`** — the pure layout. Row-major, wrapping at 10 columns, decks stacking down the table as separate blocks. Two decisions worth calling out:
  - Columns fit **18 world units, not the felt's 60**. The default camera (y 25, fov 35) frames ~28×16; the full felt would fit 33 columns nobody can read. A 52-card spread lands in x ±8.8, z ±7.0 — inside the ±14.0 / ±7.9 the camera actually shows.
  - Tile pitch (1.8 × 2.4) clears `CARD_STACK_RADIUS` (1.7). Tighter and `collectStackGroup` reads a row as one loose pile — hovering would fan the whole row and a dropped card would snap onto its neighbour.
  - The grid is anchored at a **fixed** top-left rather than centred, so opening a new row can't shift the rows above it.
- **`spawnPackDeckSpread`** (sibling of `spawnPackDeck`) — same `card:preview:<slot>-<code>` ids, so `clearPreview` is untouched. Face-up regardless of the deck's `isFaceUp`; `isFaceUp` remains the durable start face for play. Empty decks are simply empty blocks (no `cards[0]` constraint without a pile to render).
- **Toggle** — a "Layout" list at the top of the "Decks & Cards" pane, plus `L`. Persisted in `localStorage` under `create-pane-layout`, alongside the panes' own `localStoreId` state; Deck is the default for a fresh editor.
- **Fallback** — refuses past 60 cards *and* past the felt's near edge (20 decks of 3 cards is under the card cap but 20 blocks deep, which a TTS import can look like). It falls back to piles with a toast and sets the control back to Deck, so the toast fires once instead of on every subsequent keystroke.
- **Click to select** — clicking a spread card jumps the pane's deck/card cursors to it. `Card.svelte` calls a single registered handler (`store/cardPick.ts`) for a click that never crossed the existing 5px drag threshold; with no handler registered, /play and /setup clicks stay inert as before.
- **`TABLE_HELP_TEXT`** updated: still "inspection only", but now says the spread is derived from the draft, so nothing you do to it is lost *or* saved.

## Verification

- `bun run test` — 311 pass (31 files). New: `__tests__/spread.test.ts` (purity, row-major wrap, stack-radius clearance, edit/add/remove, block stacking, both refusals) and `__tests__/preview-layout.test.ts` (default, persistence across a re-import, junk value). Six new `CreatePane` cases drive the real tweakpane control: no piles left in Spread, tiles hold still across an add and a card rename, Deck↔Spread round-trips identically, the cap falls back, and a click selects.
- `bun run check` — 0 errors (8 pre-existing warnings).
- `bun run build` — clean.
- Prettier/eslint clean on every touched file. `Card.svelte`'s 4 eslint errors are baseline (verified by stashing).
- Not verified in a browser: the Chrome extension wasn't connected in this environment, so the on-screen result is checked by computing the grid's world-space extents against the default camera frustum (above) rather than by looking at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xyGD8LoAvFB8DNPC9oz6W