### PR TITLE
tableplace-86: one interactivity() context per camera, not per deck or hand card

### DIFF
--- a/src/lib/Deck.svelte
+++ b/src/lib/Deck.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import * as THREE from 'three';
 	import { T } from '@threlte/core';
-	import { Text, Billboard, ImageMaterial, interactivity } from '@threlte/extras';
+	import { Text, Billboard, ImageMaterial } from '@threlte/extras';
 	import { dragStart, dragStore, setDeckHover } from '$lib/store/dragStore.svelte';
 	import { degrees } from '$lib/utils/constants-rotation';
 	import {
@@ -19,8 +19,11 @@
 	import { resolveCardImage, sheetRefCache, CARD_BACK_DEFAULT } from '$lib/packs';
 	import DropFootprint from './drop/DropFootprint.svelte';
 
-	interactivity();
-
+	// No interactivity() here on purpose. It calls setContext, so a per-deck call
+	// would shadow TableScene's context — the handlers below would raycast with
+	// the default compute instead of TableScene's (no intersectionPoint, no
+	// table-plane fallback) and stopPropagation could never reach a card. They
+	// register into TableScene's one context instead.
 	let { id = '' }: { id: string } = $props();
 
 	const deck = $derived($gameStore?.decks?.[id] ?? {});

--- a/src/lib/HUDPreview/HUDPreviewScene.svelte
+++ b/src/lib/HUDPreview/HUDPreviewScene.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import { T } from '@threlte/core';
 	import { dragStore } from '$lib/store/dragStore.svelte';
-	import { useViewport, interactivity } from '@threlte/extras';
+	import { useViewport } from '@threlte/extras';
 	import PreviewCard from './PreviewCard.svelte';
 
-	interactivity();
+	// No interactivity() — the preview pane is display-only. If it ever gains a
+	// pointer handler it needs its own call, not the parent's: this HUD has its
+	// own camera (see HUDTrayScene) and the table camera's ray would never hit it.
 	let {}: {} = $props();
 
 	const viewport = useViewport();

--- a/src/lib/HUDPreview/PreviewCard.svelte
+++ b/src/lib/HUDPreview/PreviewCard.svelte
@@ -2,10 +2,11 @@
 	import { gameStore } from '$lib/store/game/gameStore.svelte';
 	import type { GameDTO } from '$lib/store/game/types';
 	import { T } from '@threlte/core';
-	import { ImageMaterial, interactivity } from '@threlte/extras';
+	import { ImageMaterial } from '@threlte/extras';
 	import { resolveCardImage, sheetRefCache } from '$lib/packs';
 
-	interactivity();
+	// The preview is display-only: nothing here registers a pointer handler, so
+	// it needs no interactivity context of its own.
 	let { id }: { id: string } = $props();
 	const card = $derived($gameStore?.cards?.[id] as NonNullable<GameDTO['cards'][string]>);
 	const isFlipped = $derived((card?.rotation ?? [0])[0] === 180);

--- a/src/lib/HUDTray/HUDTrayScene.svelte
+++ b/src/lib/HUDTray/HUDTrayScene.svelte
@@ -9,6 +9,20 @@
 	import { gameActions } from '$lib/store/game/actions';
 	import { gameStore } from '$lib/store/game/gameStore.svelte';
 
+	/**
+	 * The one interactivity() the HUD keeps, and the only one besides
+	 * TableScene's (see #86). `<HUD>` calls createCameraContext(), so
+	 * `useThrelte().camera` inside it resolves to the OrthographicCamera below,
+	 * not the table camera — and a Raycaster is set from exactly one camera. The
+	 * tray's meshes sit in that ortho camera's space, so a ray cast from the
+	 * table's perspective camera would never hit them. Hence a second context,
+	 * whose default compute picks up this camera.
+	 *
+	 * `<HUD>` does not create a DOM context, so `useDOM().dom` — interactivity's
+	 * listener target — is still the shared canvas element. Only the camera is
+	 * re-rooted, which is why this needs to be per HUD root and never per card:
+	 * TrayCard registers into this context.
+	 */
 	interactivity();
 	let {}: {} = $props();
 

--- a/src/lib/HUDTray/TrayCard.svelte
+++ b/src/lib/HUDTray/TrayCard.svelte
@@ -10,7 +10,7 @@
 <script lang="ts">
 	import { T } from '@threlte/core';
 	import * as THREE from 'three';
-	import { ImageMaterial, interactivity } from '@threlte/extras';
+	import { ImageMaterial } from '@threlte/extras';
 	import { Spring } from 'svelte/motion';
 	import { degrees } from '$lib/utils/constants-rotation';
 	import { CARD_DRAG_Y } from '$lib/utils/constants-cards';
@@ -20,7 +20,10 @@
 	import { gameStore } from '$lib/store/game/gameStore.svelte';
 	import { gameActions } from '$lib/store/game/actions';
 
-	interactivity();
+	// No interactivity() here on purpose — one call per card in hand meant one
+	// Raycaster and one full set of DOM listeners per card. The handlers below
+	// register into HUDTrayScene's context, which is the one that owns the tray's
+	// orthographic camera.
 	let {
 		id,
 		index = 0,

--- a/src/lib/TableScene.svelte
+++ b/src/lib/TableScene.svelte
@@ -53,6 +53,15 @@
 	const tablePlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), -TABLE_TOP_Y);
 	const planeHit = new THREE.Vector3();
 
+	/**
+	 * The main scene's one and only interactivity context (see #86). Every
+	 * interactive entity on the table — Card, Deck, Piece, Table — registers into
+	 * this one, so they share a Raycaster, a dispatch loop (which is what lets
+	 * stopPropagation pick the topmost hit across entity types) and the compute
+	 * below. Descendants must not call interactivity() themselves: setContext
+	 * would shadow this for their subtree. The only other call in the app is
+	 * HUDTrayScene's, which needs a second one for its own camera.
+	 */
 	interactivity({
 		compute: (event, state) => {
 			if (!mesh) return;

--- a/src/lib/__tests__/interactivity-contexts.test.ts
+++ b/src/lib/__tests__/interactivity-contexts.test.ts
@@ -1,0 +1,49 @@
+/**
+ * `interactivity()` from @threlte/extras is not idempotent and not cheap:
+ * every call does setContext (shadowing any parent context for that subtree),
+ * builds its own Raycaster, and adds a full set of DOM listeners to the shared
+ * canvas element. Calling it inside a component that renders once per deck or
+ * once per card in hand therefore scaled listeners and per-pointermove raycasts
+ * with the board — and, worse, split the dispatch loop, so stopPropagation
+ * could not cross entity types and TableScene's custom `compute` did not apply
+ * inside a Deck or a TrayCard (see #86).
+ *
+ * The invariant is "one context per camera": TableScene owns the table camera,
+ * HUDTrayScene owns an OrthographicCamera that `<HUD>`'s createCameraContext
+ * re-roots, and a Raycaster can only be set from one camera. Nothing else may
+ * call it — a component gets handlers by having an ancestor that called it, not
+ * by calling it itself.
+ *
+ * This is a source-level guard because the failure is silent at runtime: an
+ * extra call renders and dispatches fine, it just quietly stops honouring the
+ * scene-wide invariants.
+ */
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const SRC = join(process.cwd(), 'src');
+
+const EXPECTED_CALL_SITES = ['lib/HUDTray/HUDTrayScene.svelte', 'lib/TableScene.svelte'];
+
+function walk(dir: string): string[] {
+	return readdirSync(dir).flatMap((entry) => {
+		const path = join(dir, entry);
+		return statSync(path).isDirectory() ? walk(path) : [path];
+	});
+}
+
+describe('interactivity() call sites', () => {
+	const callSites = walk(SRC)
+		.filter((path) => path.endsWith('.svelte') || path.endsWith('.ts'))
+		.filter((path) => !path.includes('__tests__'))
+		// a bare `interactivity(` at the start of a statement — not the import,
+		// and not the word inside a comment
+		.filter((path) => /^\s*interactivity\(/m.test(readFileSync(path, 'utf8')))
+		.map((path) => relative(SRC, path))
+		.sort();
+
+	it('is called exactly once per camera, and nowhere else', () => {
+		expect(callSites).toEqual(EXPECTED_CALL_SITES);
+	});
+});


### PR DESCRIPTION
Task: tableplace-86

Closes #86

`interactivity()` was called **six** times. It is not idempotent — each call does
`setContext` (shadowing the parent context for that subtree), builds its own
`Raycaster`, and adds a full set of DOM listeners to the shared canvas element.
Four of those calls lived in components that render once per entity.

## What changed

Removed the calls in `Deck.svelte`, `HUDTray/TrayCard.svelte`,
`HUDPreview/HUDPreviewScene.svelte` and `HUDPreview/PreviewCard.svelte`. Their
`<T.*>` handlers now register into the nearest remaining context — which is the
one that owns the camera their meshes actually live in.

**Two calls remain, one per camera.** That is the invariant, and it is a real
constraint rather than caution:

- `TableScene.svelte` — unchanged, keeps its `compute`.
- `HUDTray/HUDTrayScene.svelte` — kept.

## The `<HUD>` finding (AC 2)

Read from `@threlte/extras/dist/components/HUD/HUD.svelte`:

```svelte
const { scene } = createSceneContext()
const { camera } = createCameraContext()
```

`createCameraContext()` does `setContext('threlte-camera-context', …)`, and
`useThrelte().camera` is just `useCamera().camera` → `getContext` of that key
(`core/dist/context/compounds/useThrelte.js`, `context/fragments/camera.svelte.js`).
So **inside a `<HUD>`, `useThrelte().camera` resolves to that HUD's own
`OrthographicCamera`, not the table camera** — and `useViewport()` resolves the
same way, which is why the tray's meshes are positioned in that ortho camera's
space. A `Raycaster` is set from exactly one camera, so a ray cast from the
table's perspective camera would never hit the tray. `HUDTrayScene` therefore
genuinely needs its own context.

Two things follow, and both matter:

- `<HUD>` does **not** create a DOM context. `useDOM().dom` — interactivity's
  listener target — is still the same shared canvas element for every context.
  So `<HUD>` re-roots the **camera**, not the listener target. The raycast is
  re-rooted; the DOM listeners are not deduped.
- Because only the camera is re-rooted, the second context belongs **per HUD
  root and never per card**: `TrayCard` registers into `HUDTrayScene`'s context
  and is raycast with the same ortho camera it is positioned by.

`HUDPreviewScene` / `PreviewCard` needed no context at all — neither file
registers a single `on*` handler on any `<T.*>`. Both calls were pure dead
weight, so all four removals landed rather than the three-and-justify-two
fallback. The comment on `HUDPreviewScene` records that if the preview ever
gains a handler it needs its own call back, for the camera reason above — not
the parent's.

## Listener / raycast counts (AC 4)

Measured on `/play` against a local server, with `connect()` / `disconnect()` /
`getHits()` in `@threlte/extras` temporarily instrumented with counters (patch
reverted; `node_modules` only, never committed). Fixed scenario: **3 decks + 7
cards in hand**, viewport 1280×800.

| | before | after |
|---|---|---|
| live interactivity contexts | 13 | **2** |
| DOM listeners on the canvas | 130 | **20** |
| raycasts per `pointermove` | 13 | **2** |
| raycasts over a 20-move sweep | 260 | **40** |

The ticket predicted 12 listeners per context; the real `DOM_EVENTS` table in
`setupInteractivity.svelte.js` has 10 entries, hence 130 rather than 156.

Before, the counts tracked the board exactly: 1 (TableScene) + 1 (HUDTrayScene)
+ 3 (decks) + 7 (hand) + 1 (HUDPreviewScene) = 13. After, they are flat — adding
decks or hand cards does not move them. A nice incidental confirmation: with the
old code, hovering a card so the preview pane mounts pushed the count 13 → 14,
because `PreviewCard` created a context of its own.

## Interaction verification (AC 3)

The Chrome extension wasn't connected in this session, so instead of clicking by
hand I drove a real Chromium (Playwright, WebGL via SwiftShader) with real DOM
pointer events and asserted against the app's own stores. Aiming is
self-calibrating: `TableScene`'s compute publishes the table-plane hit as
`dragStore.intersectionPoint` on every `pointermove`, so one sweep gives a
screen→world map, and each entity is then located by spiralling out from that
estimate until its hover fires (meshes sit above the plane, so perspective
parallax offsets them on screen).

All 14 checks pass:

- deck hover highlight — all 3 decks report `setDeckHover`
- deck pointerdown draws the top card, and the deck is one card shorter after the commit
- **drag tracking with the pointer off the table mesh** — dragged into the sky and past both edges; the card kept tracking at `(-0.74, -6.26)`, `(10.24, -7.19)`, `(-8.19, -7.30)`. This is the `compute` fallback, the thing most likely to break, and it is intact.
- table card hover (`setHover`), and table card drag → lands somewhere new
- tray plane hover fires in the HUD context (`isTrayHovered`)
- tray card hover-expand — its hover owner is a module-private store, so asserted on pixels: 99.4% of the tray band changes when a card is hovered
- tray card pointerdown lifts it out of the hand, tracks the pointer, and drops onto the table (hand 7 → 6)
- preview pane on hover+space, with the context count still 2
- counter click steps the value by exactly **1** (#84 stays fixed). Note a plain left click is `-1` by design — `counter-input.ts`: click deals damage, shift heals.
- **deck overlapping a card** (the case the ticket flagged): a card sitting on a deck lifts the card and the deck does **not** also draw.

Every check was also run against the pre-fix code as a control, and the results
are identical except for the context-count assertion — so no behaviour changed,
only the number of contexts doing the work.

### One thing worth knowing about the old behaviour

Pre-fix, the overlapping-deck case already behaved correctly, but for an
accidental reason: `claimPointerDown` calls `stopImmediatePropagation()`, which
halts the **native** DOM event and so prevented the Deck's separate context
listener from running at all. Plain `stopPropagation()` never had that effect —
it only breaks one context's dispatch loop. So cross-entity "topmost wins" held
for `pointerdown` by luck and not for anything else (e.g. `Card`'s `onclick`,
which uses plain `stopPropagation`). It is now a property of the shared dispatch
loop instead of a side effect of stopping the DOM event.

## Regression guard

`src/lib/__tests__/interactivity-contexts.test.ts` scans the source tree and
asserts the call sites are exactly `TableScene.svelte` and `HUDTrayScene.svelte`.
Source-level because the failure mode is silent: an extra call renders and
dispatches fine, it just quietly stops honouring the scene-wide invariants.
Verified it fails when a call is re-added.

## Gate

- `bun run test` — 38 files, **392 passed**
- `bun run check` — **0 errors** (8 pre-existing warnings in `Card.svelte` / `Piece.svelte`)
- `bun run build` — clean
- `bun run lint` — red at baseline and **unchanged by this branch**: 59 eslint errors and 29 prettier files both before and after (verified by stashing). All 7 touched files pass `prettier --check`; the 5 eslint errors in the touched files (`let {}: {} = $props()`, unused `emissiveIntensity`) are pre-existing and only moved line numbers.

## Not in scope

`TableScene`'s compute logic, the drag/drop model and HUD camera setup are
untouched. Rebased onto `main` after #84 (PR #85) landed.
