### PR TITLE
tableplace-88: Cheap deck verbs — drag-vs-draw, flip deck, shuffle hotkey, draw N

### DIFF
--- a/docs/research/deck-manipulation-primitives.md
+++ b/docs/research/deck-manipulation-primitives.md
@@ -43,7 +43,7 @@ UI surface; L = needs new interaction infra (selection, menus).
 |---|-----------|-----------|--------|-------|
 | A1 | **Group loose stack → deck** (hotkey `G` on hovered card) | `G` group | **S/M** | Everything needed exists: reuse the `resolveStackHeight` radius scan for membership, order by Y, `addDeck` at base-card XZ, delete loose card entities. Instantly gives piles draw-1 / count / return-to-top semantics for free. |
 | A2 | **Square-up on stack drop** — snap XZ to stack base | auto-align | **S** | Pure change in the drop commit; makes stacks read as intentional piles instead of drift. Optional small random jitter for feel. Holding `Alt` at release opts out (raw pointer XZ, rests on the felt), so cards can still be laid out deliberately next to each other. |
-| A3 | **Grab whole pile** (modifier-drag or long-press on a stack/deck) | RMB-drag / container drag | **M** | For decks: drag threshold on pointerdown — move = drag deck, click = draw (today drawing is the only possible outcome). |
+| A3 | **Grab whole pile** (modifier-drag or long-press on a stack/deck) | RMB-drag / container drag | **M** | *Shipped for decks.* Drag threshold on pointerdown — move = drag the whole deck (streams through the position throttle like cards), click = draw 1 to the felt in front of the deck. Loose stacks still wait on the selection model. |
 | A4 | **Split / take N** (drag off top with count, or cut at midpoint) | number+drag, Cut | **M** | Depends on A1 (needs real pile objects to split). |
 | A5 | **Re-settle stack Ys** when a mid-card is removed | gravity | **S** | Run the stack scan on pickup, not just drop. |
 | A6 | **Ungroup deck → loose stack** (hotkey `Shift+G` on a hovered deck) | unpack container | **S** | *Shipped.* The inverse of A1 and the only way back out of a `G` short of drawing one card at a time. `DeckDTO.cards` is already the full ordered list, so it's one patch: delete the deck, write the cards. `orderForDeck` is its own inverse, so the ordering convention survives the round trip. Own decks only (matches shuffle), and capped at `UNGROUP_MAX_CARDS` (40) so a 200-card deck can't carpet the felt. |
@@ -53,9 +53,9 @@ UI surface; L = needs new interaction infra (selection, menus).
 
 | # | Primitive | TTS analog | Effort | Notes |
 |---|-----------|-----------|--------|-------|
-| B1 | **Draw N** (number keys 1–9 while hovering deck) | number keys | **S** | `drawFromTop` just needs a count param + fan the drawn cards. |
-| B2 | **Flip whole deck** (toggle `isFaceUp`) | flip deck | **S** | Field exists, mutation doesn't. Mind the ordering convention flip (top = last vs first). |
-| B3 | **Shuffle hotkey + visible feedback** (hover deck + `S`) | shake/`R` | **S** | Action exists; needs binding + a broadcastable wiggle so opponents see it happened. |
+| B1 | **Draw N** (number keys 1–9 while hovering deck) | number keys | **S** | *Shipped.* `drawFromTop(id, count)` lands the cards fanned down-screen of the deck, one thickness apart in Y, in a single patch. |
+| B2 | **Flip whole deck** (toggle `isFaceUp`) | flip deck | **S** | *Shipped.* `F` on a hovered deck. Toggling `isFaceUp` alone is the physical flip — the draw convention (top = last vs first) makes the former bottom the new top. |
+| B3 | **Shuffle hotkey + visible feedback** (hover deck + `S`) | shake/`R` | **S** | *Shipped.* `S` on a hovered own deck; `shuffledAt` rides the shuffle patch and every client's Deck plays a decaying yaw wiggle when it changes. |
 | B4 | **Deal to seats** (right-click → deal N to each player tray) | Deal | **M** | Blocked on B6 for discoverability, but the action itself is a loop of draw→tray patches. |
 | B5 | **Search / browse deck** (scrollable contents list, take/reorder) | Search | **M** | SPEC already plans the Bag to *reuse* this UI — build it once here. Hidden-info: only reveal to the searcher. |
 | B6 | **Context menu on card/deck** (right-click) | RMB menu | **M/L** | The unlock for every discoverable verb (deal, search, reset, flip-pile). Today right-click on a card falls through to camera orbit. |

--- a/src/lib/Deck.svelte
+++ b/src/lib/Deck.svelte
@@ -2,8 +2,9 @@
 	import * as THREE from 'three';
 	import { T } from '@threlte/core';
 	import { Text, Billboard, ImageMaterial } from '@threlte/extras';
+	import type { IntersectionEvent } from '@threlte/extras';
+	import { Spring } from 'svelte/motion';
 	import { dragStart, dragStore, setDeckHover } from '$lib/store/dragStore.svelte';
-	import { degrees } from '$lib/utils/constants-rotation';
 	import {
 		CARD_DRAG_Y,
 		CARD_WIDTH,
@@ -13,10 +14,11 @@
 	} from '$lib/utils/constants-cards';
 	import { createDeckEdgeTexture, deckEdgeRepeatY } from '$lib/utils/deck-edge-texture';
 	import { browser } from '$app/environment';
-	import { DEG2RAD } from 'three/src/math/MathUtils.js';
 	import { gameStore } from './store/game/gameStore.svelte';
 	import { gameActions } from './store/game/actions';
 	import { resolveCardImage, sheetRefCache, CARD_BACK_DEFAULT } from '$lib/packs';
+	import { claimPointerDown } from '$lib/utils/single-hit-dispatch';
+	import { DRAG_THRESHOLD_PX } from '$lib/utils/counter-input';
 	import DropFootprint from './drop/DropFootprint.svelte';
 
 	// No interactivity() here on purpose. It calls setContext, so a per-deck call
@@ -59,37 +61,102 @@
 
 	const isHovered = $derived(id === $dragStore.isDeckHovered);
 	// dropping here replaces the table landing entirely, so the deck has to be
-	// the cue — the drop indicator suppresses its table footprint while hovered
-	const isDropTarget = $derived(isHovered && !!$dragStore.isDragging);
+	// the cue — the drop indicator suppresses its table footprint while hovered.
+	// Cards only: a dragged deck or piece just settles on the felt (see
+	// resolveDrop), so lighting up would promise a landing that can't happen —
+	// and the deck being dragged is always hovered by its own pointer.
+	const isDragged = $derived($dragStore.isDragging === id);
+	const isDropTarget = $derived(
+		isHovered &&
+			!!$dragStore.isDragging &&
+			!$dragStore.isDragging.startsWith('deck:') &&
+			!$dragStore.isDragging.startsWith('piece:')
+	);
 
-	function handleDragStart(e: PointerEvent) {
+	// Lift + glide springs, same rig as Piece.svelte: the local drag snaps XZ
+	// instantly (a spring there reads as input lag), remote decks glide toward
+	// the ~200ms-throttled store position instead of teleporting between ticks.
+	const lift = new Spring(position[1] ?? 0, {
+		stiffness: 0.28,
+		damping: 0.7,
+		precision: 0.0001
+	});
+	$effect(() => {
+		lift.target = isDragged ? CARD_DRAG_Y : (deck.position?.[1] ?? 0);
+	});
+
+	const planar = new Spring(
+		{ x: position[0] ?? 0, z: position[2] ?? 0 },
+		{ stiffness: 0.15, damping: 0.8, precision: 0.0001 }
+	);
+	$effect(() => {
+		const [x = 0, , z = 0] = deck.position ?? [];
+		if (isDragged) planar.set({ x, z }, { instant: true });
+		else planar.target = { x, z };
+	});
+
+	// Shuffle wiggle: a decaying yaw twitch, kicked whenever `shuffledAt`
+	// changes — the reorder patch alone is invisible from the back, so this is
+	// what tells everyone (shuffler included) a shuffle happened. Low damping
+	// on purpose: the spring overshoots a few times, which reads as a riffle.
+	const wiggle = new Spring(0, { stiffness: 0.3, damping: 0.15, precision: 0.001 });
+	// null = not seeded yet: the first run only records, so a late joiner
+	// doesn't replay a shuffle that happened before they arrived
+	let prevShuffledAt: number | null | undefined = null;
+	$effect(() => {
+		const t = deck.shuffledAt;
+		const prev = prevShuffledAt;
+		prevShuffledAt = t;
+		if (prev === null || t === undefined || t === prev) return;
+		wiggle.set(0.3, { instant: true });
+		wiggle.target = 0;
+	});
+
+	let pendingDrag: { x: number; y: number } | null = null;
+
+	// Drag threshold, same as Card/Piece: the pointerdown only arms the
+	// gesture. Travel past the threshold and it's a deck move; release under
+	// it and the click handler draws instead.
+	function onPendingMove(ne: PointerEvent) {
+		if (!pendingDrag) return;
+		if (Math.hypot(ne.clientX - pendingDrag.x, ne.clientY - pendingDrag.y) < DRAG_THRESHOLD_PX)
+			return;
+		cancelPendingDrag();
+		// origin (pre-lift store position) is what Esc returns the deck to
+		dragStart(id, CARD_DRAG_Y, deck.position);
+	}
+
+	function cancelPendingDrag() {
+		pendingDrag = null;
+		window.removeEventListener('pointermove', onPendingMove);
+		window.removeEventListener('pointerup', cancelPendingDrag);
+	}
+
+	$effect(() => cancelPendingDrag);
+
+	function handlePointerDown(e: IntersectionEvent<PointerEvent>) {
+		// claims the pointerdown ahead of anything behind the deck — see
+		// claimPointerDown — and locks OrbitControls out of the gesture
+		if (!claimPointerDown(e)) return;
+		pendingDrag = { x: e.nativeEvent.clientX, y: e.nativeEvent.clientY };
+		window.addEventListener('pointermove', onPendingMove);
+		window.addEventListener('pointerup', cancelPendingDrag);
+	}
+
+	// a press that never travelled: the draw (the pre-threshold behavior —
+	// one card off the top, landing in front of the deck)
+	function handleClick(e: IntersectionEvent<MouseEvent>) {
+		if (e.delta > DRAG_THRESHOLD_PX) return; // was a drag, not a click
 		e.stopPropagation();
-		const { x = 0, z = 0 } = $dragStore.intersectionPoint as THREE.Vector3;
-		const card = gameActions.drawFromTop(id);
-		if (!card) return console.warn('No card drawn');
-
-		const rotX = isFaceUp ? 0 : 180;
-		const rotY = 0;
-		const rotZ = -degrees[gameActions?.getMySeat()] / DEG2RAD;
-		gameStore.updateState({
-			cards: {
-				[card.id]: {
-					...card,
-					position: [x, CARD_DRAG_Y, z],
-					rotation: [rotX, rotY, rotZ],
-					backImageUrl: card.backImageUrl ?? deckBackImage
-				}
-			}
-		});
-
-		dragStart(card.id, CARD_DRAG_Y);
+		gameActions.drawFromTop(id);
 	}
 </script>
 
 <T.Group
-	{position}
-	{rotation}
-	onpointerdown={handleDragStart}
+	position={[planar.current.x, lift.current, planar.current.z]}
+	rotation={[rotation[0], rotation[1] + wiggle.current, rotation[2]]}
+	onpointerdown={handlePointerDown}
+	onclick={handleClick}
 	onpointerenter={() => setDeckHover(id)}
 	onpointerleave={() => setDeckHover(null)}
 >

--- a/src/lib/TableScene.svelte
+++ b/src/lib/TableScene.svelte
@@ -79,6 +79,10 @@
 				const dragId = $dragStore.isDragging as string;
 				if (dragId.startsWith('piece:')) {
 					gameStore.updateState({ pieces: { [dragId]: { position: [cx, PIECE_DRAG_Y, cz] } } });
+				} else if (dragId.startsWith('deck:')) {
+					// decks float at card height while dragged; these stream through
+					// the same position throttle as cards (see storeIntegration.ts)
+					gameStore.updateState({ decks: { [dragId]: { position: [cx, CARD_DRAG_Y, cz] } } });
 				} else {
 					gameStore.updateState({ cards: { [dragId]: { position: [cx, CARD_DRAG_Y, cz] } } });
 				}

--- a/src/lib/drop/DropIndicator.svelte
+++ b/src/lib/drop/DropIndicator.svelte
@@ -72,8 +72,10 @@
 
 	// height the dragged entity is floating at, for the connector's top end
 	const liftY = $derived(
-		(dragId ? ($gameStore?.pieces?.[dragId] ?? $gameStore?.cards?.[dragId]) : undefined)
-			?.position?.[1] ?? 0
+		(dragId
+			? ($gameStore?.pieces?.[dragId] ?? $gameStore?.cards?.[dragId] ?? $gameStore?.decks?.[dragId])
+			: undefined
+		)?.position?.[1] ?? 0
 	);
 	const connector = $derived(liftY - surfaceY);
 </script>

--- a/src/lib/drop/commit.ts
+++ b/src/lib/drop/commit.ts
@@ -43,6 +43,8 @@ export function commitActiveDrag() {
 		gameActions.placeOnTopOfDeck(drop.targetId, id);
 	} else if (drop && id.startsWith('piece:')) {
 		gameStore.updateState({ pieces: { [id]: { position: drop.position } } });
+	} else if (drop && id.startsWith('deck:')) {
+		gameStore.updateState({ decks: { [id]: { position: drop.position } } });
 	} else if (drop) {
 		gameStore.updateState({ cards: { [id]: { position: drop.position } } });
 	}
@@ -67,6 +69,7 @@ export function cancelActiveDrag() {
 	}
 
 	if (id.startsWith('piece:')) gameStore.updateState({ pieces: { [id]: { position: origin } } });
+	else if (id.startsWith('deck:')) gameStore.updateState({ decks: { [id]: { position: origin } } });
 	else gameStore.updateState({ cards: { [id]: { position: origin } } });
 
 	dragEnd();
@@ -76,6 +79,8 @@ function commitActiveDragAtRest(id: string) {
 	const drop = resolveDrop(get(gameStore), id, null);
 	if (drop && id.startsWith('piece:'))
 		gameStore.updateState({ pieces: { [id]: { position: drop.position } } });
+	else if (drop && id.startsWith('deck:'))
+		gameStore.updateState({ decks: { [id]: { position: drop.position } } });
 	else if (drop) gameStore.updateState({ cards: { [id]: { position: drop.position } } });
 	dragEnd();
 }

--- a/src/lib/formats/spec-version.ts
+++ b/src/lib/formats/spec-version.ts
@@ -24,7 +24,7 @@ export const PACK_SPEC_VERSION = '1.0.0';
  * compatibility promise (issue #39), and semver's 0.x rule — where the minor
  * is the breaking component — says exactly that.
  */
-export const SCENARIO_SPEC_VERSION = '0.1.0';
+export const SCENARIO_SPEC_VERSION = '0.1.1';
 
 export type Semver = { major: number; minor: number; patch: number };
 

--- a/src/lib/hotkeys/shuffle.ts
+++ b/src/lib/hotkeys/shuffle.ts
@@ -1,0 +1,22 @@
+import toast from 'svelte-french-toast';
+import { get } from 'svelte/store';
+import { dragStore } from '$lib/store/dragStore.svelte';
+import { gameActions } from '$lib/store/game/actions';
+
+/**
+ * `S` on a hovered deck: shuffle it.
+ *
+ * Ownership matches the pane button and `Shift+G`: only your own decks.
+ * No deck under the pointer is silent (a toast on every stray keypress is
+ * noise); someone else's deck gets told why nothing happened.
+ */
+export function shuffleHoveredDeck(deckId?: string) {
+	const id = deckId ?? get(dragStore).isDeckHovered;
+	if (!id) return;
+	if (!gameActions.getMyDecks().some(([key]) => key === id)) {
+		toast.error("That deck isn't yours to shuffle");
+		return;
+	}
+	gameActions.shuffleDeck(id);
+	return id;
+}

--- a/src/lib/store/__tests__/deck-verbs.test.ts
+++ b/src/lib/store/__tests__/deck-verbs.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import { gameStore } from '../game/gameStore.svelte';
+import { gameActions } from '../game/actions';
+import { dragStore } from '../dragStore.svelte';
+import { CARD_REST_Y, CARD_THICKNESS } from '$lib/utils/constants-cards';
+import { resolveDrop } from '$lib/utils/transforms/drop';
+import { TABLE_TOP_Y } from '$lib/utils/constants-table';
+
+const ME = 'seat0';
+const DECK = `deck:${ME}:0`;
+
+const inDeck = (id: string) => ({
+	id,
+	faceImageUrl: `${id}.png`,
+	backImageUrl: 'back.png'
+});
+
+/** a facedown 4-card deck at the table centre — top of the pile is `d` */
+function seed(isFaceUp = false) {
+	gameStore.set({
+		players: { [ME]: { id: ME, seat: 0 } },
+		decks: {
+			[DECK]: {
+				id: DECK,
+				isFaceUp,
+				position: [0, 0.4, 0] as [number, number, number],
+				rotation: [0, 0, 0] as [number, number, number],
+				cards: [inDeck('a'), inDeck('b'), inDeck('c'), inDeck('d')]
+			}
+		},
+		cards: {}
+	});
+}
+
+beforeEach(() => {
+	localStorage.setItem('myPlayerId', ME);
+	dragStore.set({
+		isDragging: null,
+		isHovered: null,
+		isDeckHovered: null,
+		isTrayHovered: false
+	});
+	seed();
+});
+
+describe('drawFromTop with a count', () => {
+	it('draws N off the top in draw order and shrinks the deck in the same patch', () => {
+		const drawn = gameActions.drawFromTop(DECK, 3);
+		expect(drawn.map((c) => c.id)).toEqual(['d', 'c', 'b']); // facedown: top = last
+		const state = get(gameStore);
+		expect(state.decks?.[DECK]?.cards?.map((c) => c.id)).toEqual(['a']);
+		expect(Object.keys(state.cards ?? {}).sort()).toEqual(['b', 'c', 'd']);
+	});
+
+	it('fans the landings instead of stacking one Y-tower', () => {
+		gameActions.drawFromTop(DECK, 3);
+		const cards = get(gameStore).cards ?? {};
+		const positions = ['d', 'c', 'b'].map((id) => cards[id]?.position ?? [0, 0, 0]);
+		// each card lands further down-screen (+Z for seat 0) than the last…
+		expect(positions[1][2]).toBeGreaterThan(positions[0][2]);
+		expect(positions[2][2]).toBeGreaterThan(positions[1][2]);
+		// …and one thickness higher, so overlaps never share a plane
+		expect(positions[0][1]).toBe(CARD_REST_Y);
+		expect(positions[1][1]).toBeCloseTo(CARD_REST_Y + CARD_THICKNESS);
+		expect(positions[2][1]).toBeCloseTo(CARD_REST_Y + 2 * CARD_THICKNESS);
+	});
+
+	it('keeps the drawn cards facedown from a facedown deck', () => {
+		gameActions.drawFromTop(DECK, 1);
+		expect(get(gameStore).cards?.d?.rotation?.[0]).toBe(180);
+	});
+
+	it('clamps the count to what the deck holds', () => {
+		const drawn = gameActions.drawFromTop(DECK, 9);
+		expect(drawn).toHaveLength(4);
+		expect(get(gameStore).decks?.[DECK]?.cards).toEqual([]);
+	});
+
+	it('returns [] from an empty deck', () => {
+		gameStore.updateState({ decks: { [DECK]: { cards: [] } } });
+		expect(gameActions.drawFromTop(DECK, 2)).toEqual([]);
+	});
+});
+
+describe('flipDeck', () => {
+	it('toggles isFaceUp, so the former bottom card draws first', () => {
+		expect(gameActions.drawFromTop(DECK)[0]?.id).toBe('d'); // facedown top
+		gameActions.flipDeck(DECK);
+		expect(get(gameStore).decks?.[DECK]?.isFaceUp).toBe(true);
+		// physical flip: the old bottom is the new visually-top card
+		expect(gameActions.drawFromTop(DECK)[0]?.id).toBe('a');
+	});
+
+	it('flips back again', () => {
+		gameActions.flipDeck(DECK);
+		gameActions.flipDeck(DECK);
+		expect(get(gameStore).decks?.[DECK]?.isFaceUp).toBe(false);
+		expect(gameActions.drawFromTop(DECK)[0]?.id).toBe('d');
+	});
+
+	it('falls back to the hovered deck', () => {
+		dragStore.update((s) => ({ ...s, isDeckHovered: DECK }));
+		expect(gameActions.flipDeck()).toBe(DECK);
+		expect(get(gameStore).decks?.[DECK]?.isFaceUp).toBe(true);
+	});
+
+	it('does nothing with no target', () => {
+		expect(gameActions.flipDeck()).toBeUndefined();
+		expect(get(gameStore).decks?.[DECK]?.isFaceUp).toBe(false);
+	});
+});
+
+describe('shuffleDeck', () => {
+	it('stamps shuffledAt so clients have a change to wiggle on', () => {
+		expect(get(gameStore).decks?.[DECK]?.shuffledAt).toBeUndefined();
+		gameActions.shuffleDeck(DECK);
+		const deck = get(gameStore).decks?.[DECK];
+		expect(typeof deck?.shuffledAt).toBe('number');
+		// same cards, whatever the order
+		expect(deck?.cards?.map((c) => c.id).sort()).toEqual(['a', 'b', 'c', 'd']);
+	});
+});
+
+describe('resolveDrop for a dragged deck', () => {
+	it('settles on the felt at half the deck body height, ignoring deck/tray hover', () => {
+		const drop = resolveDrop(
+			get(gameStore),
+			DECK,
+			{ x: 3, z: 2 },
+			// a dragged deck hovers itself; the tray must not swallow the pile
+			{ deckId: DECK, tray: true }
+		);
+		expect(drop?.kind).toBe('table');
+		expect(drop?.position[0]).toBe(3);
+		expect(drop?.position[2]).toBe(2);
+		expect(drop?.position[1]).toBeGreaterThan(TABLE_TOP_Y);
+		expect(drop?.position[1]).toBeLessThan(1);
+	});
+});

--- a/src/lib/store/__tests__/group-stack.test.ts
+++ b/src/lib/store/__tests__/group-stack.test.ts
@@ -54,9 +54,9 @@ describe('groupStackIntoDeck', () => {
 
 	it('keeps the visual top card on top: drawing returns it first', () => {
 		const deckId = gameActions.groupStackIntoDeck('middle') as string;
-		expect(gameActions.drawFromTop(deckId)?.id).toBe('top');
-		expect(gameActions.drawFromTop(deckId)?.id).toBe('middle');
-		expect(gameActions.drawFromTop(deckId)?.id).toBe('bottom');
+		expect(gameActions.drawFromTop(deckId)[0]?.id).toBe('top');
+		expect(gameActions.drawFromTop(deckId)[0]?.id).toBe('middle');
+		expect(gameActions.drawFromTop(deckId)[0]?.id).toBe('bottom');
 	});
 
 	it('lands the deck at the base card XZ', () => {
@@ -71,7 +71,7 @@ describe('groupStackIntoDeck', () => {
 		const deck = get(gameStore).decks?.[deckId];
 		expect(deck?.isFaceUp).toBe(true);
 		expect(deck?.cards?.[0].id).toBe('top'); // face-up convention: top is first
-		expect(gameActions.drawFromTop(deckId)?.id).toBe('top');
+		expect(gameActions.drawFromTop(deckId)[0]?.id).toBe('top');
 	});
 
 	it('groups a lone card into a 1-card deck', () => {
@@ -165,7 +165,7 @@ describe('ungroupDeck', () => {
 		const secondId = gameActions.groupStackIntoDeck('top') as string;
 		const second = get(gameStore).decks?.[secondId];
 		expect(second?.cards).toEqual(first?.cards);
-		expect(gameActions.drawFromTop(secondId)?.id).toBe('top');
+		expect(gameActions.drawFromTop(secondId)[0]?.id).toBe('top');
 	});
 
 	it('spreads a facedown deck to facedown cards', () => {

--- a/src/lib/store/game/actions/deck.ts
+++ b/src/lib/store/game/actions/deck.ts
@@ -4,9 +4,17 @@ import { gameStore } from '../gameStore.svelte';
 import { get } from 'svelte/store';
 import { dragStore } from '$lib/store/dragStore.svelte';
 import { collectStackGroup, orderForDeck } from '$lib/utils/transforms/stacking';
-import { CARD_REST_Y, CARD_THICKNESS, deckHeightForCount } from '$lib/utils/constants-cards';
+import {
+	CARD_FAN_STEP,
+	CARD_HEIGHT,
+	CARD_REST_Y,
+	CARD_THICKNESS,
+	deckHeightForCount
+} from '$lib/utils/constants-cards';
 import { TABLE_TOP_Y } from '$lib/utils/constants-table';
-import type { GameDTO } from '../types';
+import { clampToTable } from '$lib/utils/transforms/drop';
+import { degrees } from '$lib/utils/constants-rotation';
+import type { CardInDeck, GameDTO } from '../types';
 
 function getMyDecks() {
 	const myPlayerId = gameActions.getMe()?.id;
@@ -205,22 +213,89 @@ function ungroupDeck(deckId?: string): UngroupResult {
 }
 
 /**
- * Draws from the top of the deck
- * Follows LIFO (Last In First Out)
- * When facedown (like a deck of cards), the top card = cards.length - 1
- * When faceup (like a visible discard pile), the top card = cards[0]
- *
- * returns the card drawn.
- * */
-function drawFromTop(id: string) {
-	const { cards, isFaceUp } = get(gameStore)?.decks?.[id] ?? {};
-	if (!cards || cards.length === 0) return console.error('Cannot draw from an empty deck');
+ * Center-to-center distance from the deck to the first drawn card: one card
+ * length plus a sliver of felt, so the landing clears the deck's footprint.
+ */
+const DRAW_LANDING_DISTANCE = CARD_HEIGHT + 0.2;
 
-	const card = isFaceUp ? cards.shift() : cards.pop();
-	gameStore.updateState({
-		decks: { [id]: { cards } }
+/**
+ * Draw `count` cards off the top of the deck (click = 1, number keys 1-9)
+ * and land them on the table between the deck and the drawer's seat.
+ *
+ * Follows LIFO (Last In First Out):
+ * when facedown (like a deck of cards), the top card = cards.length - 1;
+ * when faceup (like a visible discard pile), the top card = cards[0].
+ *
+ * The landings cascade down-screen one CARD_FAN_STEP apart with a thickness
+ * of Y between them — the hover-fan look, not one Y-tower — first-drawn
+ * nearest the deck. Deck shrink and table cards go in ONE patch, so remote
+ * clients never see the cards in both places (and last-write-wins concurrency
+ * stays a single-patch problem).
+ *
+ * Returns the drawn cards, first drawn (the old top) first.
+ * */
+function drawFromTop(id: string, count = 1): CardInDeck[] {
+	const deck = get(gameStore)?.decks?.[id];
+	const available = deck?.cards;
+	if (!available || available.length === 0) {
+		console.error('Cannot draw from an empty deck');
+		return [];
+	}
+
+	const isFaceUp = deck.isFaceUp ?? false;
+	const remaining = [...available];
+	const drawn: CardInDeck[] = [];
+	for (let i = 0; i < Math.min(count, available.length); i++) {
+		const card = isFaceUp ? remaining.shift() : remaining.pop();
+		if (card) drawn.push(card);
+	}
+
+	// "down-screen" for the drawer: +Z for seat 0, rotating with the seat —
+	// the same frame fanOffset uses. Card yaw is degrees applied as -z.
+	const seatYaw = degrees[gameActions.getMySeat()] ?? 0;
+	const rotZ = -seatYaw / DEG2RAD;
+	const [deckX = 0, , deckZ = 0] = deck.position ?? [];
+	const taken = new Set(Object.keys(get(gameStore)?.cards ?? {}));
+	const cards: Record<string, GameDTO['cards'][string]> = {};
+
+	drawn.forEach((card, index) => {
+		const distance = DRAW_LANDING_DISTANCE + index * CARD_FAN_STEP;
+		const [x, z] = clampToTable(
+			deckX + Math.sin(seatYaw) * distance,
+			deckZ + Math.cos(seatYaw) * distance
+		);
+		const cardId = allocateCardId(card.id, `${id}:draw-${index}`, taken);
+		taken.add(cardId);
+		cards[cardId] = {
+			faceImageUrl: card.faceImageUrl ?? '',
+			...(card.backImageUrl || deck.deckBackImageUrl
+				? { backImageUrl: card.backImageUrl ?? (deck.deckBackImageUrl as string) }
+				: {}),
+			position: [x, CARD_REST_Y + index * CARD_THICKNESS, z],
+			// a face-up deck deals face-up cards; 180 on x is facedown
+			rotation: [isFaceUp ? 0 : 180, 0, rotZ]
+		};
 	});
-	return card; // returns card to hoist into cards for dragging
+
+	gameStore.updateState({ decks: { [id]: { cards: remaining } }, cards });
+	return drawn;
+}
+
+/**
+ * Flip the whole deck like a physical pile (hotkey `F` on a hovered deck).
+ *
+ * Toggling `isFaceUp` IS the flip: drawFromTop's ordering convention
+ * (facedown top = last element, face-up top = first) means the former
+ * bottom card becomes the new top with no array surgery — exactly what
+ * turning a real pile over does.
+ */
+function flipDeck(deckId?: string) {
+	const id = deckId ?? get(dragStore).isDeckHovered;
+	if (!id) return;
+	const deck = get(gameStore)?.decks?.[id];
+	if (!deck) return;
+	gameStore.updateState({ decks: { [id]: { isFaceUp: !(deck.isFaceUp ?? false) } } });
+	return id;
 }
 
 type Card = NonNullable<GameDTO['decks'][string]['cards']>[number];
@@ -269,7 +344,10 @@ export function shuffleDeck(deckId: string) {
 	const shuffledCards = shuffleCards(cards);
 	if (!shuffledCards || shuffledCards.length === 0) return console.log('Error shuffling');
 	return gameStore.updateState({
-		decks: { [deckId]: { cards: shuffledCards } }
+		// shuffledAt rides the same patch as the reorder: the new card order is
+		// invisible from the back, the changed timestamp is what every client's
+		// Deck.svelte turns into the wiggle
+		decks: { [deckId]: { cards: shuffledCards, shuffledAt: Date.now() } }
 	});
 }
 
@@ -278,6 +356,7 @@ export const deckActions = {
 	groupStackIntoDeck,
 	ungroupDeck,
 	drawFromTop,
+	flipDeck,
 	getDeckLength,
 	getMyDecks,
 	placeOnTopOfDeck,

--- a/src/lib/store/game/types.ts
+++ b/src/lib/store/game/types.ts
@@ -44,6 +44,12 @@ export type DeckDTO = {
 	packOrigin?: PackOrigin;
 	/** scenario authoring intent (tbps v2): reshuffle this deck on scenario load */
 	shuffleOnLoad?: boolean;
+	/**
+	 * wall-clock ms of the last shuffle. Its only job is to CHANGE in the same
+	 * patch as the reordered cards — the reorder alone is invisible from the
+	 * back, the changed timestamp is what remote clients turn into the wiggle.
+	 */
+	shuffledAt?: number;
 };
 
 interface SeatState {

--- a/src/lib/utils/transforms/drop.ts
+++ b/src/lib/utils/transforms/drop.ts
@@ -1,6 +1,11 @@
 import type { GameDTO } from '$lib/store/game/types';
 import { TABLE_FEATURES_DEFAULT, type TableFeatures } from '$lib/store/tableFeatures';
-import { CARD_WIDTH, CARD_HEIGHT, CARD_REST_Y } from '$lib/utils/constants-cards';
+import {
+	CARD_WIDTH,
+	CARD_HEIGHT,
+	CARD_REST_Y,
+	deckHeightForCount
+} from '$lib/utils/constants-cards';
 import { PIECE_DEFAULT_RADIUS, PIECE_REST_Y } from '$lib/utils/constants-pieces';
 import { EDGE_MARGIN, TABLE_HALF_X, TABLE_HALF_Z, TABLE_TOP_Y } from '$lib/utils/constants-table';
 import { resolveStack } from './stacking';
@@ -97,7 +102,12 @@ export function resolveDrop(
 	if (!dragId) return null;
 
 	const isPiece = dragId.startsWith('piece:');
-	const entity = isPiece ? state?.pieces?.[dragId] : state?.cards?.[dragId];
+	const isDeck = dragId.startsWith('deck:');
+	const entity = isPiece
+		? state?.pieces?.[dragId]
+		: isDeck
+			? state?.decks?.[dragId]
+			: state?.cards?.[dragId];
 	if (!entity) return null;
 
 	const [ex = 0, , ez = 0] = entity.position ?? [];
@@ -112,6 +122,21 @@ export function resolveDrop(
 			position: [x, PIECE_REST_Y, z],
 			rotation,
 			footprint: { shape: 'circle', r },
+			footprintY: TABLE_TOP_Y
+		};
+	}
+
+	// decks don't nest, stack, or enter the tray: a dragged pile settles on
+	// the felt wherever it's pointed, centred at half its body height (the
+	// group origin is the slab's middle, not its base)
+	if (isDeck) {
+		const count = ('cards' in entity ? entity.cards : undefined)?.length ?? 0;
+		const restY = TABLE_TOP_Y + deckHeightForCount(count) / 2;
+		return {
+			kind: 'table',
+			position: [x, restY, z],
+			rotation,
+			footprint: { shape: 'rect', w: CARD_WIDTH, h: CARD_HEIGHT },
 			footprintY: TABLE_TOP_Y
 		};
 	}

--- a/src/lib/websocket/storeIntegration.ts
+++ b/src/lib/websocket/storeIntegration.ts
@@ -120,9 +120,7 @@ export function wsWrapperUpdateGameState(fn: Function) {
 		console.log('ws update gamestate: spread args', ...args);
 		const metadata = createWsMetaData();
 		if (!metadata.playerId || metadata.playerId === '') {
-			console.warn(
-				'wsWrapperUpdateGameState: No playerId found when creating websocket metadata'
-			);
+			console.warn('wsWrapperUpdateGameState: No playerId found when creating websocket metadata');
 			return fn(...args);
 		}
 
@@ -134,12 +132,13 @@ export function wsWrapperUpdateGameState(fn: Function) {
 		};
 
 		// NOTE: This is a hacky way to check if there are any position updates
-		// (cards AND pieces — anything draggable must go through the throttle,
-		// or pointer-move-rate messages trip the server rate limiter)
-		const hasPositionUpdate = [payload.value.cards, payload.value.pieces].some((collection) =>
-			Object.values(collection || {}).some(
-				(item: any) => !!item && Object.keys(item ?? {}).includes('position')
-			)
+		// (cards, pieces AND decks — anything draggable must go through the
+		// throttle, or pointer-move-rate messages trip the server rate limiter)
+		const hasPositionUpdate = [payload.value.cards, payload.value.pieces, payload.value.decks].some(
+			(collection) =>
+				Object.values(collection || {}).some(
+					(item: any) => !!item && Object.keys(item ?? {}).includes('position')
+				)
 		);
 		const now = Date.now();
 		const limitMs = 200;

--- a/src/routes/play/+page.svelte
+++ b/src/routes/play/+page.svelte
@@ -6,8 +6,11 @@
 	import { onMount } from 'svelte';
 	import { initWrappers } from '$lib/websocket/storeIntegration';
 	import { initWebsocket } from '$lib/websocket';
+	import { get } from 'svelte/store';
 	import { gameActions } from '$lib/store/game/actions';
+	import { dragStore } from '$lib/store/dragStore.svelte';
 	import { ungroupHoveredDeck } from '$lib/hotkeys/ungroup';
+	import { shuffleHoveredDeck } from '$lib/hotkeys/shuffle';
 	import { startAutoClaim } from '$lib/scenario/autoClaim';
 	import Pane from './Pane.svelte';
 	import { page } from '$app/state';
@@ -18,17 +21,28 @@
 	import toast from 'svelte-french-toast';
 
 	function handleKeyDown(event: KeyboardEvent) {
+		// hover-target routing: a hovered deck takes the key, otherwise it
+		// falls through to the hovered-card behavior
+		const hoveredDeck = get(dragStore).isDeckHovered;
 		if (event.code === 'Space') cameraTransforms.togglePreviewHud(true);
-		if (event.code === 'KeyF') gameActions.flipCard();
+		// F flips whatever is under the pointer — the whole deck beats the card
+		if (event.code === 'KeyF') {
+			if (hoveredDeck) gameActions.flipDeck(hoveredDeck);
+			else gameActions.flipCard();
+		}
 		if (event.code === 'KeyC') cameraTransforms.resetView();
 		if (event.code === 'KeyT') gameActions.tapCard();
 		if (event.code === 'KeyR') gameActions.tapCard(true);
+		if (event.code === 'KeyS') shuffleHoveredDeck();
 		// G groups the hovered pile into a deck; Shift+G spreads a hovered deck
 		// back into loose cards
 		if (event.code === 'KeyG' && event.shiftKey) ungroupHoveredDeck();
 		else if (event.code === 'KeyG') gameActions.groupStackIntoDeck();
 		if (event.code === 'ArrowUp') gameActions.incrementHeight(0.01);
 		if (event.code === 'ArrowDown') gameActions.incrementHeight(-0.01);
+		// number keys 1-9 on a hovered deck: draw that many, fanned toward you
+		const drawN = /^Digit([1-9])$/.exec(event.code);
+		if (drawN && hoveredDeck) gameActions.drawFromTop(hoveredDeck, Number(drawN[1]));
 	}
 
 	function handleKeyUp(event: KeyboardEvent) {

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -4,23 +4,37 @@
 	import TableScene from '$lib/TableScene.svelte';
 	import { cameraTransforms } from '$lib/utils/transforms/camera';
 	import { onMount } from 'svelte';
+	import { get } from 'svelte/store';
 	import { gameActions } from '$lib/store/game/actions';
+	import { dragStore } from '$lib/store/dragStore.svelte';
 	import { ungroupHoveredDeck } from '$lib/hotkeys/ungroup';
+	import { shuffleHoveredDeck } from '$lib/hotkeys/shuffle';
 	import { disconnect } from '$lib/websocket/connection';
 	import SetupPane from './SetupPane.svelte';
 
 	function handleKeyDown(event: KeyboardEvent) {
+		// hover-target routing: a hovered deck takes the key, otherwise it
+		// falls through to the hovered-card behavior (mirrors /play)
+		const hoveredDeck = get(dragStore).isDeckHovered;
 		if (event.code === 'Space') cameraTransforms.togglePreviewHud(true);
-		if (event.code === 'KeyF') gameActions.flipCard();
+		// F flips whatever is under the pointer — the whole deck beats the card
+		if (event.code === 'KeyF') {
+			if (hoveredDeck) gameActions.flipDeck(hoveredDeck);
+			else gameActions.flipCard();
+		}
 		if (event.code === 'KeyC') cameraTransforms.resetView();
 		if (event.code === 'KeyT') gameActions.tapCard();
 		if (event.code === 'KeyR') gameActions.tapCard(true);
+		if (event.code === 'KeyS') shuffleHoveredDeck();
 		// G groups the hovered pile into a deck; Shift+G spreads a hovered deck
 		// back into loose cards
 		if (event.code === 'KeyG' && event.shiftKey) ungroupHoveredDeck();
 		else if (event.code === 'KeyG') gameActions.groupStackIntoDeck();
 		if (event.code === 'ArrowUp') gameActions.incrementHeight(0.01);
 		if (event.code === 'ArrowDown') gameActions.incrementHeight(-0.01);
+		// number keys 1-9 on a hovered deck: draw that many, fanned toward you
+		const drawN = /^Digit([1-9])$/.exec(event.code);
+		if (drawN && hoveredDeck) gameActions.drawFromTop(hoveredDeck, Number(drawN[1]));
 	}
 
 	function handleKeyUp(event: KeyboardEvent) {

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -33,7 +33,7 @@ Every file carries an in-band discriminator at the top level: `"tbpp": 1` or `"t
 
 ### 2.1 Spec versions
 
-Current: **pack `1.0.0`**, **scenario `0.1.0`**. The scenario spec is `0.x` on purpose — under semver, `0.x` may break on every minor, which is precisely the promise being made.
+Current: **pack `1.0.0`**, **scenario `0.1.1`**. The scenario spec is `0.x` on purpose — under semver, `0.x` may break on every minor, which is precisely the promise being made.
 
 Two version fields exist and they answer different questions:
 
@@ -370,8 +370,8 @@ Decks spawn in declaration order. A facedown deck is shuffled when spawned direc
 	},
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"x-tableplace-spec-version": "1.0.0",
-	"x-generated-at": "2026-07-25T10:07:29.095Z",
-	"x-tableplace-source-sha": "8f51cd719fc58c03837df9059a6f2cbcd9a5d407-dirty"
+	"x-generated-at": "2026-07-25T13:32:45.257Z",
+	"x-tableplace-source-sha": "6ccfc198d3635c87b35a3752e3ac880f9087a12a-dirty"
 }
 ```
 
@@ -455,7 +455,7 @@ A scenario is a saved arrangement. Version 2 **references** packs rather than co
 
 ### 7.1 Fields
 
-- **`specVersion`** — the scenario spec you generated against (§2.1). Currently `0.1.0`.
+- **`specVersion`** — the scenario spec you generated against (§2.1). Currently `0.1.1`.
 - **`name`**, **`createdAt`** — title and a Unix epoch timestamp in milliseconds.
 - **`packs[]`** — `{ id, source? }` for every pack the scenario draws from. `source` is `"builtin"` for packs shipped with the app (currently only `standard-52`), or an `https://` URL a `.tbpp.json` can be fetched from. A remote pack goes through the same validation as a local import.
 - **`placements[]`** — one entry per spawned thing:
@@ -828,6 +828,11 @@ Scenarios are **seat-relative**. Entities belong to placeholder players `seat0`�
 					"description": "scenario authoring intent (tbps v2): reshuffle this deck on scenario load",
 					"type": "boolean",
 					"title": "shuffleOnLoad"
+				},
+				"shuffledAt": {
+					"description": "wall-clock ms of the last shuffle. Its only job is to CHANGE in the same\npatch as the reordered cards — the reorder alone is invisible from the\nback, the changed timestamp is what remote clients turn into the wiggle.",
+					"type": "number",
+					"title": "shuffledAt"
 				}
 			}
 		},
@@ -1079,9 +1084,9 @@ Scenarios are **seat-relative**. Entities belong to placeholder players `seat0`�
 		}
 	},
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"x-tableplace-spec-version": "0.1.0",
-	"x-generated-at": "2026-07-25T10:07:29.095Z",
-	"x-tableplace-source-sha": "8f51cd719fc58c03837df9059a6f2cbcd9a5d407-dirty"
+	"x-tableplace-spec-version": "0.1.1",
+	"x-generated-at": "2026-07-25T13:32:45.257Z",
+	"x-tableplace-source-sha": "6ccfc198d3635c87b35a3752e3ac880f9087a12a-dirty"
 }
 ```
 
@@ -1093,7 +1098,7 @@ Two packs — one builtin, one fetched from `https://example.com/packs/ember-due
 {
 	"$schema": "https://table.place/scenario.schema.json",
 	"tbps": 2,
-	"specVersion": "0.1.0",
+	"specVersion": "0.1.1",
 	"name": "ember-duel-opening",
 	"createdAt": 1700000000000,
 	"packs": [

--- a/static/pack.schema.json
+++ b/static/pack.schema.json
@@ -191,6 +191,6 @@
 	},
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"x-tableplace-spec-version": "1.0.0",
-	"x-generated-at": "2026-07-25T10:07:29.095Z",
-	"x-tableplace-source-sha": "8f51cd719fc58c03837df9059a6f2cbcd9a5d407-dirty"
+	"x-generated-at": "2026-07-25T13:32:45.257Z",
+	"x-tableplace-source-sha": "6ccfc198d3635c87b35a3752e3ac880f9087a12a-dirty"
 }

--- a/static/scenario.schema.json
+++ b/static/scenario.schema.json
@@ -352,6 +352,11 @@
 					"description": "scenario authoring intent (tbps v2): reshuffle this deck on scenario load",
 					"type": "boolean",
 					"title": "shuffleOnLoad"
+				},
+				"shuffledAt": {
+					"description": "wall-clock ms of the last shuffle. Its only job is to CHANGE in the same\npatch as the reordered cards — the reorder alone is invisible from the\nback, the changed timestamp is what remote clients turn into the wiggle.",
+					"type": "number",
+					"title": "shuffledAt"
 				}
 			}
 		},
@@ -603,7 +608,7 @@
 		}
 	},
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"x-tableplace-spec-version": "0.1.0",
-	"x-generated-at": "2026-07-25T10:07:29.095Z",
-	"x-tableplace-source-sha": "8f51cd719fc58c03837df9059a6f2cbcd9a5d407-dirty"
+	"x-tableplace-spec-version": "0.1.1",
+	"x-generated-at": "2026-07-25T13:32:45.257Z",
+	"x-tableplace-source-sha": "6ccfc198d3635c87b35a3752e3ac880f9087a12a-dirty"
 }


### PR DESCRIPTION
Task: tableplace-88
Closes #88

Source: `docs/research/deck-manipulation-primitives.md` (A3, B1, B2, B3). All client-side, every mutation patch-shaped; no server/protocol change.

## Deck drag vs draw (A3)
- Deck `pointerdown` now only arms the gesture with the same 5px threshold Card/Piece use: move past it → drag the whole deck; release under it → draw 1 (via `onclick` + `e.delta`, so a sub-threshold jiggle still draws).
- Dragged decks stream through `TableScene`'s drag loop at card height and **join the position-throttle check in `storeIntegration.ts`**, so pointer-move-rate patches can't trip the server rate limiter.
- `resolveDrop`/`commitActiveDrag` grew a deck branch: a dragged pile settles on the felt at half its body height (decks don't nest/stack/enter the tray), Esc returns it to its pickup origin, and Deck.svelte gained Piece's lift/glide springs so remote peers see a smooth glide between throttled ticks.
- The deck drop-target highlight is now card-drags-only — a dragged deck perpetually hovers itself.

## Flip whole deck (B2)
- `flipDeck` action + `F` while hovering a deck (falls through to the card flip otherwise). Toggling `isFaceUp` alone is the physical flip: the draw convention (facedown top = last element, face-up top = first) makes the former bottom card the new visually-top card, so subsequent draws come from the correct end. Unit-tested both directions.

## Shuffle hotkey + visible feedback (B3)
- `S` while hovering one of your own decks (ownership + toast mirror `Shift+G`; the pane button is unchanged).
- New `shuffledAt` field on `DeckDTO` rides the same patch as the reorder; every client's Deck plays a decaying yaw wiggle when it changes. Seeded on mount so late joiners don't replay a pre-join shuffle. Schemas regenerated.

## Draw N (B1)
- `drawFromTop(id, count)` + number keys 1–9 on a hovered deck. Drawn cards land between the deck and the drawer's seat, cascaded one `CARD_FAN_STEP` apart and one `CARD_THICKNESS` up in Y (no Y-tower), clamped to the table. Deck shrink + landings commit in ONE patch so remote clients never see a card in both places.
- `/setup` mirrors the new bindings (it already mirrored the rest of the keydown handler).

## Verification
- `bun run test`: 38 files / 402 tests pass, including new `deck-verbs.test.ts` (draw-N order/fan/clamp, flip convention, shuffledAt stamp, deck drop resolution) and updated `group-stack` tests for the new return shape.
- `bun run check`: 0 errors (warnings are the pre-existing spring-init pattern).
- `bun run build` passes; `eslint` problem count identical to main (59); prettier failures are baseline-only (this branch actually fixes one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuukVQiLRFysmLCaPu2sRz