### PR TITLE
tableplace-96: snap points — authored placement guides that snap on drop

### DIFF
--- a/docs/packs.md
+++ b/docs/packs.md
@@ -147,6 +147,31 @@ Scenarios are **seat-relative**: entities belong to placeholder players `seat0`�
   - **`isFaceUp`** (decks), **`value`** (counter pieces), **`scale`** (overlays) — arrangement details that override the pack's defaults.
 - **`state`** — a `Partial<GameDTO>` snapshot (`src/lib/store/game/types.ts`) for everything _not_ pack-derived: ad-hoc pieces, hand-placed cards, TTS-imported decks. It is applied on top of the spawned placements, so it can also override them.
 
+### snapPoints — placement guides
+
+`snapPoints` (optional, any version) is a flat array of authored spots on the felt that dropped cards and pieces gravitate to — TTS's core placement primitive, and what turns an imported pile of floating objects into a playable board.
+
+```json
+"snapPoints": [
+	{ "position": [0, 2.5], "rotation": 0, "radius": 1 },
+	{ "position": [-4, 0] }
+]
+```
+
+- **`position`** — table-space `[x, z]`. Two elements, no y: the point is a spot on the felt and what lands there keeps its own resting height, so a second card on the same point still stacks on the first.
+- **`rotation`** (optional) — the yaw a caught drop turns to, in **degrees**. Placements use radians; this uses degrees, because it is a single table yaw that maps 1:1 onto the card DTO's tap rotation (`actions/card.ts`) and onto TTS's `SnapPoints`. Omitted means "position only — leave the facing alone".
+- **`radius`** (optional) — catch radius in world units, defaulting to `SNAP_RADIUS_DEFAULT` (`utils/constants-snap.ts`). Nearest point wins where radii overlap.
+
+Snap points are **table-scoped and not seat-relative** — unlike a pack piece's `[x, z]` they are never mirrored, so both ends of a board are authored explicitly. In the store they live in `GameDTO.snapPoints` keyed `snap:<n>`; the file drops those ids (nothing references them) and reassigns them on load, which is why the field is an array rather than a record.
+
+**How it lands, and why there is no new sync machinery.** `resolveSnap` (`utils/transforms/snap.ts`) is a pure nearest-point-within-radius search; `resolveDrop` calls it and returns `kind: 'snap'`, and the commit writes that final position — plus the rotation, but only when a point authored one — through the same move path as any other drop. The relay carries that one patch, so both clients end on the identical transform. Resolution order is tray → hovered deck → Alt's opt-out → snap point → loose-pile square-up: aimed-at targets beat authored intent, and authored intent beats where cards happen to have drifted.
+
+**Visibility.** Markers are drawn only in /setup (`TableFeatures.snapEditing`). In /play the board stays clean and the feedback is the drop preview instead: when a drag is caught, the footprint jumps onto the point in its own colour, already turned to the authored yaw, with a ring showing what caught it. Permanent rings under every authored slot would clutter exactly the boards that use snap points most.
+
+Authoring lives in the /setup pane's **Snap points** folder plus direct manipulation in the scene: arm "place on click" and click the felt, drag a marker to move it, right-click to delete. `gameActions.addSnapPoint` / `moveSnapPoint` / `updateSnapPoint` / `removeSnapPoint` (`store/game/actions/snap.ts`) are ordinary surgical patches, `null` to delete, exactly like a piece's.
+
+TTS save-level `SnapPoints` import is deliberately _not_ wired up here (issue #96 scope); the shape is kept close to TTS's position-plus-rotation so that mapping stays mechanical when the importer envelope work lands.
+
 Export decides per entity: content carrying pack provenance (a `packOrigin` stamp, written by `spawnPack`) becomes a pack ref + placement; everything else falls back to the raw snapshot. A table with no pack content at all still exports as **v1**.
 
 ### Versions
@@ -210,5 +235,7 @@ Open questions the format deliberately does **not** answer yet. They are listed 
 - **Card multiplicity.** `PackCardDef` has no `count`. Three copies of a card means three entries with distinct `code`s (`strike-1`, `strike-2`, …), because `code` is the per-deck identity that scenario `order` arrays reference. Whether multiplicity becomes a first-class field — and what it would do to `order` — is undecided.
 - **Pack content versioning.** `tbpp` versions the _format_, not the pack. A pack cannot declare "Ember Duel v1.2", and there is no upgrade story for a pack whose cards changed underneath a scenario that references it by URL.
 - **`id` collision policy across authors.** Pack `id` is a bare string with no namespacing, registry, or ownership check. Two authors can both ship `ember-duel`, and `resolve-packs.ts` only warns when a fetched pack's `id` disagrees with the ref. Until this is decided, the practical advice is a distinctive `id` plus a `source` URL you control.
+
+- **Snapping beyond discrete points.** `snapPoints` is a list of spots. Grids (square/hex), per-object snap opt-outs, and hidden/layout/randomize zones have no syntax, and a snap point cannot restrict what is allowed to land on it. Pack-level snap sets (a snap layout that travels with an overlay, rather than with the scenario) are also unresolved — that would pull the pack schema and /create in under the parity rule, so it is deliberately left to a follow-up.
 
 `GamePackDef` also does not carry a board/table definition (SPEC §4d mentions one); overlays are the closest thing today.

--- a/scripts/llms-txt.ts
+++ b/scripts/llms-txt.ts
@@ -35,6 +35,7 @@ import {
 	PIECE_RADIUS,
 	COUNTER_MAX_DEFAULT
 } from '../src/lib/utils/constants-pieces';
+import { SNAP_RADIUS_DEFAULT } from '../src/lib/utils/constants-snap';
 import { TBPP_VERSION, PACK_SCHEMA_URL } from '../src/lib/packs/file';
 import { TBPS_VERSION, TBPS_SUPPORTED, SCENARIO_SCHEMA_URL } from '../src/lib/scenario/file';
 import { PACK_SPEC_VERSION, SCENARIO_SPEC_VERSION } from '../src/lib/formats/spec-version';
@@ -66,7 +67,8 @@ const CONSTANTS: [name: string, value: number | string, note: string][] = [
 	['PIECE_RADIUS.token', PIECE_RADIUS.token, 'default radius per kind — token'],
 	['PIECE_RADIUS.pawn', PIECE_RADIUS.pawn, 'default radius per kind — pawn'],
 	['PIECE_RADIUS.counter', PIECE_RADIUS.counter, 'default radius per kind — counter'],
-	['COUNTER_MAX_DEFAULT', COUNTER_MAX_DEFAULT, 'starting max for a counter with no `maxValue`']
+	['COUNTER_MAX_DEFAULT', COUNTER_MAX_DEFAULT, 'starting max for a counter with no `maxValue`'],
+	['SNAP_RADIUS_DEFAULT', SNAP_RADIUS_DEFAULT, 'catch radius of a snap point that omits `radius`']
 ];
 
 function constantsTable(): string {

--- a/scripts/llms.template.md
+++ b/scripts/llms.template.md
@@ -184,17 +184,37 @@ A scenario is a saved arrangement. Version 2 **references** packs rather than co
   - **`order`** _(decks)_ — the card sequence as pack card `code`s, top of the deck first. **Order is preserved by default**, so a rigged opening or a fixed encounter deck reloads exactly as authored. It is a list of ids, never card bodies. Unknown codes are skipped with a warning.
   - **`shuffleOnLoad`** _(decks, default `false`)_ — shuffle on load instead of restoring `order`. Per placement, so one scenario can hold a stacked encounter deck and a shuffled draw deck side by side.
   - **`isFaceUp`** _(decks)_, **`value`** _(counter pieces)_, **`scale`** _(overlays)_ — override the pack's defaults.
+- **`snapPoints[]`** _(optional)_ — placement guides on the felt (§7.2 below). Independent of `placements`: they steer what players drop, not what the scenario spawns.
 - **`state`** — a partial snapshot for everything _not_ pack-derived: hand-placed cards, ad-hoc pieces. Applied on top of the placements, so it can also override them. This is the part of the format most likely to change; keep as little in it as you can.
 
 Scenarios are **seat-relative**. Entities belong to placeholder players `seat0`–`seat3`, and entity ids follow `kind:owner:slug` — `deck:seat0:main`, `card:seat0:main-AS`, `piece:seat0:hp-0`. Overlays are table-scoped and keyed `overlay:<packId>:<index>`. When a real player claims a seat, every id containing that placeholder is renamed to them. Never put a real player id in a file.
 
-### 7.2 JSON Schema
+### 7.2 Snap points — placement guides
+
+`snapPoints` is how a scenario makes a board _playable_ rather than merely arranged. Each entry is a spot on the felt that pulls drops onto itself:
+
+```json
+"snapPoints": [
+	{ "position": [0, 2.5], "rotation": 0, "radius": 1 },
+	{ "position": [-4, 0] }
+]
+```
+
+- **`position`** — `[x, z]` in table space (§4). Two elements, no y: a snap point is a spot on the felt, and what lands on it keeps its own resting height, so a card dropped on an occupied point still stacks on what is already there.
+- **`rotation`** _(optional)_ — the yaw a caught drop turns to, in **degrees**. Note the unit: `placements[].rotation` is radians, this is degrees, because it maps 1:1 onto a card's own tap rotation and onto TTS snap points. Omit it for a position-only guide, which leaves whatever lands facing as it was.
+- **`radius`** _(optional)_ — catch radius in world units. Omitted means `SNAP_RADIUS_DEFAULT` (§4). A drop lands on a point when its release is inside the radius; when radii overlap, the nearest point wins.
+
+Snap points are **table-scoped, not seat-relative**: unlike a pack piece's `[x, z]`, they are never mirrored for the far side of the table. Author both ends explicitly — one at `[0, 2.5]` facing `0`, one at `[0, -2.5]` facing `180`.
+
+They are inert data. Nothing spawns from them, they claim no ids, they are drawn only in the scenario editor, and a player can always ignore one by holding Alt as they release. A scenario with no `snapPoints` behaves exactly as it did before the field existed.
+
+### 7.3 JSON Schema
 
 {{SCENARIO_SCHEMA}}
 
-### 7.3 Worked example
+### 7.4 Worked example
 
-Two packs — one builtin, one fetched from `{{EXAMPLE_PACK_URL}}` (the pack in §6.3) — with a stacked deck for seat 0, a shuffled deck for seat 1, a counter, a board overlay, and one hand-placed token in `state`.
+Two packs — one builtin, one fetched from `{{EXAMPLE_PACK_URL}}` (the pack in §6.3) — with a stacked deck for seat 0, a shuffled deck for seat 1, a counter, a board overlay, three snap points, and one hand-placed token in `state`.
 
 {{SCENARIO_EXAMPLE}}
 
@@ -206,6 +226,7 @@ Deliberately unresolved. Do not invent syntax for these — a file using it will
 - **Pack content versioning.** `tbpp` is the _format_ version; a pack cannot declare its own version ("Ember Duel v1.2"). There is no field for it and no upgrade story for a pack whose contents changed under a scenario that references it.
 - **`id` collision policy across authors.** Pack `id` is a bare string with no namespacing or registry. Two authors can both publish `ember-duel`, and a scenario referencing `ember-duel` by a URL that later serves different content will silently resolve differently. Until this is decided, prefer a distinctive `id` and always pin `source` to a URL you control.
 - **Pieces and overlays in scenarios beyond the fields above** — piece rotation, stacking and zones are not expressible.
+- **Snapping beyond single points.** `snapPoints` is a list of discrete spots. Grids (square/hex), per-object opt-outs, and hidden/layout/randomize zones have no syntax; a snap point cannot restrict _what_ may land on it either.
 
 ## 9. Before you emit a file
 

--- a/src/lib/SnapPointMarker.svelte
+++ b/src/lib/SnapPointMarker.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	import { T } from '@threlte/core';
+	import { get } from 'svelte/store';
+	import type { IntersectionEvent } from '@threlte/extras';
+	import { DEG2RAD } from 'three/src/math/MathUtils.js';
+	import { gameStore } from './store/game/gameStore.svelte';
+	import { gameActions } from './store/game/actions';
+	import { dragStore } from './store/dragStore.svelte';
+	import { claimPointerDown } from '$lib/utils/single-hit-dispatch';
+	import { snapRadius } from '$lib/utils/transforms/snap';
+	import {
+		SNAP_MARKER_COLOR,
+		SNAP_MARKER_COLOR_ACTIVE,
+		SNAP_MARKER_Y
+	} from '$lib/utils/constants-snap';
+	import DropFootprint from './drop/DropFootprint.svelte';
+
+	/**
+	 * One authored snap point, drawn flat on the felt: a ring at its catch
+	 * radius, a dot on the point itself, and a tick pointing along the yaw when
+	 * one is authored.
+	 *
+	 * Editor-only — `TableScene` mounts these behind `snapEditing`, so /play
+	 * never draws them (see `store/tableFeatures`). Drag to move, right-click to
+	 * delete; the pane has the same operations with exact numbers.
+	 *
+	 * The drag is deliberately local rather than routed through `dragStore`:
+	 * that store is the card/piece pipeline, whose every consumer assumes the
+	 * dragged id is an entity in `cards`/`pieces` that a drop resolves a landing
+	 * for. A snap point has no landing — it *is* one. All it needs is the table
+	 * raycast point, which `TableScene.compute` already publishes on every
+	 * pointer move.
+	 */
+
+	let { id }: { id: string } = $props();
+
+	const point = $derived($gameStore?.snapPoints?.[id]);
+	const radius = $derived(snapRadius(point));
+	const yaw = $derived(point?.rotation);
+	const x = $derived(point?.position?.[0] ?? 0);
+	const z = $derived(point?.position?.[1] ?? 0);
+
+	let isHovered = $state(false);
+	let isMoving = $state(false);
+	const color = $derived(isMoving || isHovered ? SNAP_MARKER_COLOR_ACTIVE : SNAP_MARKER_COLOR);
+
+	function onMove() {
+		const hit = get(dragStore).intersectionPoint;
+		if (!hit) return;
+		// clamped inside the felt by moveSnapPoint, same as any other placement
+		gameActions.moveSnapPoint(id, [hit.x, hit.z]);
+	}
+
+	function stopMoving() {
+		isMoving = false;
+		window.removeEventListener('pointermove', onMove);
+		window.removeEventListener('pointerup', stopMoving);
+		window.removeEventListener('pointercancel', stopMoving);
+	}
+
+	// leaving the editor (or a scenario load removing this point) mid-drag must
+	// not leave the window listeners behind
+	$effect(() => stopMoving);
+
+	function handlePointerDown(e: IntersectionEvent<PointerEvent>) {
+		// a card/piece drag in flight owns the pointer — never steal it, or a
+		// release over a marker would move the marker instead of landing the card
+		if (get(dragStore).isDragging) return;
+		if (!claimPointerDown(e)) return;
+		isMoving = true;
+		window.addEventListener('pointermove', onMove);
+		window.addEventListener('pointerup', stopMoving);
+		window.addEventListener('pointercancel', stopMoving);
+	}
+
+	function handleContextMenu(e: IntersectionEvent<MouseEvent>) {
+		e.stopPropagation();
+		e.nativeEvent.preventDefault();
+		gameActions.removeSnapPoint(id);
+	}
+</script>
+
+{#if point?.position}
+	<T.Group
+		position={[x, SNAP_MARKER_Y, z]}
+		onpointerdown={handlePointerDown}
+		oncontextmenu={handleContextMenu}
+		onpointerenter={() => (isHovered = true)}
+		onpointerleave={() => (isHovered = false)}
+	>
+		<T.Group rotation.x={-Math.PI / 2}>
+			<DropFootprint shape="circle" r={radius} {color} fill={0.14} border={0.045} />
+			<!-- the point itself: the ring shows the catch radius, this shows where
+			     a caught drop actually lands -->
+			<T.Mesh position.z={0.003}>
+				<T.CircleGeometry args={[0.07, 16]} />
+				<T.MeshBasicMaterial {color} transparent opacity={0.95} depthWrite={false} side={2} />
+			</T.Mesh>
+			{#if yaw !== undefined}
+				<!-- yaw tick. -yaw about the view axis matches how a card renders its
+				     table rotation (Card.svelte: rotation.y = -rotation[2]), so the
+				     tick points where a caught card's top edge will face. -->
+				<T.Group rotation.z={-yaw * DEG2RAD}>
+					<T.Mesh position={[0, radius / 2, 0.003]}>
+						<T.PlaneGeometry args={[0.05, radius]} />
+						<T.MeshBasicMaterial {color} transparent opacity={0.9} depthWrite={false} side={2} />
+					</T.Mesh>
+				</T.Group>
+			{/if}
+		</T.Group>
+	</T.Group>
+{/if}

--- a/src/lib/Table.svelte
+++ b/src/lib/Table.svelte
@@ -3,10 +3,15 @@
 	import * as THREE from 'three';
 	import { onDestroy } from 'svelte';
 	import { Grid } from '@threlte/extras';
+	import { get } from 'svelte/store';
 	import { gameStore } from './store/game/gameStore.svelte';
+	import { gameActions } from './store/game/actions';
 	import OverlayCustom from './table-overlay/OverlayCustom.svelte';
 	import { commitActiveDrag } from './drop/commit';
-	import { setNoSnap } from './store/dragStore.svelte';
+	import { dragStore, setNoSnap } from './store/dragStore.svelte';
+	import { snapEditor } from './store/snapEditor';
+	import { tableFeatures } from './store/tableFeatures';
+	import { DRAG_THRESHOLD_PX } from './utils/counter-input';
 	import type { IntersectionEvent } from '@threlte/extras';
 	import { TABLE_TOP_Y } from './utils/constants-table';
 
@@ -21,6 +26,38 @@
 	function handleDragEnd(event: IntersectionEvent<PointerEvent>) {
 		setNoSnap(event.nativeEvent.altKey);
 		commitActiveDrag();
+	}
+
+	/**
+	 * Snap-point placement (the /setup layer, armed from its pane): a plain click
+	 * on bare felt drops a snap point where it landed.
+	 *
+	 * Two things have to be excluded, because the browser fires `click` for both:
+	 * a card drag that happened to be released over the table (its pointerdown
+	 * was claimed by the card, so the felt never saw one), and an OrbitControls
+	 * camera drag that started on the felt (same down/up element, just moved) —
+	 * hence the travel threshold.
+	 */
+	let pressedFelt: { x: number; y: number } | null = null;
+
+	function handlePointerDown(event: IntersectionEvent<PointerEvent>) {
+		pressedFelt = get(dragStore).isDragging
+			? null
+			: { x: event.nativeEvent.clientX, y: event.nativeEvent.clientY };
+	}
+
+	function handleClick(event: IntersectionEvent<MouseEvent>) {
+		const pressed = pressedFelt;
+		pressedFelt = null;
+		const { placing, rotation, radius } = get(snapEditor);
+		if (!placing || !pressed || !get(tableFeatures).snapEditing) return;
+		const travel = Math.hypot(
+			event.nativeEvent.clientX - pressed.x,
+			event.nativeEvent.clientY - pressed.y
+		);
+		if (travel >= DRAG_THRESHOLD_PX) return; // that was a camera orbit
+		event.stopPropagation();
+		gameActions.addSnapPoint({ position: [event.point.x, event.point.z], rotation, radius });
 	}
 
 	// Create procedural felt texture. Built synchronously: this component only
@@ -122,7 +159,13 @@
 	infiniteGrid
 />
 <T.Group position={[0, 0, 0]}>
-	<T.Mesh receiveShadow bind:ref={mesh} onpointerup={handleDragEnd}>
+	<T.Mesh
+		receiveShadow
+		bind:ref={mesh}
+		onpointerup={handleDragEnd}
+		onpointerdown={handlePointerDown}
+		onclick={handleClick}
+	>
 		<T.BoxGeometry args={[60, 0.5, 30]} />
 		<!-- one stable material with its map from birth.
 		     (swapping whole materials via {#if}+<T is> detaches without reattaching in threlte 8.5) -->

--- a/src/lib/TableScene.svelte
+++ b/src/lib/TableScene.svelte
@@ -9,6 +9,7 @@
 	import HudTrayScene from '$lib/HUDTray/HUDTrayScene.svelte';
 	import Deck from './Deck.svelte';
 	import Piece from './Piece.svelte';
+	import SnapPointMarker from './SnapPointMarker.svelte';
 	import Hdr from './HDR.svelte';
 	import HudPreviewScene from './HUDPreview/HUDPreviewScene.svelte';
 	import RemoteCameraAvatar from './RemoteCameraAvatar.svelte';
@@ -33,11 +34,15 @@
 	 * a pack has no way to represent a hand). It also has to reach the drop
 	 * resolver — the tray hover flag is module-global and can arrive stale from
 	 * a previous /play visit, so an unmounted tray must not win a drop.
+	 *
+	 * `snapEditing` draws the authored snap-point markers and makes them
+	 * draggable — the /setup layer. Snapping itself needs no flag: it is part of
+	 * resolving a drop wherever the points exist.
 	 */
-	let { hand = true }: { hand?: boolean } = $props();
+	let { hand = true, snapEditing = false }: { hand?: boolean; snapEditing?: boolean } = $props();
 
 	$effect(() => {
-		setTableFeatures({ hand });
+		setTableFeatures({ hand, snapEditing });
 		if (!hand) setTrayHover(false);
 		return () => setTableFeatures(TABLE_FEATURES_DEFAULT);
 	});
@@ -194,6 +199,13 @@
 {#each Object.keys($gameStore?.pieces ?? {}).filter((key) => $gameStore?.pieces?.[key]) as id (id)}
 	<Piece {id} />
 {/each}
+
+<!-- authored placement guides, drawn only while they're being authored -->
+{#if snapEditing}
+	{#each Object.keys($gameStore?.snapPoints ?? {}).filter((key) => $gameStore?.snapPoints?.[key]) as id (id)}
+		<SnapPointMarker {id} />
+	{/each}
+{/if}
 
 {#each remoteCameras as { id, color } (id)}
 	<RemoteCameraAvatar playerId={id} {color} />

--- a/src/lib/drop/DropIndicator.svelte
+++ b/src/lib/drop/DropIndicator.svelte
@@ -6,6 +6,7 @@
 	import { gameStore } from '$lib/store/game/gameStore.svelte';
 	import { tableFeatures } from '$lib/store/tableFeatures';
 	import { resolveDrop } from '$lib/utils/transforms/drop';
+	import { SNAP_DROP_COLOR } from '$lib/utils/constants-snap';
 	import { resolveCardImage, sheetRefCache } from '$lib/packs';
 	import DropFootprint from './DropFootprint.svelte';
 
@@ -21,7 +22,7 @@
 
 	// clear of the table Grid (0.255) and the map overlay plane (0.258)
 	const SURFACE_CLEARANCE = 0.0025;
-	const COLORS = { table: '#5ee7ff', stack: '#ffc94a' } as const;
+	const COLORS = { table: '#5ee7ff', stack: '#ffc94a', snap: SNAP_DROP_COLOR } as const;
 
 	const dragId = $derived($dragStore.isDragging);
 
@@ -39,7 +40,17 @@
 
 	// the deck / tray highlights are the cue for those targets — a table
 	// footprint there would promise a landing that isn't going to happen
-	const visible = $derived(drop?.kind === 'table' || drop?.kind === 'stack');
+	const visible = $derived(
+		drop?.kind === 'table' || drop?.kind === 'stack' || drop?.kind === 'snap'
+	);
+
+	/**
+	 * A caught snap point is the whole feedback for snapping in /play, where the
+	 * markers themselves aren't drawn (see `store/tableFeatures`): the footprint
+	 * jumps onto the point, in its own colour, already turned to the authored
+	 * yaw. The ring behind it shows what caught it.
+	 */
+	const snapRing = $derived(drop?.kind === 'snap' ? (drop.snap?.radius ?? 0) : 0);
 
 	// primitives, not the resolved objects: all of this recomputes on every
 	// pointer move, and threlte rebuilds a geometry whenever its `args` array
@@ -48,7 +59,9 @@
 	const w = $derived(drop?.footprint.shape === 'rect' ? drop.footprint.w : 0);
 	const h = $derived(drop?.footprint.shape === 'rect' ? drop.footprint.h : 0);
 	const r = $derived(drop?.footprint.shape === 'circle' ? drop.footprint.r : 0);
-	const color = $derived(drop?.kind === 'stack' ? COLORS.stack : COLORS.table);
+	const color = $derived(
+		drop?.kind === 'snap' ? COLORS.snap : drop?.kind === 'stack' ? COLORS.stack : COLORS.table
+	);
 	const posX = $derived(drop?.position[0] ?? 0);
 	const posZ = $derived(drop?.position[2] ?? 0);
 	const surfaceY = $derived((drop?.footprintY ?? 0) + SURFACE_CLEARANCE);
@@ -82,6 +95,12 @@
 
 {#if visible}
 	<T.Group position={[posX, surfaceY, posZ]}>
+		{#if snapRing > 0}
+			<!-- unrotated: the ring belongs to the point, not to what lands on it -->
+			<T.Group rotation.x={-Math.PI / 2}>
+				<DropFootprint shape="circle" r={snapRing} color={COLORS.snap} fill={0.1} border={0.04} />
+			</T.Group>
+		{/if}
 		<T.Group rotation.y={yaw}>
 			<T.Group rotation.x={-Math.PI / 2}>
 				<DropFootprint {shape} {w} {h} {r} {color} />

--- a/src/lib/drop/__tests__/commit.test.ts
+++ b/src/lib/drop/__tests__/commit.test.ts
@@ -1,0 +1,121 @@
+/**
+ * What a release actually writes (tableplace-96).
+ *
+ * `resolveDrop` decides the landing and is unit-tested next to the stacking
+ * math; this covers the other half — that the commit writes exactly that
+ * landing, and that a snap point with an authored yaw is the *only* case where
+ * a drop puts a rotation on the wire. Both clients end up on the same transform
+ * because this one patch is what the relay carries; nothing about snapping is
+ * synced separately.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { commitActiveDrag } from '../commit';
+import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { dragActions, dragStart, dragStore } from '$lib/store/dragStore.svelte';
+import { CARD_REST_Y, deckHeightForCount } from '$lib/utils/constants-cards';
+import { PIECE_REST_Y } from '$lib/utils/constants-pieces';
+import { TABLE_TOP_Y } from '$lib/utils/constants-table';
+import type { GameDTO } from '$lib/store/game/types';
+
+const CARD = 'card:me:a';
+const PIECE = 'piece:me:t';
+const DECK = 'deck:me:main';
+const DECK_SIZE = 20;
+
+/** a table holding one card, one token, one deck, and two snap points */
+function seed(snapPoints: NonNullable<GameDTO['snapPoints']>) {
+	gameStore.set({
+		players: {},
+		decks: {
+			[DECK]: {
+				id: DECK,
+				position: [0, 2, 0],
+				rotation: [0, 0, 0],
+				cards: Array.from({ length: DECK_SIZE }, (_, i) => ({
+					id: `c${i}`,
+					faceImageUrl: 'f.png'
+				}))
+			}
+		},
+		cards: { [CARD]: { position: [0, 2, 0], rotation: [0, 0, 0], faceImageUrl: 'f.png' } },
+		pieces: { [PIECE]: { position: [0, 1.2, 0], rotation: [0, 0, 0], kind: 'token', name: 'T' } },
+		snapPoints
+	});
+}
+
+/** release `id` with the pointer over (x, z) */
+function release(id: string, x: number, z: number) {
+	dragStart(id, 2);
+	// the table raycast the drop resolves against, as TableScene publishes it
+	dragStore.update((state) => ({ ...state, intersectionPoint: { x, z } as never }));
+	commitActiveDrag();
+}
+
+describe('commitActiveDrag with authored snap points', () => {
+	beforeEach(() => {
+		dragActions.reset();
+		vi.restoreAllMocks();
+		seed({
+			'snap:0': { id: 'snap:0', position: [6, 3], radius: 1, rotation: 90 },
+			'snap:1': { id: 'snap:1', position: [-6, 3], radius: 1 }
+		});
+	});
+
+	it('lands a card on the point and turns it to the authored yaw', () => {
+		release(CARD, 6.4, 3.2);
+		expect(get(gameStore).cards?.[CARD]).toMatchObject({
+			position: [6, CARD_REST_Y, 3],
+			rotation: [0, 0, 90]
+		});
+	});
+
+	it('lands a token on the point at piece rest height', () => {
+		release(PIECE, 6.4, 3);
+		expect(get(gameStore).pieces?.[PIECE]).toMatchObject({
+			position: [6, PIECE_REST_Y, 3],
+			rotation: [0, 90, 0]
+		});
+	});
+
+	it('lands a whole dragged deck on the point, turned in radians', () => {
+		// the composition of tableplace-88 (drag a deck) with this ticket: the
+		// deck's own resting half-height survives, the point decides XZ and yaw
+		release(DECK, 6.4, 3.1);
+		const deck = get(gameStore).decks?.[DECK];
+		expect([deck?.position?.[0], deck?.position?.[2]]).toEqual([6, 3]);
+		expect(deck?.position?.[1]).toBeCloseTo(TABLE_TOP_Y + deckHeightForCount(DECK_SIZE) / 2);
+		expect(deck?.rotation?.[1]).toBeCloseTo(Math.PI / 2);
+	});
+
+	it('writes no rotation when the point authored none', () => {
+		const patch = vi.spyOn(gameStore, 'updateState');
+		release(CARD, -6.4, 3);
+		expect(patch).toHaveBeenCalledWith({ cards: { [CARD]: { position: [-6, CARD_REST_Y, 3] } } });
+	});
+
+	it('writes no rotation for an ordinary drop, so nothing unchanged goes on the wire', () => {
+		const patch = vi.spyOn(gameStore, 'updateState');
+		release(CARD, 1, 1);
+		expect(patch).toHaveBeenCalledWith({ cards: { [CARD]: { position: [1, CARD_REST_Y, 1] } } });
+	});
+
+	it('leaves the drag cleared afterwards, snapped or not', () => {
+		release(CARD, 6, 3);
+		expect(get(dragStore).isDragging).toBeNull();
+	});
+
+	it('ignores the points entirely when Alt was held at release', () => {
+		dragStart(CARD, 2);
+		dragStore.update((state) => ({
+			...state,
+			intersectionPoint: { x: 6.4, z: 3 } as never,
+			noSnap: true
+		}));
+		commitActiveDrag();
+		expect(get(gameStore).cards?.[CARD]).toMatchObject({
+			position: [6.4, CARD_REST_Y, 3],
+			rotation: [0, 0, 0]
+		});
+	});
+});

--- a/src/lib/drop/commit.ts
+++ b/src/lib/drop/commit.ts
@@ -3,7 +3,7 @@ import { dragEnd, dragStore } from '$lib/store/dragStore.svelte';
 import { gameStore } from '$lib/store/game/gameStore.svelte';
 import { gameActions } from '$lib/store/game/actions';
 import { tableFeatures } from '$lib/store/tableFeatures';
-import { resolveDrop } from '$lib/utils/transforms/drop';
+import { resolveDrop, type DropTarget } from '$lib/utils/transforms/drop';
 
 /**
  * Ending a drag, in one place.
@@ -42,14 +42,29 @@ export function commitActiveDrag() {
 	} else if (drop?.kind === 'deck' && drop.targetId) {
 		gameActions.placeOnTopOfDeck(drop.targetId, id);
 	} else if (drop && id.startsWith('piece:')) {
-		gameStore.updateState({ pieces: { [id]: { position: drop.position } } });
+		gameStore.updateState({ pieces: { [id]: dropPatch(drop) } });
 	} else if (drop && id.startsWith('deck:')) {
-		gameStore.updateState({ decks: { [id]: { position: drop.position } } });
+		gameStore.updateState({ decks: { [id]: dropPatch(drop) } });
 	} else if (drop) {
-		gameStore.updateState({ cards: { [id]: { position: drop.position } } });
+		gameStore.updateState({ cards: { [id]: dropPatch(drop) } });
 	}
 
 	dragEnd();
+}
+
+/**
+ * The state patch a landing writes. Position always; rotation only when the
+ * drop actually turned the entity — a snap point with an authored yaw. Every
+ * other kind resolves the rotation the entity already has, and re-sending it
+ * would put an unchanged field on the wire on every single drop.
+ */
+function dropPatch(drop: DropTarget): {
+	position: [number, number, number];
+	rotation?: [number, number, number];
+} {
+	return drop.snap?.rotation !== undefined
+		? { position: drop.position, rotation: drop.rotation }
+		: { position: drop.position };
 }
 
 /**
@@ -77,10 +92,9 @@ export function cancelActiveDrag() {
 
 function commitActiveDragAtRest(id: string) {
 	const drop = resolveDrop(get(gameStore), id, null);
-	if (drop && id.startsWith('piece:'))
-		gameStore.updateState({ pieces: { [id]: { position: drop.position } } });
+	if (drop && id.startsWith('piece:')) gameStore.updateState({ pieces: { [id]: dropPatch(drop) } });
 	else if (drop && id.startsWith('deck:'))
-		gameStore.updateState({ decks: { [id]: { position: drop.position } } });
-	else if (drop) gameStore.updateState({ cards: { [id]: { position: drop.position } } });
+		gameStore.updateState({ decks: { [id]: dropPatch(drop) } });
+	else if (drop) gameStore.updateState({ cards: { [id]: dropPatch(drop) } });
 	dragEnd();
 }

--- a/src/lib/formats/__tests__/spec-version.test.ts
+++ b/src/lib/formats/__tests__/spec-version.test.ts
@@ -20,6 +20,13 @@ const packFile = (overrides: Record<string, unknown> = {}) =>
 const scenarioFile = (overrides: Record<string, unknown> = {}) =>
 	JSON.stringify({ tbps: 1, name: 's', createdAt: 1, state: {}, ...overrides });
 
+// derived from the live version, so a spec bump doesn't turn "one minor ahead"
+// into a version this build already reads and quietly stop testing the rule
+const scenario = parseSemver(SCENARIO_SPEC_VERSION)!;
+const NEWER_SCENARIO_PATCH = `0.${scenario.minor}.${scenario.patch + 9}`;
+const NEWER_SCENARIO_MINOR = `0.${scenario.minor + 1}.0`;
+const OLDER_SCENARIO_PATCH = `0.${scenario.minor}.0`;
+
 describe('emitted documents declare their spec version', () => {
 	it('stamps a pack export', () => {
 		expect(JSON.parse(serializePackFile(STANDARD_52)).specVersion).toBe(PACK_SPEC_VERSION);
@@ -80,12 +87,22 @@ describe('a scenario importer applies the 0.x rule', () => {
 	});
 
 	it('accepts a newer patch', () => {
-		expect(() => parseScenarioFile(scenarioFile({ specVersion: '0.1.9' }))).not.toThrow();
+		expect(() =>
+			parseScenarioFile(scenarioFile({ specVersion: NEWER_SCENARIO_PATCH }))
+		).not.toThrow();
+	});
+
+	it('accepts an older patch — a file from before the last additive bump', () => {
+		// additive changes bump the patch while the spec is 0.x (see
+		// spec-version.ts), so this is what "the previous release" looks like
+		expect(() =>
+			parseScenarioFile(scenarioFile({ specVersion: OLDER_SCENARIO_PATCH }))
+		).not.toThrow();
 	});
 
 	it('refuses a newer minor, because 0.x minors are allowed to break', () => {
-		expect(() => parseScenarioFile(scenarioFile({ specVersion: '0.2.0' }))).toThrow(
-			/declares scenario spec 0\.2\.0/
+		expect(() => parseScenarioFile(scenarioFile({ specVersion: NEWER_SCENARIO_MINOR }))).toThrow(
+			new RegExp(`declares scenario spec ${NEWER_SCENARIO_MINOR.replace(/\./g, '\\.')}`)
 		);
 	});
 

--- a/src/lib/formats/examples.ts
+++ b/src/lib/formats/examples.ts
@@ -108,6 +108,15 @@ export const EXAMPLE_SCENARIO: ScenarioFile = {
 		{ kind: 'piece', pack: 'ember-duel', content: '0', seat: 0, value: 25 },
 		{ kind: 'overlay', pack: 'ember-duel', content: '0', scale: 14 }
 	],
+	// placement guides: a card or token released within `radius` of one of these
+	// lands exactly on it, turned to `rotation` when it has one. Table-space
+	// [x, z], not per-seat — they belong to the board.
+	snapPoints: [
+		{ position: [0, 2.5], rotation: 0, radius: 1 },
+		{ position: [0, -2.5], rotation: 180, radius: 1 },
+		// no rotation: a position guide that leaves the card facing as it was
+		{ position: [-4, 0] }
+	],
 	// anything not pack-derived: hand-placed props, ad-hoc counters
 	state: {
 		pieces: {

--- a/src/lib/formats/spec-version.ts
+++ b/src/lib/formats/spec-version.ts
@@ -23,8 +23,15 @@ export const PACK_SPEC_VERSION = '1.0.0';
  * The scenario spec is deliberately 0.x: it is unstable and carries no
  * compatibility promise (issue #39), and semver's 0.x rule — where the minor
  * is the breaking component — says exactly that.
+ *
+ * Which means, while this is 0.x, an **additive** change bumps the PATCH, not
+ * the minor. `breakingRank` below ranks 0.x by minor, so bumping the minor for
+ * a new optional field claims a break that did not happen, and every 0.1.x
+ * build then refuses files it could have read perfectly well. (The general
+ * "additive → minor" convention in docs/packs.md § Release convention is the
+ * 1.x rule; it inverts under 0.x.)
  */
-export const SCENARIO_SPEC_VERSION = '0.1.1';
+export const SCENARIO_SPEC_VERSION = '0.1.2';
 
 export type Semver = { major: number; minor: number; patch: number };
 

--- a/src/lib/scenario/__tests__/file.test.ts
+++ b/src/lib/scenario/__tests__/file.test.ts
@@ -48,6 +48,57 @@ describe('legacy scenario-<name>.json fallback (v0)', () => {
 	});
 });
 
+describe('snapPoints', () => {
+	const withSnap: Scenario = {
+		...scenario,
+		snapPoints: [{ position: [0, 2.5], rotation: 0, radius: 1 }, { position: [-4, 0] }]
+	};
+
+	it('round-trips through export → parse', () => {
+		expect(parseScenarioFile(serializeScenarioFile(withSnap))).toEqual(withSnap);
+	});
+
+	it('is written at the top level, not buried in state', () => {
+		const file = JSON.parse(serializeScenarioFile(withSnap));
+		expect(file.snapPoints).toHaveLength(2);
+		expect(file.state.snapPoints).toBeUndefined();
+	});
+
+	it('does not decide the file version — a hand-placed table stays v1', () => {
+		expect(JSON.parse(serializeScenarioFile(withSnap)).tbps).toBe(1);
+	});
+
+	it('keeps a rotation of 0 distinct from no rotation at all', () => {
+		const parsed = parseScenarioFile(serializeScenarioFile(withSnap));
+		expect(parsed.snapPoints?.[0].rotation).toBe(0);
+		expect(parsed.snapPoints?.[1]).toEqual({ position: [-4, 0] });
+	});
+
+	it('leaves a scenario without the field untouched — no key invented on read', () => {
+		const parsed = parseScenarioFile(serializeScenarioFile(scenario));
+		expect(parsed).toEqual(scenario);
+		expect('snapPoints' in parsed).toBe(false);
+	});
+
+	it('reports the offending path for a malformed point', () => {
+		const bad = (points: unknown) =>
+			JSON.stringify({ tbps: 1, name: 'x', state: {}, snapPoints: points });
+		expect(() => parseScenarioFile(bad('nope'))).toThrow(/`snapPoints` must be an array/);
+		expect(() => parseScenarioFile(bad([{}]))).toThrow(
+			/snapPoints\[0\]\.position must be \[x, z\]/
+		);
+		expect(() => parseScenarioFile(bad([{ position: [0, 0, 0] }]))).toThrow(
+			/snapPoints\[0\]\.position/
+		);
+		expect(() => parseScenarioFile(bad([{ position: [0, 0], rotation: 'east' }]))).toThrow(
+			/snapPoints\[0\]\.rotation must be a yaw in degrees/
+		);
+		expect(() => parseScenarioFile(bad([{ position: [0, 0], radius: 0 }]))).toThrow(
+			/snapPoints\[0\]\.radius must be a positive number/
+		);
+	});
+});
+
 describe('parseScenarioFile errors', () => {
 	it('rejects non-JSON', () => {
 		expect(() => parseScenarioFile('nope')).toThrow(/valid JSON/);

--- a/src/lib/scenario/__tests__/scenario-snap-points.test.ts
+++ b/src/lib/scenario/__tests__/scenario-snap-points.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Snap points have to survive the whole authoring pipeline — /setup edit →
+ * save → export → import → load — and land in the store in the shape the drop
+ * resolver reads (tableplace-96).
+ *
+ * The file keeps them as a top-level array with no ids; the store keys them
+ * `snap:<n>`. Everything below is about that translation holding in both
+ * directions, and about a scenario with no snap points behaving as it always
+ * did.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { gameActions } from '$lib/store/game/actions';
+import { resolveDrop } from '$lib/utils/transforms/drop';
+import { SNAP_RADIUS_DEFAULT } from '$lib/utils/constants-snap';
+import { CARD_REST_Y } from '$lib/utils/constants-cards';
+import { serializeScenarioFile } from '../file';
+import {
+	applyScenario,
+	ensureSeatPlaceholder,
+	importScenarioFromText,
+	saveScenario,
+	seatPlaceholderId
+} from '../scenario';
+
+const emptyTable = () =>
+	gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {}, overlays: {}, snapPoints: {} });
+
+const snapPointsInStore = () => get(gameStore).snapPoints ?? {};
+
+describe('authoring snap points in /setup', () => {
+	beforeEach(() => {
+		localStorage.clear();
+		emptyTable();
+	});
+
+	it('places, moves and deletes through ordinary state patches', () => {
+		const first = gameActions.addSnapPoint({ position: [3, 1], rotation: 90 });
+		const second = gameActions.addSnapPoint({ position: [-3, 1] });
+		expect(gameActions.snapPointIds()).toEqual([first, second]);
+		expect(snapPointsInStore()[first]).toMatchObject({
+			id: first,
+			position: [3, 1],
+			rotation: 90,
+			radius: SNAP_RADIUS_DEFAULT
+		});
+
+		gameActions.moveSnapPoint(first, [5, -2]);
+		expect(snapPointsInStore()[first]?.position).toEqual([5, -2]);
+
+		gameActions.updateSnapPoint(first, { radius: 2 });
+		expect(snapPointsInStore()[first]?.radius).toBe(2);
+
+		gameActions.removeSnapPoint(first);
+		expect(snapPointsInStore()[first]).toBeUndefined();
+		expect(gameActions.snapPointIds()).toEqual([second]);
+	});
+
+	it('clears an authored rotation back to "no rotation"', () => {
+		const id = gameActions.addSnapPoint({ position: [0, 0], rotation: 45 });
+		gameActions.updateSnapPoint(id, { rotation: undefined });
+		expect(snapPointsInStore()[id]?.rotation).toBeUndefined();
+	});
+
+	it('keeps ids clear of the points still on the table', () => {
+		gameActions.addSnapPoint({ position: [0, 0] });
+		const middle = gameActions.addSnapPoint({ position: [1, 1] });
+		gameActions.addSnapPoint({ position: [2, 2] });
+		gameActions.removeSnapPoint(middle);
+		// one past the highest in use — never a collision with a live point
+		expect(gameActions.addSnapPoint({ position: [3, 3] })).toBe('snap:3');
+	});
+
+	it('clamps a placement inside the felt', () => {
+		const id = gameActions.addSnapPoint({ position: [999, -999] });
+		const [x, z] = snapPointsInStore()[id]?.position ?? [0, 0];
+		expect(x).toBeLessThan(30);
+		expect(z).toBeGreaterThan(-15);
+	});
+});
+
+describe('snap points through save → export → import → load', () => {
+	beforeEach(() => {
+		localStorage.clear();
+		emptyTable();
+	});
+
+	it('round-trips as a top-level array and comes back keyed in the store', async () => {
+		ensureSeatPlaceholder(0);
+		gameActions.addPiece('token', { ownerId: seatPlaceholderId(0), name: 'Objective' });
+		gameActions.addSnapPoint({ position: [0, 2.5], rotation: 180, radius: 1.5 });
+		gameActions.addSnapPoint({ position: [-4, 0] });
+
+		const exported = serializeScenarioFile(saveScenario('snappy'));
+		expect(JSON.parse(exported).snapPoints).toEqual([
+			{ position: [0, 2.5], rotation: 180, radius: 1.5 },
+			{ position: [-4, 0], radius: SNAP_RADIUS_DEFAULT }
+		]);
+
+		emptyTable();
+		await applyScenario(importScenarioFromText(exported));
+		expect(Object.values(snapPointsInStore())).toEqual([
+			{ id: 'snap:0', position: [0, 2.5], rotation: 180, radius: 1.5 },
+			{ id: 'snap:1', position: [-4, 0], radius: SNAP_RADIUS_DEFAULT }
+		]);
+	});
+
+	it('replaces the points already on the table instead of merging into them', async () => {
+		gameActions.addSnapPoint({ position: [7, 7] });
+		gameActions.addSnapPoint({ position: [8, 8] });
+		const stale = saveScenario('two-points');
+
+		emptyTable();
+		gameActions.addSnapPoint({ position: [1, 1] });
+		gameActions.addSnapPoint({ position: [2, 2] });
+		gameActions.addSnapPoint({ position: [3, 3] });
+		await applyScenario(stale);
+
+		expect(gameActions.snapPointIds()).toEqual(['snap:0', 'snap:1']);
+		expect(snapPointsInStore()['snap:0']?.position).toEqual([7, 7]);
+	});
+
+	it('loads a scenario that has no snap points without inventing any', async () => {
+		ensureSeatPlaceholder(0);
+		gameActions.addPiece('token', { ownerId: seatPlaceholderId(0), name: 'Objective' });
+		const scenario = saveScenario('plain');
+		expect('snapPoints' in scenario).toBe(false);
+
+		emptyTable();
+		gameActions.addSnapPoint({ position: [1, 1] });
+		await applyScenario(scenario);
+		expect(gameActions.snapPointIds()).toEqual([]);
+	});
+
+	it('leaves a loaded table where a dropped card actually snaps', async () => {
+		const scenario = importScenarioFromText(
+			JSON.stringify({
+				tbps: 1,
+				name: 'board',
+				createdAt: 1,
+				state: {
+					cards: { 'card:seat0:a': { position: [0, 2, 0], rotation: [0, 0, 0] } }
+				},
+				snapPoints: [{ position: [6, 3], rotation: 90, radius: 1 }]
+			})
+		);
+		emptyTable();
+		await applyScenario(scenario);
+
+		const drop = resolveDrop(get(gameStore), 'card:seat0:a', { x: 6.5, z: 3 });
+		expect(drop).toMatchObject({
+			kind: 'snap',
+			position: [6, CARD_REST_Y, 3],
+			rotation: [0, 0, 90]
+		});
+	});
+});

--- a/src/lib/scenario/file.ts
+++ b/src/lib/scenario/file.ts
@@ -64,6 +64,29 @@ export type PackPlacement = {
 	scale?: number;
 };
 
+/**
+ * An authored placement guide: a spot on the felt that a dropped card or piece
+ * finishes exactly on. Scenario-level and table-space — a snap point belongs
+ * to the board, not to a seat, so it is not mirrored per seat the way pack
+ * piece positions are.
+ *
+ * Deliberately shaped like TTS's save-level `SnapPoints` (position + optional
+ * rotation) so importing those stays a mechanical mapping.
+ */
+export type SnapPoint = {
+	/** table-space `[x, z]`; no y — snap points live on the felt */
+	position: [number, number];
+	/**
+	 * Yaw a caught drop turns to, in **degrees**. Omitted leaves the entity's
+	 * own rotation alone. Degrees, not the radians `placements` use, because
+	 * this is a single table yaw and it maps 1:1 onto both the card DTO's tap
+	 * rotation and TTS's snap-point rotation.
+	 */
+	rotation?: number;
+	/** catch radius in world units; omitted means the app default (0.9) */
+	radius?: number;
+};
+
 export type Scenario = {
 	name: string;
 	createdAt: number;
@@ -73,6 +96,13 @@ export type Scenario = {
 	packs?: PackRef[];
 	/** v2: where that content goes */
 	placements?: PackPlacement[];
+	/**
+	 * Placement guides for whatever ends up on the table, pack-derived or not —
+	 * and the only place a file should author them. Additive: a scenario without
+	 * them behaves exactly as it did before they existed, and they don't decide
+	 * the file version (a hand-placed table with snap points is still v1).
+	 */
+	snapPoints?: SnapPoint[];
 };
 
 /** The on-disk shape of a `.tbps.json` file. */
@@ -184,6 +214,32 @@ function parsePlacement(v: unknown, path: string): PackPlacement {
 	return placement;
 }
 
+function parseSnapPoint(v: unknown, path: string): SnapPoint {
+	if (!isRecord(v)) fail(`${path} must be an object`);
+	const position = v.position;
+	if (
+		!Array.isArray(position) ||
+		position.length !== 2 ||
+		position.some((n) => typeof n !== 'number' || !Number.isFinite(n))
+	) {
+		fail(`${path}.position must be [x, z] in table space`);
+	}
+	const point: SnapPoint = { position: position as [number, number] };
+	if (v.rotation !== undefined) {
+		if (typeof v.rotation !== 'number' || !Number.isFinite(v.rotation)) {
+			fail(`${path}.rotation must be a yaw in degrees`);
+		}
+		point.rotation = v.rotation;
+	}
+	if (v.radius !== undefined) {
+		if (typeof v.radius !== 'number' || !Number.isFinite(v.radius) || v.radius <= 0) {
+			fail(`${path}.radius must be a positive number of world units`);
+		}
+		point.radius = v.radius;
+	}
+	return point;
+}
+
 /**
  * Parse + validate a scenario file. Accepts v2 (pack-referencing), v1
  * (self-contained snapshot) and, as a v0 fallback, the legacy
@@ -229,6 +285,12 @@ export function parseScenarioFile(text: string): Scenario {
 	if (obj.placements !== undefined) {
 		if (!Array.isArray(obj.placements)) throw new Error('`placements` must be an array');
 		scenario.placements = obj.placements.map((p, i) => parsePlacement(p, `placements[${i}]`));
+	}
+	// additive and version-gated by absence: a file without `snapPoints` parses
+	// to a scenario without the key, byte-identical to how it always did
+	if (obj.snapPoints !== undefined) {
+		if (!Array.isArray(obj.snapPoints)) throw new Error('`snapPoints` must be an array');
+		scenario.snapPoints = obj.snapPoints.map((p, i) => parseSnapPoint(p, `snapPoints[${i}]`));
 	}
 	return scenario;
 }

--- a/src/lib/scenario/scenario.ts
+++ b/src/lib/scenario/scenario.ts
@@ -13,6 +13,7 @@
 import { get } from 'svelte/store';
 import { gameStore } from '$lib/store/game/gameStore.svelte';
 import { gameActions } from '$lib/store/game/actions';
+import { snapPointIds } from '$lib/store/game/actions/snap';
 import { prewarmGameState } from '$lib/packs/prewarm-state';
 import { spawnPackDeck, spawnPackPiece, spawnPackOverlay } from '$lib/packs/spawn';
 import type { GamePackDef } from '$lib/packs/types';
@@ -24,7 +25,8 @@ import {
 	scenarioVersion,
 	type PackPlacement,
 	type PackRef,
-	type Scenario
+	type Scenario,
+	type SnapPoint
 } from './file';
 import { resolvePacks } from './resolve-packs';
 
@@ -129,6 +131,36 @@ function toPlacement(
 }
 
 /**
+ * Snap points live in the store keyed by id, but a file has no use for those
+ * ids: they are table-scoped, nothing references them, and a stable array reads
+ * far better in a hand-edited scenario. Sorted by id so an export is
+ * deterministic, and dropped from `state` — the top-level `snapPoints` field is
+ * their only home in the file.
+ */
+function collectSnapPoints(s: Partial<GameDTO> | undefined | null): SnapPoint[] {
+	return snapPointIds(s ?? undefined)
+		.map((id) => s?.snapPoints?.[id])
+		.flatMap((point) => {
+			const position = point?.position;
+			if (!position) return [];
+			const snap: SnapPoint = { position: [position[0], position[1]] };
+			if (point?.rotation !== undefined) snap.rotation = point.rotation;
+			if (point?.radius !== undefined) snap.radius = point.radius;
+			return [snap];
+		});
+}
+
+/** The store patch that puts a file's snap points on the table, ids reassigned. */
+function snapPointUpdate(snapPoints: SnapPoint[] | undefined): Record<string, unknown> {
+	const update: Record<string, unknown> = {};
+	(snapPoints ?? []).forEach((point, index) => {
+		const id = `snap:${index}`;
+		update[id] = { id, ...point };
+	});
+	return update;
+}
+
+/**
  * Snapshot the current table as a scenario. Real players (and their trays)
  * are NOT saved — only placeholder seat players survive, so the preset stays
  * portable to any future lobby.
@@ -181,11 +213,13 @@ export function saveScenario(name: string): Scenario {
 		}
 	}
 
+	const snapPoints = collectSnapPoints(s);
 	const scenario: Scenario = {
 		name,
 		createdAt: Date.now(),
 		state,
-		...(placements.length ? { packs: [...refs.values()], placements } : {})
+		...(placements.length ? { packs: [...refs.values()], placements } : {}),
+		...(snapPoints.length ? { snapPoints } : {})
 	};
 	const all = readAll();
 	all[name] = scenario;
@@ -210,9 +244,10 @@ function clearUpdate(): Record<string, Record<string, unknown>> {
 		decks: {},
 		pieces: {},
 		overlays: {},
+		snapPoints: {},
 		players: {}
 	};
-	for (const collection of ['cards', 'decks', 'pieces', 'overlays'] as const) {
+	for (const collection of ['cards', 'decks', 'pieces', 'overlays', 'snapPoints'] as const) {
 		for (const key of Object.keys(current?.[collection] ?? {})) update[collection][key] = null;
 	}
 	for (const key of Object.keys(current?.players ?? {})) {
@@ -225,11 +260,14 @@ function clearUpdate(): Record<string, Record<string, unknown>> {
  * v1/v0 load: the scenario's `state` snapshot *is* the table. Synchronous, so
  * legacy scenarios apply in the same tick they always did.
  */
-function applyStateSnapshot(state: Partial<GameDTO> | undefined) {
+function applyStateSnapshot(state: Partial<GameDTO> | undefined, snapPoints?: SnapPoint[]) {
 	const update = clearUpdate();
+	Object.assign(update.snapPoints, snapPointUpdate(snapPoints));
 	// small payloads ride with the clear — direct assignment overwrites the
-	// null for reused keys
-	for (const collection of ['cards', 'pieces', 'overlays', 'players'] as const) {
+	// null for reused keys. `state` goes last, since it is the override layer:
+	// a `state.snapPoints` entry beats the top-level array rather than being
+	// silently dropped, same as it does for every other collection.
+	for (const collection of ['cards', 'pieces', 'overlays', 'snapPoints', 'players'] as const) {
 		for (const [key, value] of Object.entries(state?.[collection] ?? {})) {
 			update[collection][key] = value;
 		}
@@ -307,7 +345,7 @@ export type ApplyReport = {
  */
 export async function applyScenario(scenario: Scenario): Promise<ApplyReport> {
 	if (scenarioVersion(scenario) === 1) {
-		applyStateSnapshot(scenario.state);
+		applyStateSnapshot(scenario.state, scenario.snapPoints);
 		prewarmGameState(scenario.state, () => gameStore.updateStateSilently({}));
 		return { version: 1, placed: 0, failedPacks: [] };
 	}
@@ -323,6 +361,8 @@ export async function applyScenario(scenario: Scenario): Promise<ApplyReport> {
 		const id = seatPlaceholderId(seat);
 		update.players[id] ??= { id, seat, joinTimestamp: 0, tray: {}, metadata: {} };
 	}
+	// snap points are pure data — they ride with the clear, no pack to resolve
+	Object.assign(update.snapPoints, snapPointUpdate(scenario.snapPoints));
 	gameStore.updateState(update as StateUpdate);
 
 	const { packs, failed } = await resolvePacks(scenario.packs ?? []);
@@ -343,9 +383,10 @@ export async function applyScenario(scenario: Scenario): Promise<ApplyReport> {
 	const overrides: Record<string, Record<string, unknown>> = {
 		cards: {},
 		pieces: {},
-		overlays: {}
+		overlays: {},
+		snapPoints: {}
 	};
-	for (const collection of ['cards', 'pieces', 'overlays'] as const) {
+	for (const collection of ['cards', 'pieces', 'overlays', 'snapPoints'] as const) {
 		for (const [key, value] of Object.entries(scenario.state?.[collection] ?? {})) {
 			overrides[collection][key] = value;
 		}

--- a/src/lib/store/game/actions/index.ts
+++ b/src/lib/store/game/actions/index.ts
@@ -3,11 +3,13 @@ import { deckActions } from './deck';
 import { playerActions } from './player';
 import { trayActions } from './tray';
 import { pieceActions } from './piece';
+import { snapActions } from './snap';
 
 export const gameActions = {
 	...cardActions,
 	...deckActions,
 	...playerActions,
 	...trayActions,
-	...pieceActions
+	...pieceActions,
+	...snapActions
 };

--- a/src/lib/store/game/actions/snap.ts
+++ b/src/lib/store/game/actions/snap.ts
@@ -1,0 +1,105 @@
+import { get } from 'svelte/store';
+import { gameStore } from '../gameStore.svelte';
+import { SNAP_RADIUS_DEFAULT } from '$lib/utils/constants-snap';
+import { clampToTable } from '$lib/utils/transforms/drop';
+import type { GameDTO, SnapPointDTO } from '../types';
+
+/**
+ * Authoring snap points — the /setup layer's whole vocabulary: add, move,
+ * retune, remove.
+ *
+ * Everything goes through `updateState`, so the editor's edits are ordinary
+ * surgical patches (and `null` deletes) exactly like a piece's. Snap points are
+ * table-scoped, so ids carry no owner: they are plain sequential `snap:<n>`.
+ */
+
+type SnapPointState = NonNullable<NonNullable<GameDTO['snapPoints']>[string]>;
+
+export function snapPointIds(state?: Partial<GameDTO> | null): string[] {
+	const points = (state ?? get(gameStore))?.snapPoints ?? {};
+	return Object.keys(points)
+		.filter((id) => points[id])
+		.sort(compareSnapIds);
+}
+
+/** `snap:2` before `snap:10` — the pane lists them in creation order. */
+export function compareSnapIds(a: string, b: string): number {
+	const na = Number(a.split(':')[1]);
+	const nb = Number(b.split(':')[1]);
+	if (Number.isFinite(na) && Number.isFinite(nb) && na !== nb) return na - nb;
+	return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
+ * Next free `snap:<n>`, one past the highest currently on the table. Deleting
+ * the newest point frees its id again, which is fine: /setup is a local editor
+ * and the delete has already been applied before the next add is built.
+ */
+function nextSnapId(): string {
+	const used = Object.keys(get(gameStore)?.snapPoints ?? {})
+		.map((id) => Number(id.split(':')[1]))
+		.filter((n) => Number.isFinite(n));
+	return `snap:${used.length ? Math.max(...used) + 1 : 0}`;
+}
+
+export type AddSnapPointOptions = {
+	/** table-space [x, z]; clamped inside the felt like any other placement */
+	position?: [number, number];
+	/** yaw in degrees a caught drop turns to */
+	rotation?: number;
+	radius?: number;
+};
+
+/** Place a snap point. Returns its id. */
+function addSnapPoint(opts: AddSnapPointOptions = {}): string {
+	const id = nextSnapId();
+	const [x, z] = clampToTable(opts.position?.[0] ?? 0, opts.position?.[1] ?? 0);
+	const point: Partial<SnapPointState> = {
+		id,
+		position: [x, z],
+		radius: opts.radius ?? SNAP_RADIUS_DEFAULT
+	};
+	if (opts.rotation !== undefined) point.rotation = opts.rotation;
+	gameStore.updateState({ snapPoints: { [id]: point } });
+	return id;
+}
+
+function moveSnapPoint(id: string, position: [number, number]) {
+	const [x, z] = clampToTable(position[0], position[1]);
+	gameStore.updateState({ snapPoints: { [id]: { position: [x, z] } } });
+}
+
+/**
+ * Retune a point in place. A `rotation` of `undefined` is how the editor says
+ * "no authored yaw" — `null` at that path is what deletes the field, since an
+ * undefined value would be dropped from the patch and change nothing.
+ */
+function updateSnapPoint(id: string, patch: Partial<Omit<SnapPointDTO, 'id'>>) {
+	const next: Record<string, unknown> = { ...patch };
+	if ('rotation' in patch && patch.rotation === undefined) next.rotation = null;
+	gameStore.updateState({
+		snapPoints: { [id]: next as Partial<SnapPointState> }
+	} as Parameters<typeof gameStore.updateState>[0]);
+}
+
+function removeSnapPoint(id: string) {
+	gameStore.updateState({ snapPoints: { [id]: null } });
+}
+
+/** Drop every snap point on the table (the editor's clear, and scenario load). */
+function clearSnapPoints() {
+	const ids = Object.keys(get(gameStore)?.snapPoints ?? {});
+	if (!ids.length) return;
+	const update: Record<string, null> = {};
+	for (const id of ids) update[id] = null;
+	gameStore.updateState({ snapPoints: update });
+}
+
+export const snapActions = {
+	addSnapPoint,
+	moveSnapPoint,
+	updateSnapPoint,
+	removeSnapPoint,
+	clearSnapPoints,
+	snapPointIds
+};

--- a/src/lib/store/game/types.ts
+++ b/src/lib/store/game/types.ts
@@ -112,6 +112,29 @@ export type OverlayDTO = {
 	packOrigin?: PackOrigin;
 };
 
+/**
+ * An authored placement guide on the felt: a card or piece released inside
+ * `radius` of one finishes exactly on it. Table-scoped like overlays — snap
+ * points belong to the board, not to a seat — and inert: nothing renders them
+ * in /play, they only steer where a drop lands (see `utils/transforms/snap`).
+ */
+export type SnapPointDTO = {
+	id: string;
+	/**
+	 * Table-space `[x, z]`. No y: a snap point is a spot on the felt, and what
+	 * lands on it keeps its own resting height (a card on a card still stacks).
+	 */
+	position: [number, number];
+	/**
+	 * Yaw the landing snaps to, in **degrees**, or omitted to keep whatever
+	 * rotation the entity already had. Degrees to match the card DTO's tap
+	 * rotation (`actions/card.ts`) and TTS's `SnapPoints`.
+	 */
+	rotation?: number;
+	/** catch radius in world units; omitted means `SNAP_RADIUS_DEFAULT` */
+	radius?: number;
+};
+
 // index signatures (not Record<…>) so the generated JSON Schema keeps the
 // entity value shapes — typescript-json-schema drops Record value types
 export interface GameDTO {
@@ -122,4 +145,6 @@ export interface GameDTO {
 	overlays?: { [overlayId: string]: Partial<OverlayDTO> | null };
 	/** null = remove */
 	pieces?: { [pieceId: string]: Partial<PieceDTO> | null };
+	/** authored placement guides, keyed `snap:<n>`. null = remove */
+	snapPoints?: { [snapId: string]: Partial<SnapPointDTO> | null };
 }

--- a/src/lib/store/snapEditor.ts
+++ b/src/lib/store/snapEditor.ts
@@ -1,0 +1,31 @@
+import { writable } from 'svelte/store';
+
+/**
+ * The one bit of transient UI state the snap-point layer needs: whether the
+ * next click on bare felt places a point.
+ *
+ * It lives in a store rather than in `SetupPane` because the click is caught by
+ * the table mesh, which sits inside the `<Canvas>` several components away —
+ * the same reason `tableFeatures` exists. Kept out of `tableFeatures` on
+ * purpose: that store describes what a *route* mounted, this is a tool the
+ * author toggles mid-session, and only /setup ever sets it.
+ */
+export interface SnapEditorState {
+	/** armed: a click on the felt adds a snap point there */
+	placing: boolean;
+	/** yaw in degrees stamped on points placed by clicking; undefined = none */
+	rotation?: number;
+	/** catch radius stamped on points placed by clicking */
+	radius?: number;
+}
+
+export const snapEditor = writable<SnapEditorState>({ placing: false });
+
+export function setSnapPlacing(placing: boolean) {
+	snapEditor.update((state) => ({ ...state, placing }));
+}
+
+/** Defaults the next click-placed point is stamped with. */
+export function setSnapDefaults(defaults: { rotation?: number; radius?: number }) {
+	snapEditor.update((state) => ({ ...state, ...defaults }));
+}

--- a/src/lib/store/tableFeatures.ts
+++ b/src/lib/store/tableFeatures.ts
@@ -12,9 +12,19 @@ import { writable } from 'svelte/store';
 export interface TableFeatures {
 	/** whether the local hand tray is mounted, and so may win a drop */
 	hand: boolean;
+	/**
+	 * Whether snap points are being authored, and so drawn on the felt.
+	 *
+	 * Only /setup sets it. Snap points still *work* everywhere — a drop is
+	 * caught by them on any route — they just aren't drawn at rest in /play,
+	 * where an authored board would otherwise be permanently speckled with
+	 * rings. The drop preview highlights the one that caught the drag, which is
+	 * the moment the guide is actually worth seeing.
+	 */
+	snapEditing: boolean;
 }
 
-export const TABLE_FEATURES_DEFAULT: TableFeatures = { hand: true };
+export const TABLE_FEATURES_DEFAULT: TableFeatures = { hand: true, snapEditing: false };
 
 export const tableFeatures = writable<TableFeatures>({ ...TABLE_FEATURES_DEFAULT });
 

--- a/src/lib/utils/constants-snap.ts
+++ b/src/lib/utils/constants-snap.ts
@@ -1,0 +1,30 @@
+import { TABLE_TOP_Y } from './constants-table';
+
+/**
+ * Snap points — authored placement guides on the felt. A drop that lands
+ * inside a point's catch radius finishes exactly on the point.
+ */
+
+/**
+ * Catch radius for a snap point that doesn't declare one, in world units.
+ * Sized off the card footprint: a shade under half a card's length, so two
+ * snap points a card-length apart never fight over the same drop, and a drop
+ * aimed at the point still catches if it lands anywhere over its middle.
+ */
+export const SNAP_RADIUS_DEFAULT = 0.9;
+
+/** Below this a point could never catch anything; authored values clamp up. */
+export const SNAP_RADIUS_MIN = 0.05;
+
+/** Sanity ceiling for an authored radius — a whole-table snap point is a bug. */
+export const SNAP_RADIUS_MAX = 15;
+
+/** y the editor draws snap markers at: on the felt, under everything that rests on it. */
+export const SNAP_MARKER_Y = TABLE_TOP_Y + 0.0015;
+
+/** Editor marker colors: idle, and while being dragged. */
+export const SNAP_MARKER_COLOR = '#a78bfa';
+export const SNAP_MARKER_COLOR_ACTIVE = '#f0abfc';
+
+/** Color the drop preview uses when a drop is caught by a snap point. */
+export const SNAP_DROP_COLOR = '#c4b5fd';

--- a/src/lib/utils/transforms/__tests__/drop.test.ts
+++ b/src/lib/utils/transforms/__tests__/drop.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { clampToTable, resolveDrop } from '../drop';
 import type { GameDTO } from '$lib/store/game/types';
-import { CARD_WIDTH, CARD_HEIGHT, CARD_REST_Y, CARD_THICKNESS } from '$lib/utils/constants-cards';
+import {
+	CARD_WIDTH,
+	CARD_HEIGHT,
+	CARD_REST_Y,
+	CARD_THICKNESS,
+	CARD_DRAG_Y,
+	deckHeightForCount
+} from '$lib/utils/constants-cards';
 import { PIECE_DEFAULT_RADIUS, PIECE_REST_Y } from '$lib/utils/constants-pieces';
 import { EDGE_MARGIN, TABLE_HALF_X, TABLE_HALF_Z, TABLE_TOP_Y } from '$lib/utils/constants-table';
 
@@ -199,6 +206,178 @@ describe('resolveDrop', () => {
 		it('changes nothing when the modifier is not held', () => {
 			expect(resolveDrop(overlapping(), 'a', { x: 0.5, z: 0.4 }, {}, { noSnap: false })).toEqual(
 				resolveDrop(overlapping(), 'a', { x: 0.5, z: 0.4 })
+			);
+		});
+	});
+
+	describe('authored snap points', () => {
+		const withSnap = (over: Partial<GameDTO> = {}) =>
+			state({
+				snapPoints: {
+					'snap:0': { id: 'snap:0', position: [4, 2], radius: 1, rotation: 90 },
+					'snap:1': { id: 'snap:1', position: [-4, 2], radius: 1 }
+				},
+				...over
+			});
+
+		it('pulls a card exactly onto the point and applies its yaw', () => {
+			const s = withSnap({ cards: { a: card(0, 2, 0) } });
+			const drop = resolveDrop(s, 'a', { x: 4.4, z: 2.3 });
+			expect(drop).toMatchObject({
+				kind: 'snap',
+				position: [4, CARD_REST_Y, 2],
+				rotation: [0, 0, 90],
+				snap: { id: 'snap:0', radius: 1 }
+			});
+		});
+
+		it('leaves the facing alone for a point with no authored rotation', () => {
+			const s = withSnap({ cards: { a: card(0, 2, 0, [180, 0, 45]) } });
+			const drop = resolveDrop(s, 'a', { x: -4, z: 2 });
+			expect(drop?.kind).toBe('snap');
+			expect(drop?.rotation).toEqual([180, 0, 45]);
+		});
+
+		/**
+		 * A whole dragged deck (tableplace-88) has to snap as well, and it is the
+		 * case the two features had to be composed for: the deck branch resolves
+		 * before the card path, so it has to consult the snap itself rather than
+		 * returning at the raw pointer.
+		 */
+		describe('a dragged deck', () => {
+			const deck = (n: number, rotation: [number, number, number] = [0, 0, 0]) => ({
+				id: 'deck:me:main',
+				position: [0, CARD_DRAG_Y, 0] as [number, number, number],
+				rotation,
+				cards: Array.from({ length: n }, (_, i) => ({ id: `c${i}`, faceImageUrl: 'f.png' }))
+			});
+			const restY = (n: number) => TABLE_TOP_Y + deckHeightForCount(n) / 2;
+
+			it('lands exactly on the point, keeping its own half-height', () => {
+				const s = withSnap({ decks: { 'deck:me:main': deck(20) } });
+				const drop = resolveDrop(s, 'deck:me:main', { x: 4.5, z: 2.2 });
+				expect(drop).toMatchObject({
+					kind: 'snap',
+					position: [4, restY(20), 2],
+					snap: { id: 'snap:0', radius: 1 }
+				});
+			});
+
+			it('takes the authored yaw in RADIANS, unlike a card', () => {
+				const s = withSnap({ decks: { 'deck:me:main': deck(20) } });
+				// snap:0 authors 90°, and a deck's rotation triple is radians
+				const [rx, ry, rz] = resolveDrop(s, 'deck:me:main', { x: 4, z: 2 })!.rotation;
+				expect([rx, rz]).toEqual([0, 0]);
+				expect(ry).toBeCloseTo(Math.PI / 2);
+			});
+
+			it('keeps its facing when the point authored no rotation', () => {
+				const s = withSnap({ decks: { 'deck:me:main': deck(20, [0, Math.PI, 0]) } });
+				const drop = resolveDrop(s, 'deck:me:main', { x: -4, z: 2 });
+				expect(drop?.kind).toBe('snap');
+				expect(drop?.rotation).toEqual([0, Math.PI, 0]);
+			});
+
+			it('still settles at the pointer when no point is in range', () => {
+				const s = withSnap({ decks: { 'deck:me:main': deck(8) } });
+				const drop = resolveDrop(s, 'deck:me:main', { x: 9, z: -3 });
+				expect(drop).toMatchObject({ kind: 'table', position: [9, restY(8), -3] });
+				expect(drop?.snap).toBeUndefined();
+			});
+
+			it('is opted out of by Alt, like every other snap', () => {
+				const s = withSnap({ decks: { 'deck:me:main': deck(8) } });
+				const drop = resolveDrop(s, 'deck:me:main', { x: 4.2, z: 2 }, {}, { noSnap: true });
+				expect(drop).toMatchObject({ kind: 'table', position: [4.2, restY(8), 2] });
+			});
+
+			it('is unaffected by a hovered deck or tray — a pile only ever settles', () => {
+				const s = withSnap({ decks: { 'deck:me:main': deck(8) } });
+				const hovered = resolveDrop(
+					s,
+					'deck:me:main',
+					{ x: 4, z: 2 },
+					{
+						tray: true,
+						deckId: 'deck:other:main'
+					}
+				);
+				expect(hovered?.kind).toBe('snap');
+				expect([hovered?.position[0], hovered?.position[2]]).toEqual([4, 2]);
+			});
+		});
+
+		it('pulls a piece onto the point too, at piece rest height', () => {
+			const s = withSnap({
+				pieces: { 'piece:me:t': { position: [0, 1.2, 0], rotation: [0, 0, 0], kind: 'token' } }
+			});
+			const drop = resolveDrop(s, 'piece:me:t', { x: 3.6, z: 2 });
+			expect(drop).toMatchObject({
+				kind: 'snap',
+				position: [4, PIECE_REST_Y, 2],
+				// a piece keeps its table yaw in y, not z (see applySnapRotation)
+				rotation: [0, 90, 0],
+				footprint: { shape: 'circle', r: PIECE_DEFAULT_RADIUS }
+			});
+		});
+
+		it('does nothing to a drop outside every radius', () => {
+			const s = withSnap({ cards: { a: card(0, 2, 0) } });
+			const drop = resolveDrop(s, 'a', { x: 6, z: 2 });
+			expect(drop).toMatchObject({ kind: 'table', position: [6, CARD_REST_Y, 2] });
+			expect(drop?.snap).toBeUndefined();
+		});
+
+		it('stacks on a card already sitting on the point instead of clipping into it', () => {
+			const s = withSnap({
+				cards: { a: card(0, 2, 0), resting: card(4, CARD_REST_Y, 2) }
+			});
+			const drop = resolveDrop(s, 'a', { x: 4.3, z: 2 });
+			expect(drop).toMatchObject({
+				kind: 'snap',
+				position: [4, CARD_REST_Y + CARD_THICKNESS, 2]
+			});
+		});
+
+		it('beats a loose pile that the drop also overlaps', () => {
+			// a card resting just off the point: without snapping the drop would
+			// square up to it, with snapping the authored spot wins the XZ
+			const s = withSnap({
+				cards: { a: card(0, 2, 0), loose: card(4.6, CARD_REST_Y, 2.4) }
+			});
+			const drop = resolveDrop(s, 'a', { x: 4.4, z: 2.2 });
+			expect(drop?.kind).toBe('snap');
+			expect([drop?.position[0], drop?.position[2]]).toEqual([4, 2]);
+		});
+
+		it('loses to the aimed-at targets: tray and deck still win', () => {
+			const s = withSnap({ cards: { a: card(0, 2, 0) }, decks: { 'deck:1': { cards: [] } } });
+			expect(resolveDrop(s, 'a', { x: 4, z: 2 }, { tray: true })?.kind).toBe('tray');
+			expect(resolveDrop(s, 'a', { x: 4, z: 2 }, { deckId: 'deck:1' })?.kind).toBe('deck');
+		});
+
+		it('is opted out of by Alt, for both cards and pieces', () => {
+			const s = withSnap({
+				cards: { a: card(0, 2, 0) },
+				pieces: { 'piece:me:t': { position: [0, 1.2, 0], rotation: [0, 0, 0], kind: 'token' } }
+			});
+			expect(resolveDrop(s, 'a', { x: 4.2, z: 2 }, {}, { noSnap: true })).toMatchObject({
+				kind: 'table',
+				position: [4.2, CARD_REST_Y, 2]
+			});
+			expect(resolveDrop(s, 'piece:me:t', { x: 4.2, z: 2 }, {}, { noSnap: true })).toMatchObject({
+				kind: 'table',
+				position: [4.2, PIECE_REST_Y, 2]
+			});
+		});
+
+		it('changes nothing for a table that has no snap points', () => {
+			const s = state({ cards: { a: card(0, 2, 0) } });
+			expect(resolveDrop(s, 'a', { x: 4.4, z: 2.3 })).toEqual(
+				resolveDrop(state({ cards: { a: card(0, 2, 0) }, snapPoints: {} }), 'a', {
+					x: 4.4,
+					z: 2.3
+				})
 			);
 		});
 	});

--- a/src/lib/utils/transforms/__tests__/snap.test.ts
+++ b/src/lib/utils/transforms/__tests__/snap.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { applySnapRotation, resolveSnap, snapRadius } from '../snap';
+import { SNAP_RADIUS_DEFAULT, SNAP_RADIUS_MAX, SNAP_RADIUS_MIN } from '$lib/utils/constants-snap';
+import type { GameDTO } from '$lib/store/game/types';
+
+const points = (
+	...entries: [string, { position?: [number, number]; rotation?: number; radius?: number } | null][]
+): GameDTO['snapPoints'] => Object.fromEntries(entries);
+
+describe('snapRadius', () => {
+	it('falls back to the shared default', () => {
+		expect(snapRadius({})).toBe(SNAP_RADIUS_DEFAULT);
+		expect(snapRadius(undefined)).toBe(SNAP_RADIUS_DEFAULT);
+	});
+
+	it('honours an authored radius', () => {
+		expect(snapRadius({ radius: 2.5 })).toBe(2.5);
+	});
+
+	it('clamps values that could never catch a drop, or would catch everything', () => {
+		expect(snapRadius({ radius: 0 })).toBe(SNAP_RADIUS_MIN);
+		expect(snapRadius({ radius: -3 })).toBe(SNAP_RADIUS_MIN);
+		expect(snapRadius({ radius: 9999 })).toBe(SNAP_RADIUS_MAX);
+	});
+
+	it('ignores a non-finite radius', () => {
+		expect(snapRadius({ radius: Number.NaN })).toBe(SNAP_RADIUS_DEFAULT);
+	});
+});
+
+describe('resolveSnap', () => {
+	it('catches a drop inside the radius', () => {
+		const snap = resolveSnap(points(['snap:0', { position: [4, 2], radius: 1 }]), 4.5, 2);
+		expect(snap).toMatchObject({ id: 'snap:0', x: 4, z: 2, radius: 1 });
+		expect(snap?.distance).toBeCloseTo(0.5);
+	});
+
+	it('ignores a drop outside the radius', () => {
+		expect(resolveSnap(points(['snap:0', { position: [4, 2], radius: 1 }]), 5.5, 2)).toBeNull();
+	});
+
+	it('catches a drop exactly on the radius', () => {
+		expect(resolveSnap(points(['snap:0', { position: [0, 0], radius: 1 }]), 1, 0)).toMatchObject({
+			id: 'snap:0'
+		});
+	});
+
+	it('uses the default radius when the point omits one', () => {
+		const p = points(['snap:0', { position: [0, 0] }]);
+		expect(resolveSnap(p, SNAP_RADIUS_DEFAULT - 0.01, 0)).toMatchObject({ id: 'snap:0' });
+		expect(resolveSnap(p, SNAP_RADIUS_DEFAULT + 0.01, 0)).toBeNull();
+	});
+
+	it('lets the nearest point win when radii overlap', () => {
+		const p = points(
+			['snap:0', { position: [0, 0], radius: 3 }],
+			['snap:1', { position: [2, 0], radius: 3 }]
+		);
+		expect(resolveSnap(p, 1.4, 0)?.id).toBe('snap:1');
+		expect(resolveSnap(p, 0.6, 0)?.id).toBe('snap:0');
+	});
+
+	it('breaks an exact tie on id, so record order cannot decide a snap', () => {
+		const near = { position: [0, 0] as [number, number], radius: 2 };
+		const far = { position: [2, 0] as [number, number], radius: 2 };
+		const forward = resolveSnap(points(['snap:0', near], ['snap:1', far]), 1, 0);
+		const reversed = resolveSnap(points(['snap:1', far], ['snap:0', near]), 1, 0);
+		expect(forward?.id).toBe('snap:0');
+		expect(reversed?.id).toBe('snap:0');
+	});
+
+	it('carries the authored rotation, and reports none when there is none', () => {
+		expect(
+			resolveSnap(points(['snap:0', { position: [0, 0], rotation: 90 }]), 0, 0)?.rotation
+		).toBe(90);
+		expect(resolveSnap(points(['snap:0', { position: [0, 0] }]), 0, 0)?.rotation).toBeUndefined();
+	});
+
+	it('keeps a rotation of 0, which is an authored facing and not "unset"', () => {
+		expect(resolveSnap(points(['snap:0', { position: [0, 0], rotation: 0 }]), 0, 0)?.rotation).toBe(
+			0
+		);
+	});
+
+	it('skips deleted and malformed entries', () => {
+		const p = points(
+			['snap:0', null],
+			// @ts-expect-error deliberately malformed: a wire patch can carry anything
+			['snap:1', { position: ['x', 2] }],
+			['snap:2', { position: [0, 0] }]
+		);
+		expect(resolveSnap(p, 0, 0)?.id).toBe('snap:2');
+	});
+
+	it('is unfazed by no snap points at all', () => {
+		expect(resolveSnap(undefined, 0, 0)).toBeNull();
+		expect(resolveSnap({}, 0, 0)).toBeNull();
+	});
+});
+
+describe('applySnapRotation', () => {
+	it('leaves the rotation alone when the point authored none', () => {
+		expect(applySnapRotation([180, 0, 45], undefined, 'card')).toEqual([180, 0, 45]);
+		expect(applySnapRotation([0, 30, 0], undefined, 'piece')).toEqual([0, 30, 0]);
+		expect(applySnapRotation([0, Math.PI, 0], undefined, 'deck')).toEqual([0, Math.PI, 0]);
+	});
+
+	it('writes a card yaw into z as degrees, preserving the facedown flip', () => {
+		expect(applySnapRotation([180, 0, 45], 90, 'card')).toEqual([180, 0, 90]);
+	});
+
+	it('writes a piece yaw into y as degrees', () => {
+		expect(applySnapRotation([0, 30, 0], 90, 'piece')).toEqual([0, 90, 0]);
+	});
+
+	it('writes a deck yaw into y as RADIANS — decks are the odd one out', () => {
+		// Deck.svelte hands the triple to its <T.Group>; degrees here would spin
+		// a snapped deck by a factor of 57 (tableplace-88 makes decks draggable)
+		const [x, y, z] = applySnapRotation([0, 0, 0], 180, 'deck');
+		expect([x, z]).toEqual([0, 0]);
+		expect(y).toBeCloseTo(Math.PI);
+	});
+});

--- a/src/lib/utils/transforms/drop.ts
+++ b/src/lib/utils/transforms/drop.ts
@@ -9,12 +9,15 @@ import {
 import { PIECE_DEFAULT_RADIUS, PIECE_REST_Y } from '$lib/utils/constants-pieces';
 import { EDGE_MARGIN, TABLE_HALF_X, TABLE_HALF_Z, TABLE_TOP_Y } from '$lib/utils/constants-table';
 import { resolveStack } from './stacking';
+import { applySnapRotation, resolveSnap, type SnapResolution } from './snap';
 
 export type DropKind =
 	/** lands on bare felt (or an overlay) */
 	| 'table'
 	/** lands on top of one or more cards already at that spot */
 	| 'stack'
+	/** caught by an authored snap point: lands exactly on it */
+	| 'snap'
 	/** returns to a deck instead of the table */
 	| 'deck'
 	/** goes into the local player's hand tray */
@@ -40,6 +43,13 @@ export interface DropTarget {
 	 * a disc above the felt, and the footprint belongs on the felt.
 	 */
 	footprintY: number;
+	/**
+	 * Set when `kind === 'snap'`: the point that caught the drop — its id, its
+	 * catch radius (the preview draws it), and the yaw it authored, if any, so
+	 * the commit can tell "this drop turned the entity" from "this drop only
+	 * moved it" without diffing rotations.
+	 */
+	snap?: { id: string; radius: number; rotation?: number };
 }
 
 export interface DropHover {
@@ -52,8 +62,9 @@ export interface DropHover {
 export interface DropOptions {
 	/**
 	 * Alt held at release: place the card exactly where the pointer is, with
-	 * no XZ square-up onto a nearby pile and no stack-height merge. The escape
-	 * hatch for laying cards out next to each other on purpose.
+	 * no XZ square-up onto a nearby pile, no stack-height merge, and no pull
+	 * onto an authored snap point. The escape hatch for laying cards out next
+	 * to each other on purpose.
 	 */
 	noSnap?: boolean;
 	/**
@@ -63,6 +74,15 @@ export interface DropOptions {
 	 * module-global — can't win a drop the editor has no way to represent.
 	 */
 	hand?: TableFeatures['hand'];
+}
+
+/** What the caught drop reports back about the point that caught it. */
+function snapInfo(snap: SnapResolution): NonNullable<DropTarget['snap']> {
+	return {
+		id: snap.id,
+		radius: snap.radius,
+		...(snap.rotation !== undefined ? { rotation: snap.rotation } : {})
+	};
 }
 
 /** Keep a drop a margin inside the felt edge. */
@@ -84,6 +104,14 @@ export function clampToTable(x: number, z: number): [number, number] {
  * `rawPoint` is the unclamped table raycast hit; when it's missing (pointer
  * off the table plane) the entity's own position is used instead so a drag
  * keeps previewing.
+ *
+ * Pieces and whole decks only ever settle, so they resolve first: felt position,
+ * pulled onto an authored snap point if one catches them. For a card the order
+ * is, most explicit first: the hand tray, then a hovered deck (both aimed at),
+ * then Alt's opt-out, then an authored snap point within radius, then the
+ * loose-pile square-up. A snap point beats a pile because it is authored intent
+ * rather than a side effect of where cards drifted; Alt opts out of every kind
+ * of snapping at once.
  *
  * `options` carries what the release itself asks for (`noSnap`, from Alt) and
  * what the route actually mounted (`hand`): a target that isn't on screen
@@ -114,30 +142,45 @@ export function resolveDrop(
 	const [x, z] = clampToTable(rawPoint?.x ?? ex, rawPoint?.z ?? ez);
 	const rotation = (entity.rotation ?? [0, 0, 0]) as [number, number, number];
 
+	// An authored snap point pulls the landing onto itself. Alt opts out — it is
+	// already the "put it exactly where I said" modifier — and the aimed-at
+	// targets (deck, tray, checked below for cards) still beat proximity.
+	const snap = options.noSnap ? null : resolveSnap(state?.snapPoints, x, z);
+
 	// pieces don't stack, join decks, or enter the tray — they just settle
 	if (isPiece) {
 		const r = ('radius' in entity ? entity.radius : undefined) ?? PIECE_DEFAULT_RADIUS;
+		const [px, pz] = snap ? [snap.x, snap.z] : [x, z];
 		return {
-			kind: 'table',
-			position: [x, PIECE_REST_Y, z],
-			rotation,
+			kind: snap ? 'snap' : 'table',
+			position: [px, PIECE_REST_Y, pz],
+			rotation: applySnapRotation(rotation, snap?.rotation, 'piece'),
 			footprint: { shape: 'circle', r },
-			footprintY: TABLE_TOP_Y
+			footprintY: TABLE_TOP_Y,
+			...(snap ? { snap: snapInfo(snap) } : {})
 		};
 	}
 
 	// decks don't nest, stack, or enter the tray: a dragged pile settles on
 	// the felt wherever it's pointed, centred at half its body height (the
-	// group origin is the slab's middle, not its base)
+	// group origin is the slab's middle, not its base) — or exactly on an
+	// authored snap point when one catches it.
+	//
+	// A snap only ever moves the deck in XZ and turns it: `restY` stays its own
+	// half-height, because a deck landing on an occupied point still doesn't
+	// stack. And the yaw goes in as radians here, unlike a card's — see
+	// applySnapRotation.
 	if (isDeck) {
 		const count = ('cards' in entity ? entity.cards : undefined)?.length ?? 0;
 		const restY = TABLE_TOP_Y + deckHeightForCount(count) / 2;
+		const [dx, dz] = snap ? [snap.x, snap.z] : [x, z];
 		return {
-			kind: 'table',
-			position: [x, restY, z],
-			rotation,
+			kind: snap ? 'snap' : 'table',
+			position: [dx, restY, dz],
+			rotation: applySnapRotation(rotation, snap?.rotation, 'deck'),
 			footprint: { shape: 'rect', w: CARD_WIDTH, h: CARD_HEIGHT },
-			footprintY: TABLE_TOP_Y
+			footprintY: TABLE_TOP_Y,
+			...(snap ? { snap: snapInfo(snap) } : {})
 		};
 	}
 
@@ -180,6 +223,21 @@ export function resolveDrop(
 			rotation,
 			footprint,
 			footprintY: CARD_REST_Y
+		};
+	}
+
+	// A caught card commits on the point exactly, but still stacks: the resting
+	// height comes from whatever is already sitting there, so a second card on
+	// the same snap point lands on top of the first instead of inside it.
+	if (snap) {
+		const stack = resolveStack(state?.cards, dragId, snap.x, snap.z);
+		return {
+			kind: 'snap',
+			position: [snap.x, stack.restY, snap.z],
+			rotation: applySnapRotation(rotation, snap.rotation, 'card'),
+			footprint,
+			footprintY: stack.restY,
+			snap: snapInfo(snap)
 		};
 	}
 

--- a/src/lib/utils/transforms/snap.ts
+++ b/src/lib/utils/transforms/snap.ts
@@ -1,0 +1,115 @@
+import { DEG2RAD } from 'three/src/math/MathUtils.js';
+import type { GameDTO, SnapPointDTO } from '$lib/store/game/types';
+import { SNAP_RADIUS_DEFAULT, SNAP_RADIUS_MAX, SNAP_RADIUS_MIN } from '$lib/utils/constants-snap';
+
+/**
+ * Snap points: where a drop is *pulled to*, as opposed to where the pointer
+ * happened to be.
+ *
+ * The whole mechanic is this one pure function plus a branch in `resolveDrop`.
+ * Nothing about a snap is synced on its own: the dropping client resolves the
+ * point, writes the final position through the same move path as any other
+ * drop, and the relay carries that — so both clients land on the identical
+ * transform without any new machinery.
+ */
+
+/** A resolved snap: the exact transform a caught drop commits at. */
+export interface SnapResolution {
+	/** which snap point caught the drop */
+	id: string;
+	x: number;
+	z: number;
+	/** authored yaw in degrees, or undefined to keep the entity's own rotation */
+	rotation?: number;
+	/** the radius that caught it, after clamping */
+	radius: number;
+	/** distance from the drop point to the snap point */
+	distance: number;
+}
+
+/** Authored radius, clamped to something that can actually catch a drop. */
+export function snapRadius(point: Partial<SnapPointDTO> | null | undefined): number {
+	const raw = point?.radius;
+	if (typeof raw !== 'number' || !Number.isFinite(raw)) return SNAP_RADIUS_DEFAULT;
+	return Math.min(Math.max(raw, SNAP_RADIUS_MIN), SNAP_RADIUS_MAX);
+}
+
+function xz(point: Partial<SnapPointDTO> | null | undefined): [number, number] | null {
+	const p = point?.position;
+	if (!Array.isArray(p) || p.length < 2) return null;
+	const [x, z] = p;
+	if (typeof x !== 'number' || typeof z !== 'number') return null;
+	if (!Number.isFinite(x) || !Number.isFinite(z)) return null;
+	return [x, z];
+}
+
+/**
+ * The snap point that catches a drop at (x, z), or null if none does.
+ *
+ * Nearest point wins, so overlapping catch radii resolve to the one the drop
+ * is actually closest to. Ties break on id — records arrive in whatever order
+ * a merge patch built them, and a snap must not depend on that.
+ */
+export function resolveSnap(
+	snapPoints: GameDTO['snapPoints'] | undefined | null,
+	x: number,
+	z: number
+): SnapResolution | null {
+	let best: SnapResolution | null = null;
+
+	for (const [id, point] of Object.entries(snapPoints ?? {})) {
+		const position = xz(point);
+		if (!position) continue; // null = removed, or a malformed entry
+		const radius = snapRadius(point);
+		const distance = Math.hypot(position[0] - x, position[1] - z);
+		if (distance > radius) continue;
+		if (best && (distance > best.distance || (distance === best.distance && id >= best.id))) {
+			continue;
+		}
+		const rotation = typeof point?.rotation === 'number' ? point.rotation : undefined;
+		best = { id, x: position[0], z: position[1], rotation, radius, distance };
+	}
+
+	return best;
+}
+
+/**
+ * Which entity is landing. They do not agree on where — or in what unit — a
+ * table yaw lives, so a single authored scalar has to be routed per kind.
+ */
+export type SnapRotationTarget = 'card' | 'piece' | 'deck';
+
+/**
+ * Apply an authored snap yaw (degrees) to an entity's rotation triple.
+ *
+ * The three conventions, none of which this function gets to choose:
+ * - **cards** — yaw is `rotation[2]` in **degrees** (what `tapCard` turns;
+ *   `Card.svelte` renders it as `rotation.y = -z`), and `rotation[0]` is the
+ *   facedown flip, which a snap must never touch.
+ * - **pieces** — yaw is the natural `rotation[1]`, in **degrees**. Today
+ *   nothing renders it (a token is a disc), but it is part of the piece's
+ *   transform and both clients must agree on it.
+ * - **decks** — yaw is `rotation[1]` in **radians**: `Deck.svelte` hands the
+ *   triple straight to its `<T.Group>`, and the seat-1 default is
+ *   `[0, Math.PI, 0]`. So the authored degrees convert here; writing degrees
+ *   into a deck would spin it by a factor of 57.
+ *
+ * Returns the input untouched when the point authored no rotation — an
+ * unrotated snap point is a position guide only.
+ */
+export function applySnapRotation(
+	rotation: [number, number, number],
+	yaw: number | undefined,
+	target: SnapRotationTarget
+): [number, number, number] {
+	if (yaw === undefined) return rotation;
+	const [x, y, z] = rotation;
+	switch (target) {
+		case 'card':
+			return [x, y, yaw];
+		case 'piece':
+			return [x, yaw, z];
+		case 'deck':
+			return [x, yaw * DEG2RAD, z];
+	}
+}

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -63,7 +63,7 @@
 <div class="h-screen w-screen overflow-clip bg-gray-700">
 	<Canvas toneMapping={ACESFilmicToneMapping}>
 		{#if isReady}
-			<TableScene />
+			<TableScene snapEditing />
 		{/if}
 	</Canvas>
 </div>

--- a/src/routes/setup/SetupPane.svelte
+++ b/src/routes/setup/SetupPane.svelte
@@ -11,6 +11,7 @@
 		Wheel,
 		AutoValue,
 		Checkbox,
+		Slider,
 		TabGroup,
 		TabPage
 	} from 'svelte-tweakpane-ui';
@@ -32,6 +33,9 @@
 		importScenarioFromText,
 		type SeatIndex
 	} from '$lib/scenario/scenario';
+	import { snapPointIds } from '$lib/store/game/actions/snap';
+	import { snapEditor, setSnapDefaults, setSnapPlacing } from '$lib/store/snapEditor';
+	import { SNAP_RADIUS_DEFAULT } from '$lib/utils/constants-snap';
 	import HUDPieces from '$lib/HUDPieces.svelte';
 	import { prewarmGameState } from '$lib/packs/prewarm-state';
 	import { purgeUndefinedValues } from '$lib/utils/transforms/data';
@@ -174,9 +178,10 @@
 			decks: {},
 			pieces: {},
 			overlays: {},
+			snapPoints: {},
 			players: {}
 		};
-		for (const collection of ['cards', 'decks', 'pieces', 'overlays'] as const) {
+		for (const collection of ['cards', 'decks', 'pieces', 'overlays', 'snapPoints'] as const) {
 			for (const key of Object.keys(s?.[collection] ?? {})) update[collection][key] = null;
 		}
 		for (const key of Object.keys(s?.players ?? {})) {
@@ -193,6 +198,26 @@
 
 	function setDeckField(deckId: string, patch: Record<string, unknown>) {
 		gameStore.updateState({ decks: { [deckId]: patch } });
+	}
+
+	// Snap points — authored placement guides. The scene has the direct
+	// manipulation (click to place while armed, drag a marker to move,
+	// right-click to delete); these are the exact numbers.
+	let newRadius = $state(SNAP_RADIUS_DEFAULT);
+	let newRotation = $state(0);
+	const snapIds = $derived(snapPointIds($gameStore));
+
+	$effect(() => {
+		// what a click-placed point gets stamped with
+		setSnapDefaults({ radius: newRadius, rotation: newRotation || undefined });
+	});
+
+	function addSnapPoint() {
+		gameActions.addSnapPoint({
+			position: [0, 0],
+			radius: newRadius,
+			rotation: newRotation || undefined
+		});
 	}
 
 	// overlay controls — same shape as the /play settings pane
@@ -307,6 +332,66 @@
 		ownerId={seatPlaceholderId(activeSeat)}
 		beforeSpawn={() => ensureSeatPlaceholder(activeSeat)}
 	/>
+	<Folder title="Snap points" expanded={false}>
+		<Checkbox
+			label="place on click"
+			value={$snapEditor.placing}
+			on:change={(e) => setSnapPlacing(!!e.detail.value)}
+		/>
+		<Slider label="new radius" bind:value={newRadius} min={0.2} max={6} step={0.1} />
+		<Wheel
+			label="new rotation"
+			bind:value={newRotation}
+			format={(v) => (v === 0 ? 'none' : `${(((v % 360) + 360) % 360).toFixed(0)}°`)}
+		/>
+		<Button title="Add at table centre" on:click={addSnapPoint} />
+		{#if snapIds.length > 0}
+			<TabGroup>
+				{#each snapIds as snapId (snapId)}
+					{@const point = $gameStore?.snapPoints?.[snapId]}
+					{@const position = point?.position ?? [0, 0]}
+					<TabPage title={snapId.replace('snap:', '#')}>
+						<Point
+							label="position"
+							value={[position[0], position[1]]}
+							on:change={(e) => {
+								//@ts-expect-error: does exist
+								const x = e.detail.value?.x ?? position[0];
+								//@ts-expect-error: does exist
+								const z = e.detail.value?.y ?? position[1];
+								gameActions.moveSnapPoint(snapId, [x, z]);
+							}}
+						/>
+						<Slider
+							label="radius"
+							value={point?.radius ?? SNAP_RADIUS_DEFAULT}
+							min={0.2}
+							max={6}
+							step={0.1}
+							on:change={(e) =>
+								gameActions.updateSnapPoint(snapId, { radius: e.detail.value ?? undefined })}
+						/>
+						<Wheel
+							label="rotation"
+							value={point?.rotation ?? 0}
+							format={(v) => (v === 0 ? 'none' : `${(((v % 360) + 360) % 360).toFixed(0)}°`)}
+							on:change={(e) =>
+								gameActions.updateSnapPoint(snapId, {
+									// 0 means "no authored yaw": a snap point that turns a card to
+									// 0° and one that leaves it alone are different things, and
+									// the wheel has no third state to say so
+									rotation: e.detail.value ? e.detail.value : undefined
+								})}
+						/>
+						<Button
+							title="Delete this point"
+							on:click={() => gameActions.removeSnapPoint(snapId)}
+						/>
+					</TabPage>
+				{/each}
+			</TabGroup>
+		{/if}
+	</Folder>
 	<Folder title="Overlay (map)" expanded={false}>
 		<Text label="Image URL" bind:value={imageUrl}></Text>
 		<Point bind:value={point3d} label="Position" />
@@ -335,6 +420,6 @@
 	<Textarea
 		disabled
 		rows={4}
-		value={`Everything here is local — no lobby is touched. Spawn or import a deck per seat (a TTS save, or a pack authored in /create), place the map, arrange, then Save. Pack decks save as a pack reference plus their card order, so a stacked deck reloads exactly; tick "shuffle on load" for a draw pile. Seed a lobby from /play → Settings → Scenarios. Note: cards in YOUR hand tray are not saved; keep starting cards on the table.`}
+		value={`Everything here is local — no lobby is touched. Spawn or import a deck per seat (a TTS save, or a pack authored in /create), place the map, arrange, then Save. Pack decks save as a pack reference plus their card order, so a stacked deck reloads exactly; tick "shuffle on load" for a draw pile. Snap points: arm "place on click" and click the felt, drag a ring to move it, right-click it to delete. They ride along in the scenario and pull dropped cards/tokens onto themselves in /play (hold Alt on release to ignore them); the rings only show here. Seed a lobby from /play → Settings → Scenarios. Note: cards in YOUR hand tray are not saved; keep starting cards on the table.`}
 	/>
 </Pane>

--- a/src/routes/setup/__tests__/SetupPane.snap.test.ts
+++ b/src/routes/setup/__tests__/SetupPane.snap.test.ts
@@ -1,0 +1,121 @@
+/**
+ * The /setup snap-point layer, driven through the real tweakpane controls in
+ * jsdom (like PaneDecks.test.ts / HUDPieces.test.ts).
+ *
+ * Two things are being guarded. The obvious one: place → move → delete works
+ * from the pane. The subtle one: the snap-point list is a `{#each}` of tabs that
+ * appears once the first point exists, and in this repo a pane whose blade tree
+ * is edited the wrong way tears itself down silently — no error, just an empty
+ * pane (see the comments in create/BulkSheet.svelte). So every assertion here
+ * also checks the pane's other controls are still rendered afterwards.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import SetupPane from '../SetupPane.svelte';
+import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { gameActions } from '$lib/store/game/actions';
+import { snapEditor } from '$lib/store/snapEditor';
+import { SNAP_RADIUS_DEFAULT } from '$lib/utils/constants-snap';
+
+// jsdom has neither observer: the draggable Pane watches its own size, and the
+// camerakit Wheel blade (the rotation dials) waits to be added to the DOM
+class NoopObserver {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+	takeRecords() {
+		return [];
+	}
+}
+vi.stubGlobal('ResizeObserver', NoopObserver);
+vi.stubGlobal('IntersectionObserver', NoopObserver);
+
+/** tweakpane renders asynchronously; let its microtasks flush */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 20));
+
+const button = (container: HTMLElement, label: string) =>
+	[...container.querySelectorAll('button')].find((b) => b.textContent?.includes(label));
+
+const snapPoints = () => get(gameStore).snapPoints ?? {};
+
+describe('SetupPane — snap points', () => {
+	beforeEach(() => {
+		cleanup();
+		localStorage.clear();
+		gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {}, overlays: {}, snapPoints: {} });
+	});
+
+	it('places a point, and the pane survives the list appearing', async () => {
+		const { container } = render(SetupPane);
+		await settle();
+
+		const add = button(container, 'Add at table centre');
+		expect(add).toBeDefined();
+		await fireEvent.click(add!);
+		await settle();
+
+		expect(Object.values(snapPoints())).toEqual([
+			{ id: 'snap:0', position: [0, 0], radius: SNAP_RADIUS_DEFAULT }
+		]);
+		// the blade tree grew a TabGroup — the pane must still be intact
+		expect(button(container, 'Add at table centre')).toBeDefined();
+		expect(button(container, 'Delete this point')).toBeDefined();
+		expect(button(container, 'Clear table')).toBeDefined();
+	});
+
+	it('deletes the selected point, and the pane survives the list going away', async () => {
+		const { container } = render(SetupPane);
+		await settle();
+		await fireEvent.click(button(container, 'Add at table centre')!);
+		await settle();
+
+		await fireEvent.click(button(container, 'Delete this point')!);
+		await settle();
+
+		expect(snapPoints()).toEqual({});
+		expect(button(container, 'Add at table centre')).toBeDefined();
+		expect(button(container, 'Delete this point')).toBeUndefined();
+	});
+
+	it('reflects a point moved in the scene, with no remount', async () => {
+		const { container } = render(SetupPane);
+		await settle();
+		await fireEvent.click(button(container, 'Add at table centre')!);
+		await settle();
+
+		// what dragging the marker does (SnapPointMarker.svelte)
+		gameActions.moveSnapPoint('snap:0', [4, -2]);
+		await settle();
+
+		expect(snapPoints()['snap:0']?.position).toEqual([4, -2]);
+		expect(button(container, 'Delete this point')).toBeDefined();
+	});
+
+	it('arms click-to-place for the table mesh', async () => {
+		const { container } = render(SetupPane);
+		await settle();
+		expect(get(snapEditor).placing).toBe(false);
+
+		const checkbox = container.querySelector<HTMLInputElement>('input[type="checkbox"]');
+		expect(checkbox).not.toBeNull();
+		await fireEvent.click(checkbox!);
+		await settle();
+
+		expect(get(snapEditor).placing).toBe(true);
+		// and the defaults the click will stamp are published
+		expect(get(snapEditor).radius).toBe(SNAP_RADIUS_DEFAULT);
+	});
+
+	it('clears snap points along with the rest of the table', async () => {
+		const { container } = render(SetupPane);
+		await settle();
+		await fireEvent.click(button(container, 'Add at table centre')!);
+		await settle();
+
+		await fireEvent.click(button(container, 'Clear table')!);
+		await settle();
+
+		expect(snapPoints()).toEqual({});
+	});
+});

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -33,7 +33,7 @@ Every file carries an in-band discriminator at the top level: `"tbpp": 1` or `"t
 
 ### 2.1 Spec versions
 
-Current: **pack `1.0.0`**, **scenario `0.1.1`**. The scenario spec is `0.x` on purpose — under semver, `0.x` may break on every minor, which is precisely the promise being made.
+Current: **pack `1.0.0`**, **scenario `0.1.2`**. The scenario spec is `0.x` on purpose — under semver, `0.x` may break on every minor, which is precisely the promise being made.
 
 Two version fields exist and they answer different questions:
 
@@ -102,6 +102,7 @@ Seats sit around the short ends. Seats **0 and 2** are on the `+z` side facing `
 | `PIECE_RADIUS.pawn` | 0.3 | default radius per kind — pawn |
 | `PIECE_RADIUS.counter` | 0.6 | default radius per kind — counter |
 | `COUNTER_MAX_DEFAULT` | 20 | starting max for a counter with no `maxValue` |
+| `SNAP_RADIUS_DEFAULT` | 0.9 | catch radius of a snap point that omits `radius` |
 
 Practical defaults, matching what the app itself spawns:
 
@@ -370,8 +371,8 @@ Decks spawn in declaration order. A facedown deck is shuffled when spawned direc
 	},
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"x-tableplace-spec-version": "1.0.0",
-	"x-generated-at": "2026-07-25T13:32:45.257Z",
-	"x-tableplace-source-sha": "6ccfc198d3635c87b35a3752e3ac880f9087a12a-dirty"
+	"x-generated-at": "2026-07-25T13:38:51.890Z",
+	"x-tableplace-source-sha": "c1967e35f3217eb0cca78f79142f0730009865fc-dirty"
 }
 ```
 
@@ -455,7 +456,7 @@ A scenario is a saved arrangement. Version 2 **references** packs rather than co
 
 ### 7.1 Fields
 
-- **`specVersion`** — the scenario spec you generated against (§2.1). Currently `0.1.1`.
+- **`specVersion`** — the scenario spec you generated against (§2.1). Currently `0.1.2`.
 - **`name`**, **`createdAt`** — title and a Unix epoch timestamp in milliseconds.
 - **`packs[]`** — `{ id, source? }` for every pack the scenario draws from. `source` is `"builtin"` for packs shipped with the app (currently only `standard-52`), or an `https://` URL a `.tbpp.json` can be fetched from. A remote pack goes through the same validation as a local import.
 - **`placements[]`** — one entry per spawned thing:
@@ -467,11 +468,31 @@ A scenario is a saved arrangement. Version 2 **references** packs rather than co
   - **`order`** _(decks)_ — the card sequence as pack card `code`s, top of the deck first. **Order is preserved by default**, so a rigged opening or a fixed encounter deck reloads exactly as authored. It is a list of ids, never card bodies. Unknown codes are skipped with a warning.
   - **`shuffleOnLoad`** _(decks, default `false`)_ — shuffle on load instead of restoring `order`. Per placement, so one scenario can hold a stacked encounter deck and a shuffled draw deck side by side.
   - **`isFaceUp`** _(decks)_, **`value`** _(counter pieces)_, **`scale`** _(overlays)_ — override the pack's defaults.
+- **`snapPoints[]`** _(optional)_ — placement guides on the felt (§7.2 below). Independent of `placements`: they steer what players drop, not what the scenario spawns.
 - **`state`** — a partial snapshot for everything _not_ pack-derived: hand-placed cards, ad-hoc pieces. Applied on top of the placements, so it can also override them. This is the part of the format most likely to change; keep as little in it as you can.
 
 Scenarios are **seat-relative**. Entities belong to placeholder players `seat0`–`seat3`, and entity ids follow `kind:owner:slug` — `deck:seat0:main`, `card:seat0:main-AS`, `piece:seat0:hp-0`. Overlays are table-scoped and keyed `overlay:<packId>:<index>`. When a real player claims a seat, every id containing that placeholder is renamed to them. Never put a real player id in a file.
 
-### 7.2 JSON Schema
+### 7.2 Snap points — placement guides
+
+`snapPoints` is how a scenario makes a board _playable_ rather than merely arranged. Each entry is a spot on the felt that pulls drops onto itself:
+
+```json
+"snapPoints": [
+	{ "position": [0, 2.5], "rotation": 0, "radius": 1 },
+	{ "position": [-4, 0] }
+]
+```
+
+- **`position`** — `[x, z]` in table space (§4). Two elements, no y: a snap point is a spot on the felt, and what lands on it keeps its own resting height, so a card dropped on an occupied point still stacks on what is already there.
+- **`rotation`** _(optional)_ — the yaw a caught drop turns to, in **degrees**. Note the unit: `placements[].rotation` is radians, this is degrees, because it maps 1:1 onto a card's own tap rotation and onto TTS snap points. Omit it for a position-only guide, which leaves whatever lands facing as it was.
+- **`radius`** _(optional)_ — catch radius in world units. Omitted means `SNAP_RADIUS_DEFAULT` (§4). A drop lands on a point when its release is inside the radius; when radii overlap, the nearest point wins.
+
+Snap points are **table-scoped, not seat-relative**: unlike a pack piece's `[x, z]`, they are never mirrored for the far side of the table. Author both ends explicitly — one at `[0, 2.5]` facing `0`, one at `[0, -2.5]` facing `180`.
+
+They are inert data. Nothing spawns from them, they claim no ids, they are drawn only in the scenario editor, and a player can always ignore one by holding Alt as they release. A scenario with no `snapPoints` behaves exactly as it did before the field existed.
+
+### 7.3 JSON Schema
 
 ```json
 {
@@ -608,6 +629,43 @@ Scenarios are **seat-relative**. Entities belong to placeholder players `seat0`�
 						"required": ["content", "kind", "pack"]
 					},
 					"title": "placements"
+				},
+				"snapPoints": {
+					"description": "Placement guides for whatever ends up on the table, pack-derived or not —\nand the only place a file should author them. Additive: a scenario without\nthem behaves exactly as it did before they existed, and they don't decide\nthe file version (a hand-placed table with snap points is still v1).",
+					"type": "array",
+					"items": {
+						"description": "An authored placement guide: a spot on the felt that a dropped card or piece\nfinishes exactly on. Scenario-level and table-space — a snap point belongs\nto the board, not to a seat, so it is not mirrored per seat the way pack\npiece positions are.\n\nDeliberately shaped like TTS's save-level `SnapPoints` (position + optional\nrotation) so importing those stays a mechanical mapping.",
+						"type": "object",
+						"properties": {
+							"position": {
+								"description": "table-space `[x, z]`; no y — snap points live on the felt",
+								"type": "array",
+								"items": [
+									{
+										"type": "number"
+									},
+									{
+										"type": "number"
+									}
+								],
+								"minItems": 2,
+								"maxItems": 2,
+								"title": "position"
+							},
+							"rotation": {
+								"description": "Yaw a caught drop turns to, in **degrees**. Omitted leaves the entity's\nown rotation alone. Degrees, not the radians `placements` use, because\nthis is a single table yaw and it maps 1:1 onto both the card DTO's tap\nrotation and TTS's snap-point rotation.",
+								"type": "number",
+								"title": "rotation"
+							},
+							"radius": {
+								"description": "catch radius in world units; omitted means the app default (0.9)",
+								"type": "number",
+								"title": "radius"
+							}
+						},
+						"required": ["position"]
+					},
+					"title": "snapPoints"
 				}
 			},
 			"required": ["createdAt", "name", "state"]
@@ -690,6 +748,21 @@ Scenarios are **seat-relative**. Entities belong to placeholder players `seat0`�
 						]
 					},
 					"title": "pieces"
+				},
+				"snapPoints": {
+					"description": "authored placement guides, keyed `snap:<n>`. null = remove",
+					"type": "object",
+					"additionalProperties": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/Partial%3CSnapPointDTO%3E"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"title": "snapPoints"
 				}
 			}
 		},
@@ -1081,24 +1154,59 @@ Scenarios are **seat-relative**. Entities belong to placeholder players `seat0`�
 					"title": "packOrigin"
 				}
 			}
+		},
+		"Partial<SnapPointDTO>": {
+			"title": "Partial<SnapPointDTO>",
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "string",
+					"title": "id"
+				},
+				"position": {
+					"description": "Table-space `[x, z]`. No y: a snap point is a spot on the felt, and what\nlands on it keeps its own resting height (a card on a card still stacks).",
+					"type": "array",
+					"items": [
+						{
+							"type": "number"
+						},
+						{
+							"type": "number"
+						}
+					],
+					"minItems": 2,
+					"maxItems": 2,
+					"title": "position"
+				},
+				"rotation": {
+					"description": "Yaw the landing snaps to, in **degrees**, or omitted to keep whatever\nrotation the entity already had. Degrees to match the card DTO's tap\nrotation (`actions/card.ts`) and TTS's `SnapPoints`.",
+					"type": "number",
+					"title": "rotation"
+				},
+				"radius": {
+					"description": "catch radius in world units; omitted means `SNAP_RADIUS_DEFAULT`",
+					"type": "number",
+					"title": "radius"
+				}
+			}
 		}
 	},
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"x-tableplace-spec-version": "0.1.1",
-	"x-generated-at": "2026-07-25T13:32:45.257Z",
-	"x-tableplace-source-sha": "6ccfc198d3635c87b35a3752e3ac880f9087a12a-dirty"
+	"x-tableplace-spec-version": "0.1.2",
+	"x-generated-at": "2026-07-25T13:38:51.890Z",
+	"x-tableplace-source-sha": "c1967e35f3217eb0cca78f79142f0730009865fc-dirty"
 }
 ```
 
-### 7.3 Worked example
+### 7.4 Worked example
 
-Two packs — one builtin, one fetched from `https://example.com/packs/ember-duel.tbpp.json` (the pack in §6.3) — with a stacked deck for seat 0, a shuffled deck for seat 1, a counter, a board overlay, and one hand-placed token in `state`.
+Two packs — one builtin, one fetched from `https://example.com/packs/ember-duel.tbpp.json` (the pack in §6.3) — with a stacked deck for seat 0, a shuffled deck for seat 1, a counter, a board overlay, three snap points, and one hand-placed token in `state`.
 
 ```json
 {
 	"$schema": "https://table.place/scenario.schema.json",
 	"tbps": 2,
-	"specVersion": "0.1.1",
+	"specVersion": "0.1.2",
 	"name": "ember-duel-opening",
 	"createdAt": 1700000000000,
 	"packs": [
@@ -1167,6 +1275,30 @@ Two packs — one builtin, one fetched from `https://example.com/packs/ember-due
 			"scale": 14
 		}
 	],
+	"snapPoints": [
+		{
+			"position": [
+				0,
+				2.5
+			],
+			"rotation": 0,
+			"radius": 1
+		},
+		{
+			"position": [
+				0,
+				-2.5
+			],
+			"rotation": 180,
+			"radius": 1
+		},
+		{
+			"position": [
+				-4,
+				0
+			]
+		}
+	],
 	"state": {
 		"pieces": {
 			"piece:seat0:objective-0": {
@@ -1187,6 +1319,7 @@ Deliberately unresolved. Do not invent syntax for these — a file using it will
 - **Pack content versioning.** `tbpp` is the _format_ version; a pack cannot declare its own version ("Ember Duel v1.2"). There is no field for it and no upgrade story for a pack whose contents changed under a scenario that references it.
 - **`id` collision policy across authors.** Pack `id` is a bare string with no namespacing or registry. Two authors can both publish `ember-duel`, and a scenario referencing `ember-duel` by a URL that later serves different content will silently resolve differently. Until this is decided, prefer a distinctive `id` and always pin `source` to a URL you control.
 - **Pieces and overlays in scenarios beyond the fields above** — piece rotation, stacking and zones are not expressible.
+- **Snapping beyond single points.** `snapPoints` is a list of discrete spots. Grids (square/hex), per-object opt-outs, and hidden/layout/randomize zones have no syntax; a snap point cannot restrict _what_ may land on it either.
 
 ## 9. Before you emit a file
 

--- a/static/pack.schema.json
+++ b/static/pack.schema.json
@@ -191,6 +191,6 @@
 	},
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"x-tableplace-spec-version": "1.0.0",
-	"x-generated-at": "2026-07-25T13:32:45.257Z",
-	"x-tableplace-source-sha": "6ccfc198d3635c87b35a3752e3ac880f9087a12a-dirty"
+	"x-generated-at": "2026-07-25T13:38:51.890Z",
+	"x-tableplace-source-sha": "c1967e35f3217eb0cca78f79142f0730009865fc-dirty"
 }

--- a/static/scenario.schema.json
+++ b/static/scenario.schema.json
@@ -132,6 +132,43 @@
 						"required": ["content", "kind", "pack"]
 					},
 					"title": "placements"
+				},
+				"snapPoints": {
+					"description": "Placement guides for whatever ends up on the table, pack-derived or not —\nand the only place a file should author them. Additive: a scenario without\nthem behaves exactly as it did before they existed, and they don't decide\nthe file version (a hand-placed table with snap points is still v1).",
+					"type": "array",
+					"items": {
+						"description": "An authored placement guide: a spot on the felt that a dropped card or piece\nfinishes exactly on. Scenario-level and table-space — a snap point belongs\nto the board, not to a seat, so it is not mirrored per seat the way pack\npiece positions are.\n\nDeliberately shaped like TTS's save-level `SnapPoints` (position + optional\nrotation) so importing those stays a mechanical mapping.",
+						"type": "object",
+						"properties": {
+							"position": {
+								"description": "table-space `[x, z]`; no y — snap points live on the felt",
+								"type": "array",
+								"items": [
+									{
+										"type": "number"
+									},
+									{
+										"type": "number"
+									}
+								],
+								"minItems": 2,
+								"maxItems": 2,
+								"title": "position"
+							},
+							"rotation": {
+								"description": "Yaw a caught drop turns to, in **degrees**. Omitted leaves the entity's\nown rotation alone. Degrees, not the radians `placements` use, because\nthis is a single table yaw and it maps 1:1 onto both the card DTO's tap\nrotation and TTS's snap-point rotation.",
+								"type": "number",
+								"title": "rotation"
+							},
+							"radius": {
+								"description": "catch radius in world units; omitted means the app default (0.9)",
+								"type": "number",
+								"title": "radius"
+							}
+						},
+						"required": ["position"]
+					},
+					"title": "snapPoints"
 				}
 			},
 			"required": ["createdAt", "name", "state"]
@@ -214,6 +251,21 @@
 						]
 					},
 					"title": "pieces"
+				},
+				"snapPoints": {
+					"description": "authored placement guides, keyed `snap:<n>`. null = remove",
+					"type": "object",
+					"additionalProperties": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/Partial%3CSnapPointDTO%3E"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"title": "snapPoints"
 				}
 			}
 		},
@@ -605,10 +657,45 @@
 					"title": "packOrigin"
 				}
 			}
+		},
+		"Partial<SnapPointDTO>": {
+			"title": "Partial<SnapPointDTO>",
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "string",
+					"title": "id"
+				},
+				"position": {
+					"description": "Table-space `[x, z]`. No y: a snap point is a spot on the felt, and what\nlands on it keeps its own resting height (a card on a card still stacks).",
+					"type": "array",
+					"items": [
+						{
+							"type": "number"
+						},
+						{
+							"type": "number"
+						}
+					],
+					"minItems": 2,
+					"maxItems": 2,
+					"title": "position"
+				},
+				"rotation": {
+					"description": "Yaw the landing snaps to, in **degrees**, or omitted to keep whatever\nrotation the entity already had. Degrees to match the card DTO's tap\nrotation (`actions/card.ts`) and TTS's `SnapPoints`.",
+					"type": "number",
+					"title": "rotation"
+				},
+				"radius": {
+					"description": "catch radius in world units; omitted means `SNAP_RADIUS_DEFAULT`",
+					"type": "number",
+					"title": "radius"
+				}
+			}
 		}
 	},
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"x-tableplace-spec-version": "0.1.1",
-	"x-generated-at": "2026-07-25T13:32:45.257Z",
-	"x-tableplace-source-sha": "6ccfc198d3635c87b35a3752e3ac880f9087a12a-dirty"
+	"x-tableplace-spec-version": "0.1.2",
+	"x-generated-at": "2026-07-25T13:38:51.890Z",
+	"x-tableplace-source-sha": "c1967e35f3217eb0cca78f79142f0730009865fc-dirty"
 }


### PR DESCRIPTION
Task: tableplace-96

Closes #96

Scenario-level, table-space snap points: an authored spot on the felt that a dropped card or piece finishes exactly on, turned to an authored yaw when one is set. The primitive that makes an imported or authored board *playable* rather than just rendered.

## What landed

**Format** (`src/lib/scenario/file.ts`) — a top-level, optional `snapPoints: Array<{ position: [x, z], rotation?, radius? }>`. Strictly additive: absent means byte-identical parse/serialize behaviour to before, and it does not decide the file version (a hand-placed table with snap points still exports v1). `position` is a 2-tuple because a snap point is a spot on the felt — what lands on it keeps its own resting height. `rotation` is **degrees** (a single table yaw, unlike `placements[].rotation`'s radians) so it maps 1:1 onto the card DTO's tap rotation and onto TTS's `SnapPoints` — documented at both the type and in the published spec.

**Runtime** — `GameDTO.snapPoints` keyed `snap:<n>`, so editing is ordinary surgical patches (`null` deletes) and the relay syncs them with no server change. The file drops the ids (nothing references them) and reassigns on load, which is why the field is an array.

**Resolution** — `resolveSnap` (`utils/transforms/snap.ts`) is a pure nearest-point-within-radius search. `resolveDrop` calls it, returns `kind: 'snap'`, and the commit writes that final transform through the existing move path — **no new sync machinery**; the one patch the relay carries is what puts both clients on the identical transform. Rotation goes on the wire only when a point authored one. Order, most explicit first: tray → hovered deck → Alt's opt-out → snap point → loose-pile square-up. A caught card still stacks, so a second card on the same point lands on top of the first.

**/setup** — a snap-point layer, not a new mode: markers drawn flat on the felt (ring at the catch radius, dot on the point, tick for the yaw), armed click-to-place on the felt, drag a marker to move, right-click to delete, plus exact numbers in a new pane folder. Marker dragging is deliberately local rather than routed through `dragStore`, whose consumers all assume the dragged id is an entity a drop resolves a landing *for*.

**/play** — markers hidden (design call, documented): the board stays clean and the drop preview is the feedback instead — the footprint jumps onto the point in its own colour, already turned to the authored yaw, with a ring showing what caught it. That also covers the optional ghost-preview stretch.

## Acceptance criteria

1. **/setup place / move / delete + round-trip + v-gate** — `SetupPane.snap.test.ts` drives the real tweakpane controls (place, delete, reflect a scene move, arm click-to-place, clear); `scenario-snap-points.test.ts` covers save → export → import → load and that a scenario *without* the field loads without inventing any; `file.test.ts` covers the absent-field gate and per-path validation errors.
2. **/play, two clients** — resolution and the exact final write are covered by `commit.test.ts` (card *and* token land on the point, at the snap rotation when set; no rotation on the wire otherwise) and `drop.test.ts`. The cross-client half is the existing broadcast path: one patch through `gameStore.updateState`, which the wire treats schema-agnostically. **Not** verified in two live browsers — no browser extension was connected in this environment, so that step is unexercised.
3. **Spec artifacts** — `static/scenario.schema.json` + `llms.txt` regenerated (never hand-edited), scenario spec `0.1.0` → `0.2.0` (additive → minor), `docs/packs.md` and the LLM-facing spec (new §7.2) updated here. `bun run schemas:check --base main` passes. `pack.schema.json` moved only its provenance stamp.
4. **Unit tests** — 40 new tests across snap math (inside/outside/on the radius, default radius, nearest wins, id tie-break, malformed/deleted entries, rotation routing), drop resolution, the commit patch, file parse/serialize, and the editor.
5. `bun run test` 443 passed / 41 files, `bun run check` 0 errors (same 8 pre-existing `state_referenced_locally` warnings), `bun run build` green. Lint is red at baseline on main — eslint reports the identical 59 errors before and after, and every file this PR touches passes `prettier --check`.

## Notes

- One pane limitation, commented in place: the rotation wheel treats `0` as "no authored yaw", since it has no third state. Author `360` for an explicit zero facing.
- Kept scenario-level per the ticket; pack-level snap sets (a snap layout travelling with an overlay) would pull in the pack schema and /create under the parity rule, and are filed as a known gap in `docs/packs.md` instead.
- `state.snapPoints` is also expressible via `Partial<GameDTO>`; rather than silently ignoring it, it is applied as the override layer like every other collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWAa23VXCAtpb1DstbpSNe