### PR TITLE
tableplace-102: dice — a self-rescheduling effect killed the whole runtime, plus a headless render harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,35 @@ jobs:
 
       - name: Build
         run: bun run build
+
+  # The headless render harness. Separate job because it needs Go (for the
+  # relay) and a real browser, and because it is the only thing here that
+  # executes three.js: jsdom never runs a raycast or a WebGL draw, which is how
+  # #102 shipped past 700 green unit tests, a clean svelte-check and a clean
+  # build. Anything that only breaks in a real browser breaks here.
+  render:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache-dependency-path: server/go.sum
+
+      - name: Install dependencies
+        run: bun install
+
+      # Chrome ships on the GitHub-hosted ubuntu images; puppeteer-core
+      # downloads nothing. The harness starts its own vite dev server on a
+      # random high port and its own Go relay, and never talks to the public
+      # api.table.place.
+      - name: Headless render harness
+        run: bun run test:e2e
+        env:
+          CHROME_PATH: /usr/bin/google-chrome

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ bun run preview
 bun run test             # bun vitest run — 29 tests, ~1s
 bun run test:watch
 bun run test:coverage
+bun run test:e2e         # headless render harness (see below); [filter] narrows by spec name
 bun run check            # svelte-kit sync && svelte-check
 bun run lint             # prettier --check . && eslint .
 bun run format           # prettier --write .
@@ -90,6 +91,30 @@ go build -o tts-server .
   radii, rotations) rather than inline literals.
 - Commits: lowercase conventional prefixes (`feat:`, `fix:`, `chore:`, `docs:`,
   `revert:`) with a short subject, often followed by an em-dash rationale.
+
+## Headless render harness (`e2e/`)
+
+`bun run test:e2e` drives a real (software-rendered) Chrome through
+`puppeteer-core` against its own `vite dev` and its own Go relay. It exists
+because **jsdom never executes three.js geometry, a raycast or a WebGL draw** —
+tableplace-102 shipped to production past 700 green unit tests, `svelte-check`
+with 0 errors and a clean build, because no test in the repo could see it.
+
+- `e2e/specs.ts` is the whole suite. Every spec has the same spine: put a new
+  primitive on the table, then assert that *everything else* still renders,
+  still gets raycast, and still moves under a real mouse. That is the assertion
+  a new primitive needs, because the scene shares one `interactivity()` context
+  (#86) and one Svelte effect graph — a single bad entity takes both down.
+- Any console `error`, `pageerror` or failed request fails a spec. Keep the app's
+  console clean; `IGNORED` in `e2e/table.ts` is for environment noise only.
+- The page is driven through `window.__tableplace` (`src/lib/dev/`), which exists
+  only under `import.meta.env.DEV`. Spawn through it — the tweakpane `List`
+  controls cannot be driven synthetically.
+- Anything a spec clicks must draw clear of the HUD panes; `dragBy` fails with
+  that diagnosis rather than looking like a frozen table.
+- Needs Chrome (`CHROME_PATH` overrides discovery) and Go for the relay. Reuses
+  a relay already on `:8080`; takes a random high port for the web server so it
+  can never disturb a dev server you are using.
 
 ## Primitive parity rule
 

--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "prettier": "^3.4.2",
         "prettier-plugin-svelte": "^3.3.3",
         "prettier-plugin-tailwindcss": "^0.6.11",
+        "puppeteer-core": "^25.3.0",
         "svelte": "^5.56.7",
         "svelte-check": "^4.7.3",
         "tailwindcss": "^4.0.0",
@@ -401,6 +402,8 @@
 
     "@polka/url": ["@polka/url@1.0.0-next.28", "", {}, "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw=="],
 
+    "@puppeteer/browsers": ["@puppeteer/browsers@3.0.6", "", { "dependencies": { "modern-tar": "^0.7.6", "yargs": "^18.0.0" }, "peerDependencies": { "proxy-agent": ">=8.0.1", "yauzl": "^2.10.0 || ^3.4.0" }, "optionalPeers": ["proxy-agent", "yauzl"], "bin": { "browsers": "lib/main-cli.js" } }, "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA=="],
+
     "@rollup/plugin-babel": ["@rollup/plugin-babel@5.3.1", "", { "dependencies": { "@babel/helper-module-imports": "^7.10.4", "@rollup/pluginutils": "^3.1.0" }, "peerDependencies": { "@babel/core": "^7.0.0", "@types/babel__core": "^7.1.9", "rollup": "^1.20.0||^2.0.0" }, "optionalPeers": ["@types/babel__core"] }, "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q=="],
 
     "@rollup/plugin-node-resolve": ["@rollup/plugin-node-resolve@15.3.1", "", { "dependencies": { "@rollup/pluginutils": "^5.0.1", "@types/resolve": "1.20.2", "deepmerge": "^4.2.2", "is-module": "^1.0.0", "resolve": "^1.22.1" }, "peerDependencies": { "rollup": "^2.78.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA=="],
@@ -655,6 +658,8 @@
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
+    "chromium-bidi": ["chromium-bidi@16.0.1", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA=="],
+
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
@@ -714,6 +719,8 @@
     "detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
 
     "devalue": ["devalue@5.8.2", "", {}, "sha512-DObPPAfdtFbXjxLqK8s2Xk9ZuWz5+ZoFEhC7J76es4GU/rEiXwHTmbImoCdyoCOcBH1UF3+Cz6Z2sYD4hyl5TA=="],
+
+    "devtools-protocol": ["devtools-protocol@0.0.1638949", "", {}, "sha512-mXwg4Fqnv0WR4iuAT/gYUmctNkjILwXFHyZ+m7Ty1dfr0ezZt2U3gnrrJTfRobJTHoXf+IbuFvFITzLrLFjwJA=="],
 
     "diet-sprite": ["diet-sprite@0.0.1", "", {}, "sha512-zSHI2WDAn1wJqJYxcmjWfJv3Iw8oL9reQIbEyx2x2/EZ4/qmUTIo8/5qOCurnAcq61EwtJJaZ0XTy2NRYqpB5A=="],
 
@@ -1071,6 +1078,10 @@
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
+    "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
+
+    "modern-tar": ["modern-tar@0.7.7", "", {}, "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ=="],
+
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
@@ -1150,6 +1161,8 @@
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "puppeteer-core": ["puppeteer-core@25.3.0", "", { "dependencies": { "@puppeteer/browsers": "3.0.6", "chromium-bidi": "16.0.1", "devtools-protocol": "0.0.1638949", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.2", "ws": "^8.21.0" } }, "sha512-fm+wpUr2oigH1PXZvwgATrM2tYWHMDG8ASzTEe9uukCye4X5Ldx1K5BTHPFKITrIWvQQAQ256d1NpbEveBcKjA=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
@@ -1371,6 +1384,8 @@
 
     "typed-array-length": ["typed-array-length@1.0.7", "", { "dependencies": { "call-bind": "^1.0.7", "for-each": "^0.3.3", "gopd": "^1.0.1", "is-typed-array": "^1.1.13", "possible-typed-array-names": "^1.0.0", "reflect.getprototypeof": "^1.0.6" } }, "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg=="],
 
+    "typed-query-selector": ["typed-query-selector@2.12.2", "", {}, "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ=="],
+
     "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
 
     "typescript-eslint": ["typescript-eslint@8.25.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.25.0", "@typescript-eslint/parser": "8.25.0", "@typescript-eslint/utils": "8.25.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.8.0" } }, "sha512-TxRdQQLH4g7JkoFlYG3caW5v1S6kEkz8rqt80iQJZUYPq1zD1Ra7HfQBJJ88ABRaMvHAXnwRvRB4V+6sQ9xN5Q=="],
@@ -1418,6 +1433,8 @@
     "vitest": ["vitest@3.1.1", "", { "dependencies": { "@vitest/expect": "3.1.1", "@vitest/mocker": "3.1.1", "@vitest/pretty-format": "^3.1.1", "@vitest/runner": "3.1.1", "@vitest/snapshot": "3.1.1", "@vitest/spy": "3.1.1", "@vitest/utils": "3.1.1", "chai": "^5.2.0", "debug": "^4.4.0", "expect-type": "^1.2.0", "magic-string": "^0.30.17", "pathe": "^2.0.3", "std-env": "^3.8.1", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinypool": "^1.0.2", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0", "vite-node": "3.1.1", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.1.1", "@vitest/ui": "3.1.1", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webdriver-bidi-protocol": ["webdriver-bidi-protocol@0.4.2", "", {}, "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA=="],
 
     "webgl-sdf-generator": ["webgl-sdf-generator@1.1.1", "", {}, "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA=="],
 
@@ -1479,6 +1496,8 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
+    "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
+
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
@@ -1498,6 +1517,8 @@
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "zimmerframe": ["zimmerframe@1.1.2", "", {}, "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@babel/core/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
@@ -1540,6 +1561,8 @@
     "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "@puppeteer/browsers/yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
 
     "@rollup/plugin-node-resolve/@rollup/pluginutils": ["@rollup/pluginutils@5.1.4", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ=="],
 
@@ -1645,6 +1668,12 @@
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
+    "@puppeteer/browsers/yargs/cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+
+    "@puppeteer/browsers/yargs/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "@puppeteer/browsers/yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
+
     "@rollup/plugin-node-resolve/@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@testing-library/dom/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -1695,6 +1724,14 @@
 
     "typescript-json-schema/yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
+    "@puppeteer/browsers/yargs/cliui/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
+    "@puppeteer/browsers/yargs/cliui/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "@puppeteer/browsers/yargs/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "@puppeteer/browsers/yargs/string-width/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
     "@vitest/coverage-c8/c8/foreground-child/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "@vitest/coverage-c8/c8/test-exclude/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
@@ -1720,6 +1757,12 @@
     "typescript-json-schema/yargs/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "typescript-json-schema/yargs/string-width/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
+    "@puppeteer/browsers/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
+
+    "@puppeteer/browsers/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "@puppeteer/browsers/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
     "concurrently/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 

--- a/e2e/assert.ts
+++ b/e2e/assert.ts
@@ -1,0 +1,15 @@
+/** The three assertions the specs actually need. */
+
+export function ok(condition: unknown, message: string): asserts condition {
+	if (!condition) throw new Error(message);
+}
+
+export function equal<T>(actual: T, expected: T, message: string): void {
+	if (actual !== expected) throw new Error(`${message} — expected ${expected}, got ${actual}`);
+}
+
+/** distance between two [x, y, z] store positions, ignoring height */
+export function planarDistance(a: number[] | null, b: number[] | null): number {
+	if (!a || !b) return 0;
+	return Math.hypot((a[0] ?? 0) - (b[0] ?? 0), (a[2] ?? 0) - (b[2] ?? 0));
+}

--- a/e2e/browser.ts
+++ b/e2e/browser.ts
@@ -1,0 +1,93 @@
+/**
+ * Finding and launching a real Chrome for the render harness.
+ *
+ * `puppeteer-core` on purpose: it downloads nothing, so CI uses whatever
+ * Chrome the runner already ships (`ubuntu-latest` has one) and a developer
+ * uses their own. `CHROME_PATH` overrides everything.
+ *
+ * The GL flags are the load-bearing part. A default headless Chrome has no GPU,
+ * three.js gets a null WebGL context, and the whole table silently renders
+ * nothing — which would make every assertion here vacuous. SwiftShader gives a
+ * real software rasteriser, so the scene actually draws and a raycast actually
+ * runs.
+ */
+
+import { existsSync, readdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import puppeteer, { type Browser } from 'puppeteer-core';
+
+/** newest first, so a stale old download never wins over a fresh one */
+function puppeteerCacheChromes(): string[] {
+	const root = join(homedir(), '.cache', 'puppeteer', 'chrome');
+	if (!existsSync(root)) return [];
+	return readdirSync(root)
+		.sort()
+		.reverse()
+		.flatMap((dir) => [
+			join(
+				root,
+				dir,
+				'chrome-mac-arm64',
+				'Google Chrome for Testing.app',
+				'Contents',
+				'MacOS',
+				'Google Chrome for Testing'
+			),
+			join(
+				root,
+				dir,
+				'chrome-mac-x64',
+				'Google Chrome for Testing.app',
+				'Contents',
+				'MacOS',
+				'Google Chrome for Testing'
+			),
+			join(root, dir, 'chrome-linux64', 'chrome')
+		]);
+}
+
+export function findChrome(): string {
+	const candidates = [
+		process.env.CHROME_PATH,
+		process.env.PUPPETEER_EXECUTABLE_PATH,
+		'/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+		'/Applications/Chromium.app/Contents/MacOS/Chromium',
+		'/usr/bin/google-chrome',
+		'/usr/bin/google-chrome-stable',
+		'/usr/bin/chromium',
+		'/usr/bin/chromium-browser',
+		...puppeteerCacheChromes()
+	].filter((path): path is string => !!path);
+
+	const found = candidates.find((path) => existsSync(path));
+	if (!found) {
+		throw new Error(
+			`No Chrome found. Set CHROME_PATH to a Chrome/Chromium binary. Looked at:\n  ${candidates.join('\n  ')}`
+		);
+	}
+	return found;
+}
+
+export async function launchBrowser(): Promise<Browser> {
+	return puppeteer.launch({
+		executablePath: findChrome(),
+		headless: process.env.E2E_HEADED !== '1',
+		args: [
+			'--no-sandbox',
+			'--disable-dev-shm-usage',
+			// software WebGL — without these the canvas has no context at all
+			'--use-gl=angle',
+			'--use-angle=swiftshader',
+			'--enable-unsafe-swiftshader',
+			'--disable-gpu-sandbox',
+			'--window-size=1280,900',
+			// a headless tab is "hidden": rAF stops, so no frame ever renders and
+			// the springs never settle
+			'--disable-backgrounding-occluded-windows',
+			'--disable-renderer-backgrounding',
+			'--disable-background-timer-throttling'
+		],
+		defaultViewport: { width: 1280, height: 900 }
+	});
+}

--- a/e2e/globals.d.ts
+++ b/e2e/globals.d.ts
@@ -1,0 +1,10 @@
+/** The dev bridge's shape, for the code that runs inside `page.evaluate`. */
+import type { TestBridge } from '../src/lib/dev/test-bridge';
+
+declare global {
+	interface Window {
+		__tableplace?: TestBridge;
+	}
+}
+
+export {};

--- a/e2e/run.ts
+++ b/e2e/run.ts
@@ -1,0 +1,64 @@
+/**
+ * The headless render harness's entry point: `bun run test:e2e`.
+ *
+ * Why this exists at all — #102 shipped to production through 457 green unit
+ * tests, a clean `svelte-check` and a clean build, because jsdom never executes
+ * three.js geometry or a raycast. Everything under `e2e/` runs in a real
+ * (software-rendered) browser so that class of failure has somewhere to be
+ * caught.
+ *
+ * Deliberately not vitest: vitest's environment here is jsdom, and a second
+ * project config that shells out to a browser would be more moving parts than
+ * a 60-line runner.
+ *
+ *   bun run test:e2e                    # everything
+ *   bun run test:e2e freeze             # specs whose name contains "freeze"
+ *   E2E_HEADED=1 E2E_VERBOSE=1 …        # watch it, with server logs
+ */
+
+import { launchBrowser } from './browser';
+import { startServers } from './servers';
+import { SPECS, type Spec } from './specs';
+
+async function main() {
+	const filter = process.argv[2];
+	const specs: Spec[] = SPECS.filter((spec) => !filter || spec.name.includes(filter));
+	if (!specs.length) {
+		console.error(`No spec matches ${JSON.stringify(filter)}`);
+		process.exit(1);
+	}
+
+	console.log('▸ starting vite dev + Go relay…');
+	const servers = await startServers();
+	console.log(`  web ${servers.web}   relay ${servers.relay}`);
+	const browser = await launchBrowser();
+
+	let failed = 0;
+	for (const spec of specs) {
+		const started = Date.now();
+		try {
+			await spec.run({ browser, servers });
+			console.log(`  ✓ ${spec.name} (${Date.now() - started}ms)`);
+		} catch (error) {
+			failed++;
+			console.log(`  ✗ ${spec.name} (${Date.now() - started}ms)`);
+			console.log(
+				String((error as Error)?.stack ?? error)
+					.split('\n')
+					.map((line) => `      ${line}`)
+					.join('\n')
+			);
+		}
+	}
+
+	await browser.close();
+	await servers.stop();
+
+	console.log(failed ? `\n${failed}/${specs.length} failed` : `\n${specs.length} passed`);
+	process.exit(failed ? 1 : 0);
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/e2e/servers.ts
+++ b/e2e/servers.ts
@@ -1,0 +1,118 @@
+/**
+ * The two processes a table needs: `vite dev` and the Go relay.
+ *
+ * The relay is not optional — `/play` renders `<TableScene>` only once the
+ * socket is open, so a harness without one tests an empty canvas. It is also
+ * why the harness must never be pointed at the default server: `connection.ts`
+ * falls back to `api.table.place` when nothing overrides it, and a test that
+ * spawns dice into the public relay is a test that spawns dice into strangers'
+ * tables. Both the `?server=` query param and `localStorage.serverurl` are set
+ * to localhost, belt and braces.
+ *
+ * Either process is reused if something is already listening on its port, so
+ * `bun run dev:all` in another terminal makes the harness start instantly.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { connect } from 'node:net';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+export const RELAY_PORT = Number(process.env.E2E_RELAY_PORT ?? 8080);
+
+/**
+ * The harness gets its OWN dev server on a random high port unless
+ * `E2E_WEB_PORT` says otherwise. Never a fixed default: a run that reuses — or
+ * worse, reclaims — whatever is on port 5173/5199 will take out the dev server
+ * of whoever is working alongside it, which is exactly what happened while this
+ * was being written. Nothing here ever kills a process it did not start.
+ */
+function pickWebPort(): number {
+	const configured = process.env.E2E_WEB_PORT;
+	if (configured) return Number(configured);
+	return 34000 + Math.floor(Math.random() * 4000);
+}
+
+export type Servers = { relay: string; web: string; stop: () => Promise<void> };
+
+/**
+ * `localhost`, not `127.0.0.1`: vite binds IPv6 loopback by default, so a
+ * v4-only probe reports a running dev server as down and the harness spawns a
+ * second one that then fails on the port being taken.
+ */
+function isListening(port: number): Promise<boolean> {
+	return new Promise((resolve) => {
+		const socket = connect({ host: 'localhost', port });
+		const settle = (open: boolean) => {
+			socket.destroy();
+			resolve(open);
+		};
+		socket.setTimeout(1000);
+		socket.once('connect', () => settle(true));
+		socket.once('timeout', () => settle(false));
+		socket.once('error', () => settle(false));
+	});
+}
+
+async function waitFor(port: number, what: string, timeoutMs = 120_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await isListening(port)) return;
+		await sleep(250);
+	}
+	throw new Error(`${what} never came up on :${port} within ${timeoutMs}ms`);
+}
+
+function run(command: string[], label: string, cwd?: string): ChildProcess {
+	const child = spawn(command[0], command.slice(1), {
+		cwd,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: { ...process.env, FORCE_COLOR: '0' }
+	});
+	const log = (chunk: Buffer) => {
+		if (process.env.E2E_VERBOSE === '1') process.stderr.write(`[${label}] ${chunk}`);
+	};
+	child.stdout?.on('data', log);
+	child.stderr?.on('data', log);
+	return child;
+}
+
+export async function startServers(): Promise<Servers> {
+	const spawned: ChildProcess[] = [];
+
+	if (!(await isListening(RELAY_PORT))) {
+		spawned.push(run(['go', 'run', 'main.go', `-addr=:${RELAY_PORT}`], 'relay', 'server'));
+		await waitFor(RELAY_PORT, 'Go relay').catch((error: Error) => {
+			throw new Error(
+				`${error.message}\nStart it yourself with \`bun run dev:server\`, or install Go 1.24+.`
+			);
+		});
+	}
+
+	// A configured port may already hold a dev server the developer started, and
+	// reusing it is the fast path. A random one never will.
+	let webPort = pickWebPort();
+	while (!(await isListening(webPort))) {
+		spawned.push(
+			run(['bun', 'run', 'vite', 'dev', '--port', String(webPort), '--strictPort'], 'web')
+		);
+		try {
+			await waitFor(webPort, 'vite dev', 60_000);
+			break;
+		} catch (error) {
+			if (process.env.E2E_WEB_PORT) throw error;
+			// lost a race for the port; take another rather than reclaim this one
+			spawned.pop()?.kill('SIGKILL');
+			webPort = pickWebPort();
+		}
+	}
+
+	return {
+		relay: `localhost:${RELAY_PORT}`,
+		web: `http://localhost:${webPort}`,
+		stop: async () => {
+			for (const child of spawned) child.kill('SIGTERM');
+			await sleep(300);
+			for (const child of spawned) if (child.exitCode === null) child.kill('SIGKILL');
+		}
+	};
+}

--- a/e2e/specs.ts
+++ b/e2e/specs.ts
@@ -1,0 +1,234 @@
+/**
+ * What the harness checks.
+ *
+ * Every spec has the same spine, because #102 does: put something new on the
+ * table, then confirm that *everything else* still answers the pointer and that
+ * nothing new mounts broken. The shared `interactivity()` context (#86) means
+ * one entity that throws during raycast takes dispatch down for the whole
+ * table — and a Svelte effect that reads state it also writes is worse still,
+ * because the runtime teardown stops every later component mounting at all.
+ * So "the deck still drags" is the assertion that catches a broken die.
+ *
+ * Positions matter. Anything the specs click has to draw clear of the HUD
+ * panes; `dragBy` fails loudly if it doesn't, because a pane over the target
+ * looks identical to a frozen table.
+ */
+
+import type { Browser } from 'puppeteer-core';
+import { ok, planarDistance } from './assert';
+import type { Servers } from './servers';
+import { openTable, type Table } from './table';
+
+export type Spec = {
+	name: string;
+	run: (context: { browser: Browser; servers: Servers }) => Promise<void>;
+};
+
+/**
+ * A clear lane of felt, left-to-right, below the Settings pane and above the
+ * bottom edge. Everything a spec drags lives here and is dragged straight down
+ * into empty table.
+ */
+const LANE = (slot: number): [number, number, number] => [-4 + slot * 4, 0.16, 1];
+const DRAG = { dx: 0, dy: 150 };
+
+let lobbySeq = 0;
+/** a fresh lobby per spec, so nothing leaks between them through the relay */
+function nextLobby(name: string): string {
+	return `e2e-${name.replace(/[^a-z0-9]+/gi, '-')}-${process.pid}-${lobbySeq++}`;
+}
+
+/**
+ * Called with `what just happened`. The runtime-teardown case is named
+ * separately because it is the failure #102 actually was, and because its
+ * signature — `effect_update_depth_exceeded` — is worth reading in the report
+ * rather than being one line of a console dump.
+ */
+function assertClean(table: Table, when: string): void {
+	const problems = table.appProblems();
+	const teardown = problems.find((problem) => /effect_update_depth_exceeded/.test(problem.text));
+	ok(
+		!teardown,
+		`the Svelte runtime tore itself down ${when} — every effect on the page is dead, ` +
+			`so nothing further mounts and nothing answers the pointer:\n  ${teardown?.text.split('\n').slice(0, 4).join('\n  ')}`
+	);
+	ok(
+		problems.length === 0,
+		`console was not clean ${when}:\n${problems.map((p) => `  [${p.kind}] ${p.text}`).join('\n')}`
+	);
+}
+
+/** the load-bearing check: pick the entity up with a real mouse and see it move */
+async function assertDraggable(table: Table, id: string, label: string): Promise<void> {
+	const before = await table.positionOf(id);
+	ok(before, `${label} (${id}) has no position to start from`);
+	const point = await table.locate(id);
+	ok(point, `${label} (${id}) never mounted into the scene — nothing to click`);
+
+	// what dispatch would see: the entity has to be the thing under its own
+	// pixel, not merely *something*. A table that has stopped updating still
+	// answers with felt.
+	const hits = await table.hits(point!);
+	ok(
+		hits.includes(id),
+		`the raycaster does not reach ${label} (${id}) at its own screen position — it hits ${
+			hits.length ? hits.join(', ') : 'nothing at all'
+		}`
+	);
+
+	await table.dragBy(id, DRAG.dx, DRAG.dy);
+	const after = await table.positionOf(id);
+	ok(
+		planarDistance(before, after) > 0.5,
+		`${label} (${id}) did not move: ${JSON.stringify(before)} → ${JSON.stringify(after)}`
+	);
+}
+
+/** "renders white" was never a material fault — it was nothing mounting at all */
+async function assertRenders(table: Table, id: string, label: string): Promise<void> {
+	const shape = await table.describe(id);
+	ok(shape, `${label} (${id}) is in the store but has no object in the scene — it never mounted`);
+	ok(shape!.meshes > 0, `${label} (${id}) mounted an empty group — no meshes to draw`);
+}
+
+async function withTable(
+	context: { browser: Browser; servers: Servers },
+	name: string,
+	body: (table: Table) => Promise<void>
+): Promise<void> {
+	const table = await openTable(context.browser, context.servers, nextLobby(name));
+	try {
+		await body(table);
+	} finally {
+		await table.close();
+	}
+}
+
+export const SPECS: Spec[] = [
+	{
+		// the control. If this fails, the harness is broken, not the app.
+		name: 'deck alone: drags, console clean',
+		run: (context) =>
+			withTable(context, 'deck-alone', async (table) => {
+				const deck = await table.seedDeck();
+				await table.settle();
+				await assertRenders(table, deck, 'deck');
+				await assertDraggable(table, deck, 'deck');
+				assertClean(table, 'with a deck alone on the table');
+			})
+	},
+	{
+		name: 'freeze: a die does not break the deck',
+		run: (context) =>
+			withTable(context, 'die', async (table) => {
+				const deck = await table.seedDeck();
+				const die = await table.spawn('die', { sides: 20, position: LANE(0) });
+				await table.settle(1200);
+				assertClean(table, 'immediately after spawning a d20');
+				await assertRenders(table, die, 'the d20');
+				await assertDraggable(table, deck, 'deck (with a d20 on the table)');
+				await assertDraggable(table, die, 'the d20 itself');
+				assertClean(table, 'after dragging with a d20 on the table');
+			})
+	},
+	{
+		name: 'freeze: every die shape is harmless',
+		run: (context) =>
+			withTable(context, 'die-shapes', async (table) => {
+				const deck = await table.seedDeck();
+				const shapes = [4, 6, 8, 10, 12, 20];
+				const dice: string[] = [];
+				for (const [index, sides] of shapes.entries()) {
+					dice.push(await table.spawn('die', { sides, position: [-9 + index * 3, 0.16, -3] }));
+				}
+				await table.settle(1500);
+				assertClean(table, 'with one die of every shape on the table');
+				for (const [index, id] of dice.entries()) {
+					await assertRenders(table, id, `the d${shapes[index]}`);
+				}
+				await assertDraggable(table, deck, 'deck (with d4…d20 on the table)');
+			})
+	},
+	{
+		name: 'freeze: a bag does not break the deck',
+		run: (context) =>
+			withTable(context, 'bag', async (table) => {
+				const deck = await table.seedDeck();
+				const bag = await table.spawn('bag', { position: LANE(0) });
+				await table.settle(1200);
+				assertClean(table, 'immediately after spawning a bag');
+				await assertRenders(table, bag, 'the bag');
+				await assertDraggable(table, deck, 'deck (with a bag on the table)');
+				await assertDraggable(table, bag, 'the bag itself');
+				assertClean(table, 'after dragging with a bag on the table');
+			})
+	},
+	{
+		/**
+		 * The reported "spawn a pack, it's just white". It was never a material
+		 * fault: the die had already torn the runtime down, so the deck landed in
+		 * the store and no component ever mounted for it. Spawning the pack
+		 * *after* the die is what makes this spec name the symptom.
+		 */
+		name: 'white pack: a deck spawned after a die still mounts and textures',
+		run: (context) =>
+			withTable(context, 'white-pack', async (table) => {
+				const die = await table.spawn('die', { sides: 6, position: LANE(0) });
+				await table.settle(1200);
+				assertClean(table, 'after spawning a d6 on an empty table');
+
+				const deck = await table.seedDeck();
+				await table.settle(1500);
+				await assertRenders(table, deck, 'a deck spawned after a die');
+
+				const shape = await table.describe(deck);
+				ok(
+					shape!.materials.some((material) => (material as { hasMap: boolean }).hasMap),
+					`the deck mounted but every material is untextured — this is what "renders white" looks like: ${JSON.stringify(shape!.materials)}`
+				);
+				await assertDraggable(table, deck, 'a deck spawned after a die');
+				await assertRenders(table, die, 'the d6');
+				assertClean(table, 'with a pack spawned after a die');
+			})
+	},
+	{
+		// acceptance criterion 4: one table carrying all four at once
+		name: 'mixed table: deck + die + bag + multi-state piece',
+		run: (context) =>
+			withTable(context, 'mixed', async (table) => {
+				const deck = await table.seedDeck();
+				const die = await table.spawn('die', { sides: 10, position: LANE(0) });
+				const bag = await table.spawn('bag', { position: LANE(1) });
+				const token = await table.spawn('token', {
+					position: LANE(2),
+					states: [
+						{ face: 'gen:std52/AS', name: 'front' },
+						{ face: 'gen:std52/KH', name: 'back' }
+					]
+				});
+				await table.settle(1500);
+				assertClean(table, 'with a deck, a d10, a bag and a two-state token on the table');
+
+				const entities = [
+					[deck, 'deck'],
+					[die, 'd10'],
+					[bag, 'bag'],
+					[token, 'two-state token']
+				] as const;
+				for (const [id, label] of entities) {
+					await assertRenders(table, id, `${label} (mixed table)`);
+					await assertDraggable(table, id, `${label} (mixed table)`);
+				}
+
+				// the state menu is what a multi-state piece exists for; cycling it
+				// must not disturb dispatch either
+				await table.page.evaluate(
+					(id) => window.__tableplace!.actions.cyclePieceState(id, 1),
+					token
+				);
+				await table.settle();
+				await assertDraggable(table, deck, 'deck (after cycling a piece state)');
+				assertClean(table, 'at the end of the mixed table');
+			})
+	}
+];

--- a/e2e/table.ts
+++ b/e2e/table.ts
@@ -1,0 +1,194 @@
+/**
+ * Driving one table in one tab.
+ *
+ * Entities are spawned through `gameActions` (the same calls the HUD panes
+ * make) but *moved with a real mouse*, because the bug this harness exists for
+ * lives in the raycast between the two: dispatch is what breaks, not state. An
+ * assertion that only round-tripped the store would have passed on the broken
+ * build.
+ */
+
+import type { Browser, ConsoleMessage, Page } from 'puppeteer-core';
+import { setTimeout as sleep } from 'node:timers/promises';
+import type { Servers } from './servers';
+
+export type Problem = { kind: 'console' | 'pageerror' | 'requestfailed'; text: string };
+export type ScreenPoint = { x: number; y: number };
+
+export type Table = {
+	page: Page;
+	/** everything the page complained about since it opened */
+	problems: Problem[];
+	/** the subset that is genuinely the app's fault (see IGNORED) */
+	appProblems: () => Problem[];
+	spawn: (kind: string, options?: Record<string, unknown>) => Promise<string>;
+	/** a standard 52-card deck, procedurally faced — no network */
+	seedDeck: () => Promise<string>;
+	locate: (id: string) => Promise<ScreenPoint | null>;
+	/** what the shared raycaster hits at a screen point — [] means dispatch is dead */
+	hits: (point: ScreenPoint) => Promise<string[]>;
+	/** the DOM element on top at a screen point — the table canvas, or a HUD pane covering it */
+	elementAt: (point: ScreenPoint) => Promise<string>;
+	/** how an entity is rendered right now; null if it never mounted */
+	describe: (id: string) => Promise<{ meshes: number; materials: unknown[] } | null>;
+	dragBy: (id: string, dx: number, dy: number) => Promise<void>;
+	positionOf: (id: string) => Promise<number[] | null>;
+	settle: (ms?: number) => Promise<void>;
+	close: () => Promise<void>;
+};
+
+/**
+ * Noise that is the *environment*, never the app: SwiftShader's warnings, and a
+ * favicon a dev server has no answer for. Deliberately short — anything else
+ * failing is a real failure, which is the entire point of the harness.
+ */
+const IGNORED = [
+	/GroupMarkerNotSet/i,
+	/SwiftShader/i,
+	/Automatic fallback to software WebGL/i,
+	/favicon/i,
+	/\[vite\] connect/i
+];
+
+function ignorable(text: string): boolean {
+	return IGNORED.some((pattern) => pattern.test(text));
+}
+
+const SUITS = ['S', 'H', 'D', 'C'];
+const RANKS = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
+
+export async function openTable(browser: Browser, servers: Servers, lobby: string): Promise<Table> {
+	const page = await browser.newPage();
+	const problems: Problem[] = [];
+
+	page.on('console', (message: ConsoleMessage) => {
+		if (message.type() === 'error') problems.push({ kind: 'console', text: message.text() });
+	});
+	page.on('pageerror', (error) => {
+		const failure = error as Error;
+		problems.push({ kind: 'pageerror', text: `${failure.message}\n${failure.stack ?? ''}` });
+	});
+	page.on('requestfailed', (request) => {
+		problems.push({
+			kind: 'requestfailed',
+			text: `${request.url()} — ${request.failure()?.errorText ?? 'failed'}`
+		});
+	});
+
+	// before ANY script runs: the module-level fallback in connection.ts reads
+	// localStorage at import time, and it defaults to the PUBLIC relay
+	await page.evaluateOnNewDocument((relay: string) => {
+		localStorage.setItem('serverurl', relay);
+	}, servers.relay);
+
+	const url =
+		`${servers.web}/play?lobby=${encodeURIComponent(lobby)}` +
+		`&server=${encodeURIComponent(servers.relay)}`;
+	await page.goto(url, { waitUntil: 'networkidle2', timeout: 60_000 });
+
+	// the bridge mounts inside the Canvas, which mounts only once the socket is
+	// open — so waiting on it is also the connection assertion
+	await page.waitForFunction('window.__tableplace?.ready === true', { timeout: 60_000 });
+
+	const settle = (ms = 700) => sleep(ms);
+	await settle(600);
+
+	const spawn = (kind: string, options: Record<string, unknown> = {}) =>
+		page.evaluate(
+			(k, o) => window.__tableplace!.actions.addPiece(k as never, o as never),
+			kind,
+			options
+		) as Promise<string>;
+
+	/**
+	 * A standard 52-card deck. The card list is built here rather than imported
+	 * so the harness only ever leans on the app's public action surface — and
+	 * `gen:` faces are canvas-drawn, so seeding one fetches nothing.
+	 */
+	const seedDeck = () =>
+		page.evaluate(
+			(suits, ranks) => {
+				const cards = suits.flatMap((suit) =>
+					ranks.map((rank) => ({
+						id: `card:std:${rank}${suit}`,
+						faceImageUrl: `gen:std52/${rank}${suit}`,
+						backImageUrl: 'gen:std52/back'
+					}))
+				);
+				return String(window.__tableplace!.actions.addDeck({ cards } as never) ?? '');
+			},
+			SUITS,
+			RANKS
+		);
+
+	const locate = (id: string) =>
+		page.evaluate((entityId) => window.__tableplace!.locate(entityId), id);
+
+	const hits = (point: ScreenPoint) =>
+		page.evaluate((screen) => window.__tableplace!.hits(screen), point);
+
+	const elementAt = (point: ScreenPoint) =>
+		page.evaluate((screen) => {
+			const element = document.elementFromPoint(screen.x, screen.y);
+			return element ? `${element.tagName.toLowerCase()}.${element.className}`.trim() : 'nothing';
+		}, point);
+
+	const describe = (id: string) =>
+		page.evaluate((entityId) => window.__tableplace!.describe(entityId), id);
+
+	const positionOf = (id: string) =>
+		page.evaluate((entityId) => {
+			const state = window.__tableplace!.state();
+			const entity =
+				state?.pieces?.[entityId] ?? state?.decks?.[entityId] ?? state?.cards?.[entityId];
+			return (entity as { position?: number[] } | undefined)?.position ?? null;
+		}, id);
+
+	/**
+	 * A real press–move–release. The intermediate moves matter twice over: a
+	 * clickable piece only lifts once the pointer has travelled past
+	 * DRAG_THRESHOLD_PX, and the position the drop commits comes from the
+	 * interactivity context's raycast on the last move.
+	 */
+	const dragBy = async (id: string, dx: number, dy: number) => {
+		const from = await locate(id);
+		if (!from) throw new Error(`cannot locate ${id} on screen`);
+		// A HUD pane over the entity swallows the press, and the failure looks
+		// exactly like a dead table — which cost an hour of chasing a bag that was
+		// never broken. Fail on the real reason instead: put the entity somewhere
+		// the panes don't cover.
+		const cover = await elementAt(from);
+		if (!cover.startsWith('canvas')) {
+			throw new Error(
+				`${id} draws at (${Math.round(from.x)}, ${Math.round(from.y)}), where the HUD covers the table (${cover}) — move it clear of the panes`
+			);
+		}
+		await page.mouse.move(from.x, from.y);
+		await sleep(80);
+		await page.mouse.down();
+		await sleep(80);
+		for (let step = 1; step <= 12; step++) {
+			await page.mouse.move(from.x + (dx * step) / 12, from.y + (dy * step) / 12);
+			await sleep(20);
+		}
+		await sleep(150);
+		await page.mouse.up();
+		await sleep(400);
+	};
+
+	return {
+		page,
+		problems,
+		appProblems: () => problems.filter((problem) => !ignorable(problem.text)),
+		spawn,
+		seedDeck,
+		locate,
+		hits,
+		elementAt,
+		describe,
+		dragBy,
+		positionOf,
+		settle,
+		close: () => page.close()
+	};
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 		"lint": "prettier --check . && eslint .",
 		"test": "bun vitest run",
 		"test:watch": "bun vitest",
-		"test:coverage": "bun vitest run --coverage"
+		"test:coverage": "bun vitest run --coverage",
+		"test:e2e": "bun e2e/run.ts"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^1.2.5",
@@ -43,6 +44,7 @@
 		"prettier": "^3.4.2",
 		"prettier-plugin-svelte": "^3.3.3",
 		"prettier-plugin-tailwindcss": "^0.6.11",
+		"puppeteer-core": "^25.3.0",
 		"svelte": "^5.56.7",
 		"svelte-check": "^4.7.3",
 		"tailwindcss": "^4.0.0",

--- a/src/lib/Card.svelte
+++ b/src/lib/Card.svelte
@@ -214,7 +214,11 @@
 	}
 </script>
 
+<!-- the store id, mirrored onto the object3D: what makes an entity findable in
+     the scene graph — by devtools, and by the headless harness, which has to
+     know where a thing actually draws in order to click it -->
 <T.Group
+	name={id}
 	{position}
 	rotation.z={rotation.current * DEG2RAD}
 	rotation.y={rotationTap.current * -DEG2RAD}

--- a/src/lib/Deck.svelte
+++ b/src/lib/Deck.svelte
@@ -152,7 +152,11 @@
 	}
 </script>
 
+<!-- the store id, mirrored onto the object3D: what makes an entity findable in
+     the scene graph — by devtools, and by the headless harness, which has to
+     know where a thing actually draws in order to click it -->
 <T.Group
+	name={id}
 	position={[planar.current.x, lift.current, planar.current.z]}
 	rotation={[rotation[0], rotation[1] + wiggle.current, rotation[2]]}
 	onpointerdown={handlePointerDown}

--- a/src/lib/Die.svelte
+++ b/src/lib/Die.svelte
@@ -92,9 +92,18 @@
 		const seq = rollSeq;
 		const result = value;
 
+		// `settled` is a local on purpose. Writing `to = from.clone()` would make
+		// this effect READ a `$state` it also writes, and since every call hands
+		// it a fresh Quaternion the source never settles equal — the effect
+		// reschedules itself forever and Svelte tears the whole runtime down with
+		// `effect_update_depth_exceeded`. That is not a die-shaped failure: it
+		// kills every effect on the page, so nothing else mounts and nothing else
+		// answers the pointer (tableplace-102). Read nothing here that is written
+		// here.
 		const settle = () => {
-			from = dieSettleQuaternion(shape, result);
-			to = from.clone();
+			const settled = dieSettleQuaternion(shape, result);
+			from = settled;
+			to = settled.clone();
 			progress.set(1, { instant: true });
 		};
 

--- a/src/lib/Piece.svelte
+++ b/src/lib/Piece.svelte
@@ -254,7 +254,11 @@
 </script>
 
 {#if piece}
+	<!-- the store id, mirrored onto the object3D: what makes an entity findable in
+	     the scene graph — by devtools, and by the headless harness, which has to
+	     know where a thing actually draws in order to click it -->
 	<T.Group
+		name={id}
 		{position}
 		onpointerdown={handlePointerDown}
 		onclick={handleClick}

--- a/src/lib/TableScene.svelte
+++ b/src/lib/TableScene.svelte
@@ -13,6 +13,7 @@
 	import Hdr from './HDR.svelte';
 	import HudPreviewScene from './HUDPreview/HUDPreviewScene.svelte';
 	import RemoteCameraAvatar from './RemoteCameraAvatar.svelte';
+	import TestBridge from './dev/TestBridge.svelte';
 	import { dragStore, setNoSnap, setTrayHover } from '$lib/store/dragStore.svelte';
 	import { setTableFeatures, TABLE_FEATURES_DEFAULT } from '$lib/store/tableFeatures';
 	import { gameStore } from './store/game/gameStore.svelte';
@@ -187,6 +188,11 @@
 <Hdr />
 <DropIndicator />
 <Table bind:mesh />
+
+<!-- the headless harness's window handle; a literal `false` in a static build -->
+{#if import.meta.env.DEV}
+	<TestBridge />
+{/if}
 
 {#each Object.entries($gameStore?.decks ?? {}) as [id] (id)}
 	<Deck {id} />

--- a/src/lib/dev/TestBridge.svelte
+++ b/src/lib/dev/TestBridge.svelte
@@ -1,0 +1,25 @@
+<!--
+	Mounts the headless harness's handle on `window` (see test-bridge.ts). Only
+	rendered under `import.meta.env.DEV`, so it is compiled out of the static
+	build entirely — the check is a literal `false` there.
+
+	It reads the scene through `useThrelte()`, which is why this has to be a
+	component inside the Canvas rather than a plain module: the camera and the
+	renderer's canvas element are what turn a world position into a pixel the
+	harness can click.
+-->
+<script lang="ts">
+	import { useThrelte } from '@threlte/core';
+	import { installTestBridge, removeTestBridge } from './test-bridge';
+
+	const { camera, renderer, scene } = useThrelte();
+
+	$effect(() => {
+		installTestBridge({
+			camera: () => $camera,
+			canvas: () => renderer?.domElement,
+			scene: () => scene
+		});
+		return removeTestBridge;
+	});
+</script>

--- a/src/lib/dev/test-bridge.ts
+++ b/src/lib/dev/test-bridge.ts
@@ -1,0 +1,176 @@
+/**
+ * The dev-only handle the headless render harness (`e2e/`) drives the table
+ * through.
+ *
+ * It exists because the class of failure #102 was reported for — a die or a bag
+ * that poisons the shared raycast and freezes every pointer interaction on the
+ * table — is invisible to jsdom: nothing there runs three.js geometry or a
+ * raycast. Catching it needs a real GPU-less browser, real pointer events at
+ * real pixels, and therefore a way to ask the live scene *where on screen* a
+ * given entity is. That is all this is.
+ *
+ * Everything here is a read of live state or a call into `gameActions`, i.e.
+ * exactly what the HUD panes already do — the harness spawns pieces the same
+ * way a player does and then clicks them with a real mouse. Nothing in the app
+ * reads this object.
+ *
+ * `import.meta.env.DEV` is a compile-time constant, so `installTestBridge` is
+ * only ever called from a dev build (see `TestBridge.svelte`).
+ */
+
+import * as THREE from 'three';
+import { get } from 'svelte/store';
+import { dragStore } from '$lib/store/dragStore.svelte';
+import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { gameActions } from '$lib/store/game/actions';
+import type { GameDTO } from '$lib/store/game/types';
+
+export type ScreenPoint = { x: number; y: number };
+
+export type TestBridge = {
+	/** set last, so the harness can poll one flag and know the scene is live */
+	ready: boolean;
+	actions: typeof gameActions;
+	state: () => Partial<GameDTO> | undefined;
+	/** world → CSS pixels within the canvas, or null when it projects off-screen */
+	project: (world: [number, number, number]) => ScreenPoint | null;
+	/** where a card / deck / piece currently draws, by store id */
+	locate: (id: string) => ScreenPoint | null;
+	/** the raycast the shared interactivity context runs, minus the dispatch */
+	hits: (screen: ScreenPoint) => string[];
+	/** what is being dragged / hovered right now — distinguishes "never lifted" from "lifted and snapped back" */
+	drag: () => { isDragging: string | null; isHovered: string | null; isBagHovered: string | null };
+	/** what an entity is actually made of — null if it never mounted at all */
+	describe: (id: string) => EntityShape | null;
+};
+
+/**
+ * Enough of an entity's rendered form to tell "did not mount", "mounted
+ * untextured" and "mounted correctly" apart. `renders white` in #102 was the
+ * first of those, so `meshes: 0` and `null` are the interesting answers.
+ */
+export type EntityShape = {
+	meshes: number;
+	/** one entry per material, in traversal order */
+	materials: { type: string; color: string; hasMap: boolean }[];
+};
+
+declare global {
+	interface Window {
+		__tableplace?: TestBridge;
+	}
+}
+
+type SceneHandles = {
+	camera: () => THREE.Camera | undefined;
+	canvas: () => HTMLCanvasElement | undefined;
+	scene: () => THREE.Scene | undefined;
+};
+
+/**
+ * Where an entity actually *draws*, not where the store says it is.
+ *
+ * The two differ enough to matter: a die sits a shape-dependent distance above
+ * the piece group's origin, a deck's height grows with its card count, and the
+ * table camera is only near-vertical — so projecting the store position and
+ * clicking there misses the mesh at the edges of the table and lands on felt.
+ * The centre of the rendered bounding box is what a player aims at.
+ */
+function renderedCentre(scene: THREE.Scene, id: string): THREE.Vector3 | null {
+	const object = scene.getObjectByName(id);
+	if (!object) return null;
+	const box = new THREE.Box3().setFromObject(object);
+	if (box.isEmpty()) return object.getWorldPosition(new THREE.Vector3());
+	return box.getCenter(new THREE.Vector3());
+}
+
+export function installTestBridge(handles: SceneHandles): void {
+	const raycaster = new THREE.Raycaster();
+
+	const project = (world: [number, number, number]): ScreenPoint | null => {
+		const camera = handles.camera();
+		const canvas = handles.canvas();
+		if (!camera || !canvas) return null;
+		const ndc = new THREE.Vector3(...world).project(camera);
+		if (!Number.isFinite(ndc.x) || !Number.isFinite(ndc.y)) return null;
+		const rect = canvas.getBoundingClientRect();
+		return {
+			x: rect.left + ((ndc.x + 1) / 2) * rect.width,
+			y: rect.top + ((1 - ndc.y) / 2) * rect.height
+		};
+	};
+
+	/**
+	 * The same intersection the interactivity context does, reported as the ids
+	 * of whatever was hit — nearest first, deduplicated. Leaf meshes are
+	 * anonymous, so each hit is attributed to its nearest named ancestor, which
+	 * is the entity group.
+	 *
+	 * A raycast that throws here throws for the real dispatch loop too, which is
+	 * the point: the harness can name the broken entity rather than only observe
+	 * that nothing responds.
+	 */
+	const hits = (screen: ScreenPoint): string[] => {
+		const camera = handles.camera();
+		const canvas = handles.canvas();
+		const scene = handles.scene();
+		if (!camera || !canvas || !scene) return [];
+		const rect = canvas.getBoundingClientRect();
+		raycaster.setFromCamera(
+			new THREE.Vector2(
+				((screen.x - rect.left) / rect.width) * 2 - 1,
+				-(((screen.y - rect.top) / rect.height) * 2 - 1)
+			),
+			camera
+		);
+		const named = (object: THREE.Object3D): string => {
+			for (let node: THREE.Object3D | null = object; node; node = node.parent) {
+				if (node.name) return node.name;
+			}
+			return object.type;
+		};
+		return [
+			...new Set(raycaster.intersectObjects(scene.children, true).map((h) => named(h.object)))
+		];
+	};
+
+	window.__tableplace = {
+		ready: true,
+		actions: gameActions,
+		state: () => get(gameStore),
+		project,
+		locate: (id) => {
+			const scene = handles.scene();
+			const centre = scene ? renderedCentre(scene, id) : null;
+			return centre ? project([centre.x, centre.y, centre.z]) : null;
+		},
+		hits,
+		drag: () => {
+			const { isDragging, isHovered, isBagHovered } = get(dragStore);
+			return { isDragging, isHovered, isBagHovered };
+		},
+		describe: (id) => {
+			const object = handles.scene()?.getObjectByName(id);
+			if (!object) return null;
+			const shape: EntityShape = { meshes: 0, materials: [] };
+			object.traverse((node) => {
+				const mesh = node as THREE.Mesh;
+				if (!mesh.isMesh) return;
+				shape.meshes++;
+				for (const material of [mesh.material].flat()) {
+					const standard = material as THREE.MeshStandardMaterial;
+					shape.materials.push({
+						type: material.type,
+						color: standard.color ? `#${standard.color.getHexString()}` : '',
+						hasMap: !!standard.map
+					});
+				}
+			});
+			return shape;
+		}
+	};
+}
+
+export function removeTestBridge(): void {
+	delete window.__tableplace;
+}

--- a/src/lib/store/game/actions/player.ts
+++ b/src/lib/store/game/actions/player.ts
@@ -35,14 +35,22 @@ function addPlayer(_id?: string) {
 function getPlayer(playerId: string) {
 	return get(gameStore).players?.[playerId];
 }
+/**
+ * Both of these return undefined on a first-ever visit, which is an ordinary
+ * state and not a fault: every caller between page load and `addPlayer()` —
+ * TableCamera, HUDPieces, initWebsocket itself — asks before there is an id and
+ * handles the miss. They used to log an error each time, which put ~8 red lines
+ * in a healthy console and made "the console is clean" untestable (#102). The
+ * callers that genuinely cannot proceed without an id still say so themselves.
+ */
 function getMe() {
 	const cacheId = handleLocalStorage.get();
-	if (!cacheId) return console.error('No player id found in localstorage');
+	if (!cacheId) return undefined;
 	return get(gameStore)?.players?.[cacheId];
 }
 function getMyId() {
 	const cacheId = handleLocalStorage.get();
-	if (!cacheId) return console.error('No player id found in localstorage');
+	if (!cacheId) return undefined;
 	return cacheId;
 }
 

--- a/src/lib/websocket/connection.ts
+++ b/src/lib/websocket/connection.ts
@@ -180,12 +180,17 @@ export async function joinLobby(lobbyId: string): Promise<boolean> {
  * @returns True if sent successfully
  */
 export function sendMessage(message: WebSocketMessage): boolean {
+	// A warning, not an error: patches made before the socket opens are dropped
+	// BY DESIGN (there is no send queue) and initWebsocket re-publishes the row
+	// that matters once it is up. Logging it as an error meant a healthy first
+	// load always had a red console, which is exactly the noise that let #102's
+	// real error hide in plain sight.
 	if (!socket) {
-		console.error('Cannot send message: no websocket server instance');
+		console.warn('Dropped a message: the websocket is not open yet');
 		return false;
 	}
 	if (!isConnected) {
-		console.error('Cannot send message: not connected to websocket server');
+		console.warn('Dropped a message: not connected to the websocket server');
 		return false;
 	}
 


### PR DESCRIPTION
Task: tableplace-102

Closes #102

## The bug

`Die.svelte`'s roll-replay effect wrote `to = from.clone()` — making the effect a **dependent of a `$state` it also writes**. Each run assigned a fresh `THREE.Quaternion`, so the source was never `equals` its previous value, so the effect rescheduled itself forever. Svelte threw `effect_update_depth_exceeded` and tore the runtime down.

That is why one die froze *everything*: no effect on the page ran again, so nothing new mounted and nothing answered the pointer. Not a raycast fault at all — the shared `interactivity()` context (#86) is innocent, and no `interactivity()` call was added.

Only `settle()` read it; `tumble()` writes `from`/`to` and reads neither. `settle()` is the branch a **freshly spawned** die takes (`rollSeq === 0`) — exactly the reported trigger.

```diff
-const settle = () => {
-    from = dieSettleQuaternion(shape, result);
-    to = from.clone();
+const settle = () => {
+    const settled = dieSettleQuaternion(shape, result);
+    from = settled;
+    to = settled.clone();
```

## The other two symptoms

- **"A spawned pack renders white"** — the same teardown, not a material problem. Captured directly: with a die on the table, spawning a pack puts the deck in the store (`decks: ["deck:…:main"]`) and nothing ever mounts for it. Fixed by the same one-line change; covered by a spec named after the symptom.
- **"Bags freeze it too"** — bags were never broken. Verified independently in a clean session with a bag and no die: spawns clean, renders, drags, and decks/cards keep dragging alongside it. It is the one spec that still passes with this fix reverted.

None of the issue's leads was the cause: not the `{#key material}` detach, not the shared `modelCache`, not a NaN bounding sphere in the d10 (every shape raycasts cleanly), not `Piece.svelte`/`HUDPieces.svelte`.

## The larger half: `e2e/`, a headless render harness

`bun run test:e2e` — `puppeteer-core` driving a real SwiftShader Chrome against its own `vite dev` and its own Go relay, spawning entities and moving them with a real mouse. jsdom never executes three.js geometry, a raycast or a WebGL draw, which is how this shipped past 700 green unit tests, `svelte-check` with 0 errors and a clean build.

Six specs, all with the same spine — put a new primitive on the table, then assert everything else still **renders**, still gets **raycast**, and still **moves**:

| spec | covers |
|---|---|
| deck alone | the control — if this fails the harness is broken, not the app |
| a die does not break the deck | the reported freeze |
| every die shape is harmless | d4…d20, incl. the hand-built d10 |
| a bag does not break the deck | bag, independently |
| white pack: a deck spawned after a die | the "renders white" symptom, by name |
| mixed table: deck + die + bag + multi-state piece | acceptance criterion 4 |

Any console `error`, `pageerror` or failed request fails a spec, with `effect_update_depth_exceeded` called out by name ("the Svelte runtime tore itself down …"). Verified both ways: **6/6 green with the fix, 4/6 red without it.**

Runs in CI as a separate `render` job (needs Go for the relay, uses the runner's Chrome; `puppeteer-core` downloads nothing). It takes a **random high port** for its web server and never kills a process it did not start, so it cannot disturb a dev server beside it. It never talks to `api.table.place` — `localStorage.serverurl` is set before any script runs, and `?server=` is passed too.

## Supporting changes

- `window.__tableplace` (`src/lib/dev/`) is how the harness spawns and locates entities. Guarded by `import.meta.env.DEV` and confirmed absent from `build/`.
- Entity groups carry their store id as the object3D `name`, so the scene graph is addressable by id — by the harness and by devtools.
- `getMe`/`getMyId` and `sendMessage` no longer log **errors** for the ordinary pre-player / pre-socket startup states. A healthy first load had ~8 red console lines; that is how a real error hides in plain sight, and it made "the console is clean" untestable.

## Verification

`bun run test` 704 passed · `bun run check` 0 errors · `bun run build` clean · `bun run schemas:check` OK · eslint/prettier at baseline on every touched file · `bun run test:e2e` 6/6.

No schema changes, so no spec-version bump. #98 and #101 are fixed forward, not reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMGYus2LieB68sR5ujd9fd
