### PR TITLE
tableplace-112: /setup and /play fire table hotkeys while you're typing in a pane field

### DIFF
--- a/docs/packs.md
+++ b/docs/packs.md
@@ -256,6 +256,24 @@ All three load. `parseScenarioFile` accepts v0 (`name` + `state` is enough) and 
 
 Sizing analysis for public/remote scenario seeding lives in issue #39: pack refs are what make a fetchable scenario small enough to be practical.
 
+### Composing a table without a browser
+
+`composeScenario(scenario, packs)` (`src/lib/compose/scenario.ts`) turns a scenario plus its already-resolved packs into the `GameDTO` fragment — decks, cards, pieces, overlays, seat placeholders, snap points — that a client would have produced. It imports no Svelte, no store and nothing from the DOM, so it runs anywhere JavaScript does.
+
+That matters because it is the **only** implementation of the layout rules. Entity ids (`kind:owner:slug`), the `seat0`…`seat3` placeholder owners, `packOrigin` stamps, mirrored positions for the far seat, and the "authored order unless `shuffleOnLoad`" convention are decided once, here. `applyScenario` is a thin wrapper over it: resolve packs → compose → push to the store, still one message per deck so a full card list stays under the server's 1 MB websocket read limit. Anything outside the browser calls the same function rather than reimplementing the grammar and drifting from it.
+
+Pack **resolution** stays outside on purpose — fetching a `.tbpp.json` is I/O, and keeping it out is what makes the composer testable and portable. The browser resolves with `scenario/resolve-packs.ts`; a script resolves off disk.
+
+`bun run seed-lobby` (`scripts/seed-lobby.ts`) is that path, end to end, from a terminal:
+
+```
+bun run seed-lobby --lobby brave-otter --server localhost:8080 --scenario duel.tbps.json
+```
+
+It resolves packs (builtin registry, URL fetch, a path relative to the scenario, or `--pack file.tbpp.json` standing in for the browser's local library), composes, opens a websocket as a throwaway player, sends the same patches — clear first, then one per deck, paced under the server's 7 msg/s limit — and disconnects. Players then only claim a seat: `/play?lobby=brave-otter&seat=0`.
+
+The seeder is an ordinary client, so its disconnect is a normal empty transition and the lobby's 15-minute idle TTL applies as usual; a seeded lobby nobody opens is collected, and a server restart drops it (in-memory state). Both are issue #39's to answer, not the seeder's.
+
 ## Versioning
 
 The discriminator value is the format version. Breaking changes bump it (`"tbpp": 2`); parsers reject versions they don't know rather than misread them. This matches the `{tableplace: 1}` pattern from the raw-link-loading research.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"format": "prettier --write .",
+		"seed-lobby": "bun scripts/seed-lobby.ts",
 		"schemas": "bun scripts/build-schemas.ts",
 		"schemas:check": "bun scripts/check-schemas.ts",
 		"lint": "prettier --check . && eslint .",

--- a/scripts/seed-lobby.ts
+++ b/scripts/seed-lobby.ts
@@ -1,0 +1,333 @@
+/// <reference types="bun-types" />
+/**
+ * Seed a live lobby with a scenario, from a terminal.
+ *
+ *   bun run seed-lobby --lobby brave-otter --server localhost:8080 --scenario duel.tbps.json
+ *
+ * Resolve the scenario's packs → compose the table (`src/lib/compose/`) → open
+ * a websocket as a throwaway player → send the same per-deck patches a browser
+ * would → disconnect. Players then do nothing but open
+ * `/play?lobby=<lobby>&seat=<n>` and claim a seat.
+ *
+ * This is the whole point of the composer: no browser, no Svelte store, no
+ * second implementation of the entity-id grammar. A provisioning API only has
+ * to call this path, not invent it.
+ *
+ * Two consequences worth knowing (see issue #39, deliberately not solved here):
+ * the seeder is a real client, so its disconnect is a normal empty transition
+ * and an unopened lobby is garbage-collected after the server's 15-minute idle
+ * TTL; and lobby state is in-memory, so a server restart drops it.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { composeScenario } from '../src/lib/compose/scenario';
+import { BUILTIN_PACKS, PACK_SOURCE_BUILTIN } from '../src/lib/packs/builtin';
+import { parsePackFile } from '../src/lib/packs/file';
+import { PACK_SOURCE_LOCAL } from '../src/lib/packs/library';
+import { parseScenarioFile } from '../src/lib/scenario/file';
+import { randomLobbyName } from '../src/lib/utils/lobby-name';
+import type { PackRef, Scenario } from '../src/lib/scenario/file';
+import type { GamePackDef } from '../src/lib/packs/types';
+import type { GameDTO } from '../src/lib/store/game/types';
+
+const USAGE = `Seed a lobby with a scenario file.
+
+  bun run seed-lobby --scenario <file.tbps.json> [options]
+
+Options
+  --scenario <file>  tbps scenario to lay out                    (required)
+  --lobby <slug>     lobby to seed; a random name if omitted
+  --server <host>    lobby server host[:port]                    (localhost:8080)
+  --pack <file>      a .tbpp.json to resolve a pack ref against; repeatable.
+                     Needed for refs the scenario marks 'local' — those live in
+                     a browser's library, which a terminal cannot read.
+  --player <id>      websocket player id to seed as     (seed-<random>)
+  --dry-run          compose and print a summary, connect to nothing
+  --help             this
+
+The seeded table is authored for the placeholder seats seat0…seat3; a player
+claims one by opening /play?lobby=<slug>&seat=<n>.`;
+
+type Options = {
+	scenario?: string;
+	lobby: string;
+	server: string;
+	packFiles: string[];
+	player: string;
+	dryRun: boolean;
+	help: boolean;
+};
+
+function parseArgs(argv: string[]): Options {
+	const opts: Options = {
+		lobby: '',
+		server: 'localhost:8080',
+		packFiles: [],
+		player: `seed-${Math.random().toString(36).slice(2, 8)}`,
+		dryRun: false,
+		help: false
+	};
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		const value = () => {
+			const next = argv[++i];
+			if (next === undefined) throw new Error(`${arg} needs a value`);
+			return next;
+		};
+		switch (arg) {
+			case '--scenario':
+				opts.scenario = value();
+				break;
+			case '--lobby':
+				opts.lobby = value();
+				break;
+			case '--server':
+				opts.server = value();
+				break;
+			case '--pack':
+				opts.packFiles.push(value());
+				break;
+			case '--player':
+				opts.player = value();
+				break;
+			case '--dry-run':
+				opts.dryRun = true;
+				break;
+			case '--help':
+			case '-h':
+				opts.help = true;
+				break;
+			default:
+				throw new Error(`unknown argument '${arg}'`);
+		}
+	}
+	return opts;
+}
+
+/** 'localhost:8080', 'https://host/', 'wss://host' → `ws(s)://host/ws` */
+function websocketUrl(server: string, lobby: string, player: string): string {
+	const host = server
+		.trim()
+		.replace(/^(https?|wss?):\/\//, '')
+		.replace(/\/+$/, '');
+	const scheme = host.startsWith('localhost') || host.startsWith('127.0.0.1') ? 'ws' : 'wss';
+	return `${scheme}://${host}/ws?lobby=${encodeURIComponent(lobby)}&player=${encodeURIComponent(player)}`;
+}
+
+/**
+ * Resolve a scenario's pack refs without a browser.
+ *
+ * Same three sources `scenario/resolve-packs.ts` has, re-pointed at a
+ * filesystem: the shipped builtin registry, a URL fetch, and `--pack` files
+ * standing in for the browser's local library. A `source` that is neither
+ * 'builtin'/'local' nor a URL is read as a path relative to the scenario, so a
+ * scenario and its packs can sit side by side in a directory.
+ */
+async function resolvePacksFromDisk(
+	refs: PackRef[],
+	fromDisk: Map<string, GamePackDef>,
+	baseDir: string
+): Promise<{ packs: Map<string, GamePackDef>; failed: { id: string; reason: string }[] }> {
+	const packs = new Map<string, GamePackDef>();
+	const failed: { id: string; reason: string }[] = [];
+
+	for (const ref of refs) {
+		// a --pack file wins over everything: it is the operator saying, for this
+		// run, exactly which bytes this id means
+		const supplied = fromDisk.get(ref.id);
+		if (supplied) {
+			packs.set(ref.id, supplied);
+			continue;
+		}
+		if ((!ref.source || ref.source === PACK_SOURCE_BUILTIN) && BUILTIN_PACKS[ref.id]) {
+			packs.set(ref.id, BUILTIN_PACKS[ref.id]);
+			continue;
+		}
+		if (!ref.source || ref.source === PACK_SOURCE_LOCAL) {
+			failed.push({
+				id: ref.id,
+				reason: `no builtin pack '${ref.id}' — pass it with --pack <file.tbpp.json>`
+			});
+			continue;
+		}
+		try {
+			const text = /^https?:\/\//.test(ref.source)
+				? await fetch(ref.source).then((r) => {
+						if (!r.ok) throw new Error(`HTTP ${r.status}`);
+						return r.text();
+					})
+				: await readFile(resolve(baseDir, ref.source), 'utf8');
+			packs.set(ref.id, parsePackFile(text));
+		} catch (error) {
+			failed.push({ id: ref.id, reason: error instanceof Error ? error.message : String(error) });
+		}
+	}
+	return { packs, failed };
+}
+
+type Patch = Record<string, Record<string, unknown>>;
+
+const COLLECTIONS = ['cards', 'pieces', 'overlays', 'snapPoints', 'players'] as const;
+
+/**
+ * The patches that turn whatever is in the lobby now into the composed table.
+ *
+ * Mirrors `applyScenario`: nulls for the current contents ride the first patch
+ * (real players survive — only the seat placeholders are ours to clear), then
+ * one patch per deck. Decks carry full card lists and a single all-in-one
+ * update can blow past the server's 1 MB websocket read limit, after which the
+ * server silently drops the whole seed.
+ */
+function seedPatches(composed: Partial<GameDTO>, current: Partial<GameDTO> | undefined): Patch[] {
+	const clear: Patch = {
+		cards: {},
+		decks: {},
+		pieces: {},
+		overlays: {},
+		snapPoints: {},
+		players: {}
+	};
+	for (const collection of ['cards', 'decks', 'pieces', 'overlays', 'snapPoints'] as const) {
+		for (const key of Object.keys(current?.[collection] ?? {})) clear[collection][key] = null;
+	}
+	for (const key of Object.keys(current?.players ?? {})) {
+		if (/^seat[0-3]$/.test(key)) clear.players[key] = null;
+	}
+	for (const collection of COLLECTIONS) {
+		Object.assign(clear[collection], composed[collection] ?? {});
+	}
+
+	const patches: Patch[] = [clear];
+	for (const [id, deck] of Object.entries(composed.decks ?? {})) {
+		patches.push({ decks: { [id]: deck as Record<string, unknown> } });
+	}
+	return patches;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Send every patch over one socket and hang up.
+ *
+ * Paced at 160 ms: the server rate-limits a client to 7 messages/second with a
+ * burst of 15 and *disconnects* whoever exceeds it (server/lobby/lobby.go), so
+ * a big scenario would otherwise be cut off halfway through its own seed.
+ */
+async function seedOverWebsocket(url: string, playerId: string, composed: Partial<GameDTO>) {
+	const socket = new WebSocket(url);
+	let synced: Partial<GameDTO> | undefined;
+
+	await new Promise<void>((ok, fail) => {
+		socket.addEventListener('open', () => ok(), { once: true });
+		socket.addEventListener('error', () => fail(new Error(`could not connect to ${url}`)), {
+			once: true
+		});
+	});
+
+	// the server syncs the lobby's current state to every joiner; that snapshot
+	// is what tells us which entities the seed has to clear out
+	socket.addEventListener('message', (event) => {
+		try {
+			const message = JSON.parse(String(event.data));
+			if (message?.type === 'sync') synced = message.value as Partial<GameDTO>;
+		} catch {
+			// a message we don't understand is not our problem — we only send
+		}
+	});
+
+	const send = (value: unknown) =>
+		socket.send(JSON.stringify({ type: 'update', playerId, timestamp: Date.now(), value }));
+
+	socket.send(JSON.stringify({ type: 'connect', playerId, timestamp: Date.now() }));
+	// give the sync a moment to arrive before deciding what to clear
+	await sleep(300);
+
+	const patches = seedPatches(composed, synced);
+	for (const patch of patches) {
+		send(patch);
+		await sleep(160);
+	}
+
+	socket.close(1000, 'seeded');
+	return patches.length;
+}
+
+function summarize(composed: Partial<GameDTO>) {
+	const decks = Object.keys(composed.decks ?? {});
+	const cards = decks.reduce((n, id) => n + (composed.decks?.[id]?.cards?.length ?? 0), 0);
+	return {
+		decks: decks.length,
+		cards: cards + Object.keys(composed.cards ?? {}).length,
+		pieces: Object.keys(composed.pieces ?? {}).length,
+		overlays: Object.keys(composed.overlays ?? {}).length,
+		snapPoints: Object.keys(composed.snapPoints ?? {}).length,
+		seats: Object.keys(composed.players ?? {}).filter((id) => /^seat[0-3]$/.test(id))
+	};
+}
+
+async function main() {
+	const opts = parseArgs(process.argv.slice(2));
+	if (opts.help) return console.log(USAGE);
+	if (!opts.scenario) {
+		console.error('--scenario is required\n');
+		console.error(USAGE);
+		process.exitCode = 1;
+		return;
+	}
+
+	const path = resolve(process.cwd(), opts.scenario);
+	const scenario: Scenario = parseScenarioFile(await readFile(path, 'utf8'));
+
+	const fromDisk = new Map<string, GamePackDef>();
+	for (const file of opts.packFiles) {
+		const pack = parsePackFile(await readFile(resolve(process.cwd(), file), 'utf8'));
+		fromDisk.set(pack.id, pack);
+	}
+
+	const { packs, failed } = await resolvePacksFromDisk(
+		scenario.packs ?? [],
+		fromDisk,
+		dirname(path)
+	);
+	for (const { id, reason } of failed) {
+		console.error(`✗ pack '${id}': ${reason}`);
+	}
+
+	const composed = composeScenario(scenario, packs);
+	const counts = summarize(composed);
+	const lobby = opts.lobby || randomLobbyName();
+
+	console.log(`scenario  ${scenario.name} (${opts.scenario})`);
+	console.log(
+		`packs     ${packs.size} resolved${failed.length ? `, ${failed.length} failed` : ''}`
+	);
+	console.log(
+		`table     ${counts.decks} decks · ${counts.cards} cards · ${counts.pieces} pieces · ${counts.overlays} overlays · ${counts.snapPoints} snap points`
+	);
+	console.log(`seats     ${counts.seats.join(', ') || 'none'}`);
+
+	if (opts.dryRun) {
+		console.log('\n--dry-run: nothing was sent.');
+		return;
+	}
+	// a scenario whose packs all failed would "seed" an empty table over
+	// whatever is already there — refuse rather than wipe a live lobby
+	if (failed.length && packs.size === 0 && (scenario.placements?.length ?? 0) > 0) {
+		console.error('\nNo pack resolved — refusing to seed an empty table.');
+		process.exitCode = 1;
+		return;
+	}
+
+	const url = websocketUrl(opts.server, lobby, opts.player);
+	const sent = await seedOverWebsocket(url, opts.player, composed);
+	console.log(`\nseeded ${lobby} on ${opts.server} in ${sent} patches`);
+	for (const seat of counts.seats) {
+		console.log(`  /play?lobby=${lobby}&seat=${seat.slice(4)}`);
+	}
+}
+
+main().catch((error) => {
+	console.error(error instanceof Error ? error.message : error);
+	process.exitCode = 1;
+});

--- a/src/lib/compose/__tests__/compose-scenario.test.ts
+++ b/src/lib/compose/__tests__/compose-scenario.test.ts
@@ -1,0 +1,254 @@
+/**
+ * The composer is the whole point of headless composition: a scenario plus its
+ * packs must become a table without a browser, and it must be the SAME table a
+ * browser would have built. What has to hold:
+ *
+ * - the module is pure — no svelte, no store, no DOM, so a bun script can
+ *   import it (`scripts/seed-lobby.ts`);
+ * - entity ids, seat placeholders, `packOrigin` stamps and card order come out
+ *   exactly as `applyScenario` produces them in the client;
+ * - shuffling stays opt-in and per placement.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { STANDARD_52 } from '$lib/packs/standard52';
+import { applyScenario } from '$lib/scenario/scenario';
+import { composeScenario, placedCount } from '../scenario';
+import type { GamePackDef } from '$lib/packs/types';
+import type { Scenario } from '$lib/scenario/file';
+
+const STACKED = ['7H', 'AS', '2C', 'KD', '10S'];
+
+const TOKENS: GamePackDef = {
+	id: 'tokens',
+	name: 'Tokens',
+	scope: 'player',
+	decks: [],
+	pieces: [
+		{ kind: 'counter', name: 'HP', maxValue: 30, position: [0, 3] },
+		{ kind: 'token', name: 'Objective', imageUrl: 'https://example.com/o.png', position: [2, 1] }
+	],
+	overlays: [{ imageUrl: 'https://example.com/board.png', ratio: 1.5, scale: 12 }]
+};
+
+/** A two-seat duel: a stacked deck each, counters each, one shared board. */
+const DUEL: Scenario = {
+	name: 'duel',
+	createdAt: 0,
+	state: {},
+	packs: [
+		{ id: 'standard-52', source: 'builtin' },
+		{ id: 'tokens', source: 'https://example.com/tokens.tbpp.json' }
+	],
+	placements: [
+		{ kind: 'deck', pack: 'standard-52', content: 'main', seat: 0, order: STACKED },
+		{ kind: 'deck', pack: 'standard-52', content: 'main', seat: 1, order: STACKED },
+		{ kind: 'piece', pack: 'tokens', content: '0', seat: 0, value: 12 },
+		{ kind: 'piece', pack: 'tokens', content: '0', seat: 1 },
+		{ kind: 'piece', pack: 'tokens', content: '1', seat: 0 },
+		{ kind: 'overlay', pack: 'tokens', content: '0' }
+	],
+	snapPoints: [{ position: [0, 2], rotation: 90 }]
+};
+
+const PACKS = new Map<string, GamePackDef>([
+	['standard-52', STANDARD_52],
+	['tokens', TOKENS]
+]);
+
+const emptyTable = () =>
+	gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {}, overlays: {} });
+
+describe('composeScenario — a multi-seat scenario, composed headlessly', () => {
+	const composed = composeScenario(DUEL, PACKS);
+
+	it('imports nothing from svelte, the store or the DOM', () => {
+		// asserted on the source, not on behaviour: the moment one of these
+		// sneaks in, `bun run seed-lobby` stops booting and the failure shows up
+		// a long way from the import that caused it
+		for (const file of ['scenario.ts', 'pack.ts', 'piece.ts']) {
+			const source = readFileSync(join(process.cwd(), 'src/lib/compose', file), 'utf8');
+			const imports = [...source.matchAll(/^import\s+(type\s+)?[^;]*?from\s+'([^']+)'/gm)];
+			const runtime = imports.filter(([, isType]) => !isType).map(([, , from]) => from);
+			expect(runtime).not.toContain('svelte');
+			expect(runtime).not.toContain('svelte/store');
+			expect(runtime.filter((from) => from.includes('store/'))).toEqual([]);
+			expect(runtime.filter((from) => from.startsWith('$lib'))).toEqual([]);
+			// comments stripped: the prose above these functions is allowed to say
+			// the word `localStorage`, the code is not allowed to reach for it
+			const code = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+			expect(code).not.toMatch(/\b(document|window|localStorage)\b/);
+		}
+	});
+
+	it('seats a placeholder player for every seat a placement owns', () => {
+		expect(Object.keys(composed.players ?? {}).sort()).toEqual(['seat0', 'seat1']);
+		expect(composed.players?.seat1).toEqual({
+			id: 'seat1',
+			seat: 1,
+			joinTimestamp: 0,
+			tray: {},
+			metadata: {}
+		});
+	});
+
+	it('builds `kind:owner:slug` ids, one per placement', () => {
+		expect(Object.keys(composed.decks ?? {}).sort()).toEqual([
+			'deck:seat0:main',
+			'deck:seat1:main'
+		]);
+		expect(Object.keys(composed.pieces ?? {}).sort()).toEqual([
+			'piece:seat0:hp-0',
+			'piece:seat0:objective-0',
+			'piece:seat1:hp-0'
+		]);
+		// overlays are table-scoped: keyed by pack, never by seat
+		expect(Object.keys(composed.overlays ?? {})).toEqual(['overlay:tokens:0']);
+	});
+
+	it('honours the authored card order and the deck slot ids', () => {
+		expect(composed.decks?.['deck:seat0:main']?.cards?.map((c) => c.id)).toEqual(
+			STACKED.map((code) => `card:seat0:main-${code}`)
+		);
+		expect(composed.decks?.['deck:seat1:main']?.cards?.map((c) => c.id)).toEqual(
+			STACKED.map((code) => `card:seat1:main-${code}`)
+		);
+	});
+
+	it('mirrors the far seat: deck rotation and authored piece positions', () => {
+		expect(composed.decks?.['deck:seat0:main']?.rotation).toEqual([0, 0, 0]);
+		expect(composed.decks?.['deck:seat1:main']?.rotation).toEqual([0, Math.PI, 0]);
+		const [x0, , z0] = composed.pieces?.['piece:seat0:hp-0']?.position ?? [];
+		const [x1, , z1] = composed.pieces?.['piece:seat1:hp-0']?.position ?? [];
+		expect([x0, z0]).toEqual([0, 3]);
+		expect([x1, z1]).toEqual([-0, -3]);
+	});
+
+	it('stamps provenance from the scenario’s own pack refs', () => {
+		expect(composed.decks?.['deck:seat0:main']?.packOrigin).toEqual({
+			pack: 'standard-52',
+			content: 'main',
+			source: 'builtin'
+		});
+		expect(composed.pieces?.['piece:seat0:hp-0']?.packOrigin).toEqual({
+			pack: 'tokens',
+			content: '0',
+			source: 'https://example.com/tokens.tbpp.json'
+		});
+		expect(composed.overlays?.['overlay:tokens:0']?.packOrigin).toEqual({
+			pack: 'tokens',
+			content: '0',
+			source: 'https://example.com/tokens.tbpp.json'
+		});
+	});
+
+	it('carries per-placement piece state through', () => {
+		expect(composed.pieces?.['piece:seat0:hp-0']).toMatchObject({ value: 12, maxValue: 30 });
+		// no `value` on the placement: the counter spawns full
+		expect(composed.pieces?.['piece:seat1:hp-0']).toMatchObject({ value: 30 });
+	});
+
+	it('reassigns snap points to `snap:<n>` keys', () => {
+		expect(composed.snapPoints).toEqual({
+			'snap:0': { id: 'snap:0', position: [0, 2], rotation: 90 }
+		});
+	});
+
+	it('skips placements whose pack never resolved, and says how many landed', () => {
+		const partial = composeScenario(DUEL, new Map([['standard-52', STANDARD_52]]));
+		expect(Object.keys(partial.decks ?? {})).toHaveLength(2);
+		expect(partial.pieces).toEqual({});
+		expect(placedCount(DUEL, new Map([['standard-52', STANDARD_52]]))).toBe(2);
+		expect(placedCount(DUEL, PACKS)).toBe(6);
+	});
+});
+
+describe('composeScenario — order and shuffling', () => {
+	it('does not shuffle unless the placement asks', () => {
+		const shuffle = vi.fn((cards) => cards);
+		composeScenario(DUEL, PACKS, { shuffleWith: shuffle });
+		expect(shuffle).not.toHaveBeenCalled();
+	});
+
+	it('shuffles exactly the placements that opted in', () => {
+		const scenario: Scenario = {
+			...DUEL,
+			placements: [
+				{ kind: 'deck', pack: 'standard-52', content: 'main', seat: 0, order: STACKED },
+				{
+					kind: 'deck',
+					pack: 'standard-52',
+					content: 'main',
+					seat: 1,
+					order: STACKED,
+					shuffleOnLoad: true
+				}
+			]
+		};
+		const shuffle = vi.fn((cards) => [...cards].reverse());
+		const composed = composeScenario(scenario, PACKS, { shuffleWith: shuffle });
+
+		expect(shuffle).toHaveBeenCalledTimes(1);
+		expect(composed.decks?.['deck:seat0:main']?.cards?.map((c) => c.id)).toEqual(
+			STACKED.map((code) => `card:seat0:main-${code}`)
+		);
+		expect(composed.decks?.['deck:seat1:main']?.cards?.map((c) => c.id)).toEqual(
+			[...STACKED].reverse().map((code) => `card:seat1:main-${code}`)
+		);
+		// authoring intent round-trips onto the deck either way
+		expect(composed.decks?.['deck:seat1:main']?.shuffleOnLoad).toBe(true);
+	});
+
+	it('composes a v1/v0 scenario as its own snapshot', () => {
+		const legacy: Scenario = {
+			name: 'legacy',
+			createdAt: 0,
+			state: {
+				cards: { 'card:seat0:x': { faceImageUrl: 'https://example.com/a.png' } },
+				players: { seat0: { id: 'seat0', seat: 0, joinTimestamp: 0, tray: {}, metadata: {} } }
+			}
+		};
+		expect(composeScenario(legacy, new Map())).toMatchObject({
+			cards: { 'card:seat0:x': { faceImageUrl: 'https://example.com/a.png' } },
+			players: { seat0: { seat: 0 } },
+			decks: {}
+		});
+	});
+
+	it('lays the raw `state` override on top of composed pack content', () => {
+		const scenario: Scenario = {
+			...DUEL,
+			state: { pieces: { 'piece:seat0:hp-0': { value: 3 } } }
+		};
+		const composed = composeScenario(scenario, PACKS);
+		// merged, not replaced — the override patches the composed piece exactly
+		// as the same patch would have patched it in the store
+		expect(composed.pieces?.['piece:seat0:hp-0']).toMatchObject({
+			value: 3,
+			maxValue: 30,
+			name: 'HP'
+		});
+	});
+});
+
+describe('headless and in-browser composition agree', () => {
+	it('produces the identical table applyScenario puts in the store', async () => {
+		emptyTable();
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(JSON.stringify({ tbpp: 1, ...TOKENS }))
+		);
+		await applyScenario(DUEL);
+		const inStore = get(gameStore);
+		const headless = composeScenario(DUEL, PACKS);
+
+		for (const collection of ['decks', 'pieces', 'overlays', 'snapPoints', 'players'] as const) {
+			expect({ [collection]: inStore[collection] }).toEqual({
+				[collection]: headless[collection]
+			});
+		}
+		vi.restoreAllMocks();
+	});
+});

--- a/src/lib/compose/pack.ts
+++ b/src/lib/compose/pack.ts
@@ -1,0 +1,250 @@
+/**
+ * Pure pack instantiation: a `GamePackDef` plus a placement in, `GameDTO`
+ * entities out. No store, no Svelte, no DOM — `packs/spawn.ts` wraps these and
+ * writes the result to the gameStore, `compose/scenario.ts` wraps them and
+ * hands the result to whoever asked (a websocket seeder, a test).
+ *
+ * Packs are templates: nothing here mutates the pack it was handed.
+ */
+
+import { PIECE_REST_Y } from '../utils/constants-pieces';
+import { composePiece, type Vec3 } from './piece';
+import type { GamePackDef, PackDeckDef, PackPieceDef } from '../packs/types';
+import type {
+	BagItem,
+	CardInDeck,
+	DeckDTO,
+	OverlayDTO,
+	PackOrigin,
+	PieceDTO
+} from '../store/game/types';
+
+export type { Vec3 };
+
+/**
+ * `seat0`…`seat3` → 0…3, and undefined for a real player id. Matched by shape
+ * rather than imported from scenario.ts, which is the module that *defines*
+ * the placeholders and already depends on this one.
+ */
+export function placeholderSeat(ownerId: string): number | undefined {
+	const match = /^seat([0-3])$/.exec(ownerId);
+	return match ? Number(match[1]) : undefined;
+}
+
+/** Reorder in place, Fisher–Yates. The default for a `shuffleOnLoad` deck. */
+export function shuffleInPlace<T>(cards: T[], random: () => number = Math.random): T[] {
+	for (let i = cards.length - 1; i > 0; i--) {
+		const j = Math.floor(random() * (i + 1));
+		[cards[i], cards[j]] = [cards[j], cards[i]];
+	}
+	return cards;
+}
+
+/**
+ * How a caller shuffles. Injectable because the browser routes shuffling
+ * through `gameActions.shuffleCards` (one shuffle implementation on the
+ * client) and a headless composer has no actions object; a seeder that wants a
+ * reproducible table passes a seeded generator.
+ */
+export type ShuffleFn = <T>(cards: T[]) => T[] | undefined | void | null;
+
+/** Options shared by every pack composer. */
+type CommonOptions = {
+	/** entity owner — `seat0`…`seat3` for scenario content, a player id otherwise */
+	ownerId: string;
+	/**
+	 * Already-resolved `packOrigin.source`: where this pack re-resolves from
+	 * ('builtin' | 'local' | URL). Deciding it needs the browser's pack library,
+	 * so it is the caller's answer, not this module's.
+	 */
+	source?: string;
+};
+
+function origin(pack: GamePackDef, content: string, source?: string): PackOrigin {
+	return { pack: pack.id, content, ...(source ? { source } : {}) };
+}
+
+/** Mirrors addDeck's two-seat defaults, but keyed off the OWNER's seat. */
+function deckDefaults(seat: number, index: number, isFaceUp: boolean) {
+	const x = 8.5 + (isFaceUp ? 2 : 0) + index * 2.5;
+	return seat % 2 === 1
+		? { position: [x, 0.4, -4.7] as Vec3, rotation: [0, Math.PI, 0] as Vec3 }
+		: { position: [x, 0.4, 4.5] as Vec3, rotation: [0, 0, 0] as Vec3 };
+}
+
+export type ComposeDeckOptions = CommonOptions & {
+	/** the owner's seat; defaults to the `seatN` placeholder's index, else 0 */
+	seat?: number;
+	position?: Vec3;
+	rotation?: Vec3;
+	isFaceUp?: boolean;
+	/**
+	 * Explicit card order as pack card codes (deck-array order). Unknown codes
+	 * are skipped with a warning; omitted = the pack's declaration order.
+	 */
+	order?: string[];
+	/**
+	 * Explicit shuffle opt-in. Scenario loads pass the placement's
+	 * `shuffleOnLoad`; plain spawns pass `!isFaceUp` to keep the historical
+	 * "facedown decks spawn shuffled" behavior.
+	 */
+	shuffle?: boolean;
+	/** re-save authoring intent: stamped onto the deck so export round-trips it */
+	shuffleOnLoad?: boolean;
+	/** sideways slot when a pack spawns several decks */
+	index?: number;
+	/** how to shuffle when `shuffle` is set; defaults to Fisher–Yates */
+	shuffleWith?: ShuffleFn;
+};
+
+/**
+ * Instantiate one of a pack's decks. Card ids are `card:<owner>:<slot>-<code>`
+ * — the grammar `scenario.ts` reads back when it turns a deck into a placement.
+ * Order and shuffling are the CALLER's choice (tbps v2 placements preserve
+ * authored order; shuffling is opt-in), never implied.
+ */
+export function composePackDeck(
+	pack: GamePackDef,
+	deck: PackDeckDef,
+	opts: ComposeDeckOptions
+): { id: string; deck: Partial<DeckDTO> } {
+	const defs = opts.order
+		? opts.order
+				.map((code) => {
+					const def = deck.cards.find((c) => c.code === code);
+					if (!def)
+						console.warn(`[compose] unknown card code '${code}' in ${pack.id}/${deck.slot}`);
+					return def;
+				})
+				.filter((def) => def !== undefined)
+		: deck.cards;
+
+	let cards: CardInDeck[] = defs.map((card) => ({
+		id: `card:${opts.ownerId}:${deck.slot}-${card.code}`,
+		faceImageUrl: card.face,
+		backImageUrl: deck.back
+	}));
+	if (opts.shuffle) {
+		const shuffle = opts.shuffleWith ?? shuffleInPlace;
+		cards = (shuffle(cards) as CardInDeck[] | undefined | null) ?? cards;
+	}
+
+	const isFaceUp = opts.isFaceUp ?? deck.isFaceUp ?? false;
+	const seat = opts.seat ?? placeholderSeat(opts.ownerId) ?? 0;
+	const defaults = deckDefaults(seat, opts.index ?? 0, isFaceUp);
+	const id = `deck:${opts.ownerId}:${deck.slot}`;
+	return {
+		id,
+		deck: {
+			id,
+			isFaceUp,
+			deckBackImageUrl: deck.back,
+			cards,
+			position: opts.position ?? defaults.position,
+			rotation: opts.rotation ?? defaults.rotation,
+			packOrigin: origin(pack, deck.slot, opts.source),
+			...(opts.shuffleOnLoad !== undefined ? { shuffleOnLoad: opts.shuffleOnLoad } : {})
+		}
+	};
+}
+
+/**
+ * A pack bag item and a live bag item are the same shape by design — the pack
+ * says what is in the bag, the store holds that same list as the bag's state.
+ * Cloned per spawn so two bags from one pack never share an array.
+ */
+function bagContents(def: PackPieceDef): BagItem[] {
+	return (def.contents ?? []).map((item) => ({ ...item }) as BagItem);
+}
+
+export type ComposePackPieceOptions = CommonOptions & {
+	/** the owner's seat; decides which way the pack's authored position mirrors */
+	seat?: number;
+	position?: Vec3;
+	rotation?: Vec3;
+	value?: number;
+	/** multi-state pieces: which authored state to start on (default 0) */
+	state?: number;
+	/** piece ids already on the table, so a repeated name gets the next `-n` */
+	taken?: ReadonlySet<string>;
+};
+
+/**
+ * Instantiate one of a pack's pieces (by index into `pack.pieces`).
+ * Returns undefined — after saying so — for an index the pack doesn't have.
+ */
+export function composePackPiece(
+	pack: GamePackDef,
+	index: number,
+	opts: ComposePackPieceOptions
+): { id: string; piece: Partial<PieceDTO> } | undefined {
+	const def = pack.pieces?.[index];
+	if (!def) {
+		console.error(`[compose] ${pack.id} has no piece[${index}]`);
+		return undefined;
+	}
+
+	// pack piece positions are authored for seat 0; mirror for the far side
+	const seat = opts.seat ?? placeholderSeat(opts.ownerId) ?? 0;
+	const m = seat % 2 === 1 ? -1 : 1;
+	return composePiece(def.kind, {
+		ownerId: opts.ownerId,
+		taken: opts.taken,
+		name: def.name,
+		color: def.color,
+		// states[0] IS the base face (see PackPieceDef.states), so a piece that
+		// declares states never falls back to imageUrl
+		imageUrl: def.states?.length ? def.states[0].face : def.imageUrl,
+		states: def.states,
+		// the placement's choice wins over the pack's own default
+		state: opts.state ?? def.state,
+		radius: def.radius,
+		maxValue: def.maxValue,
+		sides: def.sides,
+		value: opts.value,
+		...(def.kind === 'bag'
+			? { contents: bagContents(def), drawMode: def.drawMode, infinite: def.infinite }
+			: {}),
+		position: opts.position ?? [def.position[0] * m, PIECE_REST_Y, def.position[1] * m],
+		rotation: opts.rotation,
+		packOrigin: origin(pack, String(index), opts.source)
+	});
+}
+
+export type ComposeOverlayOptions = Omit<CommonOptions, 'ownerId'> & {
+	/** accepted and ignored: overlays are table-scoped, keyed by pack */
+	ownerId?: string;
+	position?: Vec3;
+	rotation?: Vec3;
+	scale?: number;
+};
+
+/**
+ * Instantiate one of a pack's overlays (by index into `pack.overlays`).
+ * Table-scoped — `claimSeat` never renames an overlay, so its id is keyed by
+ * pack rather than by owner.
+ */
+export function composePackOverlay(
+	pack: GamePackDef,
+	index: number,
+	opts: ComposeOverlayOptions = {}
+): { id: string; overlay: Partial<OverlayDTO> } | undefined {
+	const def = pack.overlays?.[index];
+	if (!def) {
+		console.error(`[compose] ${pack.id} has no overlay[${index}]`);
+		return undefined;
+	}
+	const id = `overlay:${pack.id}:${index}`;
+	return {
+		id,
+		overlay: {
+			id,
+			imageUrl: def.imageUrl,
+			ratio: def.ratio,
+			scale: opts.scale ?? def.scale,
+			position: opts.position ?? [0, 0.255, 0],
+			rotation: opts.rotation ?? [0, 0, 0],
+			packOrigin: origin(pack, String(index), opts.source)
+		}
+	};
+}

--- a/src/lib/compose/piece.ts
+++ b/src/lib/compose/piece.ts
@@ -1,0 +1,163 @@
+/**
+ * Pure piece construction: the half of `addPiece` that decides what a piece
+ * *is*, with no store behind it.
+ *
+ * Two callers, one implementation. `store/game/actions/piece.ts` is the
+ * browser one — it resolves the acting owner, picks a fan-out spawn position
+ * and hands over the piece ids already on the table. `compose/pack.ts` is the
+ * headless one, assembling the same inputs from a scenario instead of a live
+ * store. That is what lets a table laid out from a terminal be the same table
+ * a browser would have laid out.
+ *
+ * Relative imports throughout (not `$lib`): this module is compiled by bun
+ * scripts that run without the SvelteKit path aliases — see `packs/types.ts`.
+ */
+
+import { COUNTER_MAX_DEFAULT, DIE_SIDES_DEFAULT, PIECE_RADIUS } from '../utils/constants-pieces';
+import type {
+	BagDrawMode,
+	BagItem,
+	DieSides,
+	PackOrigin,
+	PieceDTO,
+	PieceKind,
+	PieceStateDTO
+} from '../store/game/types';
+
+export type Vec3 = [number, number, number];
+
+const KIND_LABEL: Record<PieceKind, string> = {
+	token: 'Token',
+	pawn: 'Pawn',
+	counter: 'Counter',
+	die: 'Die',
+	bag: 'Bag'
+};
+
+export function slugify(name: string, fallback: string): string {
+	const slug = name
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '');
+	return slug || fallback;
+}
+
+/**
+ * The state index a piece is actually showing: clamped into its `states`
+ * array, and 0 for a piece that has none. Shared by the renderer and the
+ * cycle/select verbs so they can never disagree about what is on the table.
+ */
+export function currentPieceState(
+	piece: { states?: PieceStateDTO[]; state?: number } | null | undefined
+): number {
+	const count = piece?.states?.length ?? 0;
+	if (count === 0) return 0;
+	return Math.min(Math.max(Math.trunc(piece?.state ?? 0), 0), count - 1);
+}
+
+/**
+ * ids are `kind:owner:slug` (claimSeat renames the owner segment) — `-n`
+ * disambiguates repeats. `taken` is every piece id already on the table, so
+ * two pieces of the same name never collide.
+ */
+export function nextPieceId(taken: ReadonlySet<string>, ownerId: string, slug: string): string {
+	let n = 0;
+	while (taken.has(`piece:${ownerId}:${slug}-${n}`)) n++;
+	return `piece:${ownerId}:${slug}-${n}`;
+}
+
+/** Everything a piece *is* — minus who owns it and where it goes. */
+export type PieceProps = {
+	name?: string;
+	/** hex tint; pawns/counters/dice without images render in this color */
+	color?: string;
+	/** resolved like card faces — a plain https:// url works */
+	imageUrl?: string;
+	/** multi-state pieces: every face, `states[0]` being the base one */
+	states?: PieceStateDTO[];
+	/** which of `states` to spawn showing (default 0) */
+	state?: number;
+	radius?: number;
+	/** counters only; the piece spawns full (`value = maxValue`) unless `value` says otherwise */
+	maxValue?: number;
+	/** counters only; restores a saved count (scenario loads) instead of spawning full */
+	value?: number;
+	/** dice only; how many faces (defaults to a d6) */
+	sides?: DieSides;
+	rotation?: Vec3;
+	/** bags only; the hidden pool a draw pulls from */
+	contents?: BagItem[];
+	/** bags only; defaults to 'random' */
+	drawMode?: BagDrawMode;
+	/** bags only; a draw clones instead of removing */
+	infinite?: boolean;
+	/** set when the piece comes from a pack, so a v2 scenario can reference it */
+	packOrigin?: PackOrigin;
+};
+
+export type ComposePieceOptions = PieceProps & {
+	ownerId: string;
+	/**
+	 * Where it lands. Required: the fan-out default a hand-spawn uses is a
+	 * function of how full the owner's edge of the table already is, which is a
+	 * store question — the caller answers it.
+	 */
+	position: Vec3;
+	/** piece ids already on the table, so a repeated name gets the next `-n` */
+	taken?: ReadonlySet<string>;
+};
+
+const NO_IDS: ReadonlySet<string> = new Set();
+
+/**
+ * Shape a piece and its id. Pure — nothing is committed anywhere; the caller
+ * decides whether that means a store patch or a websocket frame.
+ */
+export function composePiece(
+	kind: PieceKind,
+	opts: ComposePieceOptions
+): { id: string; piece: Partial<PieceDTO> } {
+	const sides = opts.sides ?? DIE_SIDES_DEFAULT;
+	// dice name themselves after their shape: `d20`, not `Die` — the shape is
+	// the only thing that distinguishes one from another at a glance
+	const name = opts.name?.trim() || (kind === 'die' ? `d${sides}` : KIND_LABEL[kind]);
+	const id = nextPieceId(opts.taken ?? NO_IDS, opts.ownerId, slugify(name, kind));
+
+	const piece: Partial<PieceDTO> = {
+		kind,
+		name,
+		position: opts.position,
+		rotation: opts.rotation ?? [0, 0, 0],
+		radius: opts.radius ?? PIECE_RADIUS[kind]
+	};
+	if (opts.color) piece.color = opts.color;
+	if (opts.imageUrl) piece.imageUrl = opts.imageUrl;
+	// Not on a die or a bag: a die's faces are geometry and a bag's is a pouch,
+	// so states would be dead weight on the wire and would hand either a state
+	// menu it has no use for. Dropped here rather than rejected at parse time so
+	// a pack that carries them anyway still imports — it just spawns plain.
+	if (kind !== 'die' && kind !== 'bag' && opts.states?.length) {
+		piece.states = opts.states.map((s) => ({ face: s.face, ...(s.name ? { name: s.name } : {}) }));
+		piece.state = currentPieceState({ states: opts.states, state: opts.state });
+	}
+	if (opts.packOrigin) piece.packOrigin = opts.packOrigin;
+	if (kind === 'counter') {
+		const maxValue = opts.maxValue ?? COUNTER_MAX_DEFAULT;
+		piece.maxValue = maxValue;
+		piece.value = opts.value ?? maxValue;
+	}
+	if (kind === 'die') {
+		piece.sides = sides;
+		piece.value = opts.value ?? 1;
+		// a fresh die has never been rolled, so nothing animates on spawn
+		piece.rollSeq = 0;
+	}
+	if (kind === 'bag') {
+		// always written, even empty: a bag with no `contents` key would leave
+		// nothing for a return-to-bag patch to merge into
+		piece.contents = opts.contents ?? [];
+		piece.drawMode = opts.drawMode ?? 'random';
+		if (opts.infinite) piece.infinite = true;
+	}
+	return { id, piece };
+}

--- a/src/lib/compose/scenario.ts
+++ b/src/lib/compose/scenario.ts
@@ -1,0 +1,221 @@
+/**
+ * Headless scenario composition: a tbps scenario plus its already-resolved
+ * packs in, the `GameDTO` fragment a client would have produced out.
+ *
+ * This is the entity-building half of `scenario.applyScenario`, lifted out of
+ * the browser. Nothing here touches a store, Svelte, `localStorage` or the
+ * DOM, so the same code that lays out a table in /play can lay one out from a
+ * bun script (`scripts/seed-lobby.ts`) or from a future provisioning API —
+ * same entity ids, same `seat0`…`seat3` placeholder owners, same `packOrigin`
+ * stamps, same card order.
+ *
+ * Pack **resolution** is deliberately not here: fetching a `.tbpp.json` is I/O,
+ * and keeping it out is what makes this testable and reusable. The caller
+ * resolves (`scenario/resolve-packs.ts` in the browser) and passes the map.
+ */
+
+import { BUILTIN_PACKS, PACK_SOURCE_BUILTIN } from '../packs/builtin';
+import { composePackDeck, composePackOverlay, composePackPiece, type ShuffleFn } from './pack';
+import type { GamePackDef } from '../packs/types';
+import type { GameDTO } from '../store/game/types';
+import type { PackPlacement, PackRef, Scenario, SeatIndex, SnapPoint } from '../scenario/file';
+
+export type { ShuffleFn };
+
+export const seatPlaceholderId = (seat: SeatIndex) => `seat${seat}`;
+export const isSeatPlaceholder = (id: string) => /^seat[0-3]$/.test(id);
+
+export type ComposeScenarioOptions = {
+	/**
+	 * How a `shuffleOnLoad` deck is shuffled. Defaults to Fisher–Yates; the
+	 * client passes its own so there is one shuffle on the client, and a seeder
+	 * that wants a reproducible table passes a seeded generator.
+	 */
+	shuffleWith?: ShuffleFn;
+	/**
+	 * Where a pack re-resolves from, stamped into every entity's `packOrigin`.
+	 * Defaults to what the scenario's own ref says, falling back to `'builtin'`
+	 * for a shipped pack. The browser overrides this to also recognise packs
+	 * held in its local library, which is knowledge no headless caller has.
+	 */
+	sourceOf?: (ref: PackRef, pack: GamePackDef) => string | undefined;
+};
+
+function defaultSourceOf(ref: PackRef, pack: GamePackDef): string | undefined {
+	if (ref.source) return ref.source;
+	return BUILTIN_PACKS[pack.id] ? PACK_SOURCE_BUILTIN : undefined;
+}
+
+/**
+ * Placeholder players a scenario needs: the ones it saved, plus one per seat
+ * its placements own content for. They hold the seat index and tray until a
+ * real player claims them (`scenario.claimSeat`), and `?seat=N` auto-claim
+ * waits on exactly this — so a seeded lobby without them is unclaimable.
+ */
+export function composePlayers(scenario: Scenario): GameDTO['players'] {
+	const players: GameDTO['players'] = {};
+	for (const [id, player] of Object.entries(scenario.state?.players ?? {})) {
+		players[id] = player as GameDTO['players'][string];
+	}
+	for (const placement of scenario.placements ?? []) {
+		if (placement.seat === undefined) continue;
+		const id = seatPlaceholderId(placement.seat);
+		players[id] ??= { id, seat: placement.seat, joinTimestamp: 0, tray: {}, metadata: {} };
+	}
+	return players;
+}
+
+/**
+ * Snap points live in a file as a plain array — table-scoped, nothing
+ * references them — and in state keyed by id. This is that reassignment.
+ */
+export function composeSnapPoints(snapPoints: SnapPoint[] | undefined): GameDTO['snapPoints'] {
+	const composed: GameDTO['snapPoints'] = {};
+	(snapPoints ?? []).forEach((point, index) => {
+		const id = `snap:${index}`;
+		composed[id] = { id, ...point };
+	});
+	return composed;
+}
+
+/**
+ * Lay an override from the scenario's raw `state` on top of composed content.
+ * Mirrors the gameStore's own merge (`store/transform-helpers.ts`): objects
+ * merge key by key, arrays and scalars replace — so a partial override patches
+ * the spawned entity here exactly as it would have patched it in the store.
+ */
+function mergeOver(base: unknown, override: unknown): unknown {
+	if (Array.isArray(base) || Array.isArray(override)) return override;
+	if (typeof base !== 'object' || typeof override !== 'object' || !base || !override) {
+		return override;
+	}
+	const merged: Record<string, unknown> = { ...(base as Record<string, unknown>) };
+	for (const [key, value] of Object.entries(override as Record<string, unknown>)) {
+		merged[key] = merged[key] ? mergeOver(merged[key], value) : value;
+	}
+	return merged;
+}
+
+/** Compose one placement into the fragment being built. */
+function place(
+	placement: PackPlacement,
+	pack: GamePackDef,
+	state: Partial<GameDTO>,
+	source: string | undefined,
+	shuffleWith: ShuffleFn | undefined
+) {
+	const ownerId = placement.seat !== undefined ? seatPlaceholderId(placement.seat) : undefined;
+
+	if (placement.kind === 'overlay') {
+		const composed = composePackOverlay(pack, Number(placement.content), {
+			source,
+			position: placement.position,
+			rotation: placement.rotation,
+			scale: placement.scale
+		});
+		if (composed) (state.overlays ??= {})[composed.id] = composed.overlay;
+		return;
+	}
+
+	// decks and pieces are seat-relative: without an owner there is no id to
+	// build, and inventing one would put content on a seat nobody can claim
+	if (!ownerId) {
+		console.error(`[compose] ${placement.kind} placement in '${pack.id}' has no seat`);
+		return;
+	}
+
+	if (placement.kind === 'deck') {
+		const deck = pack.decks.find((d) => d.slot === placement.content);
+		if (!deck) {
+			console.error(`[scenario] pack '${pack.id}' has no deck '${placement.content}'`);
+			return;
+		}
+		const composed = composePackDeck(pack, deck, {
+			ownerId,
+			source,
+			position: placement.position,
+			rotation: placement.rotation,
+			isFaceUp: placement.isFaceUp,
+			// authored order is the default; shuffling is an explicit opt-in
+			order: placement.order,
+			shuffle: placement.shuffleOnLoad === true,
+			shuffleOnLoad: placement.shuffleOnLoad,
+			shuffleWith
+		});
+		(state.decks ??= {})[composed.id] = composed.deck;
+		return;
+	}
+
+	const index = Number(placement.content);
+	if (!Number.isInteger(index)) {
+		console.error(`[scenario] ${placement.kind} placement content must be an index`);
+		return;
+	}
+	const composed = composePackPiece(pack, index, {
+		ownerId,
+		source,
+		// ids allocated against what this composition has already placed — the
+		// client asks the same question of a table it cleared first
+		taken: new Set(Object.keys(state.pieces ?? {})),
+		position: placement.position,
+		rotation: placement.rotation,
+		value: placement.value,
+		state: placement.state
+	});
+	if (composed) (state.pieces ??= {})[composed.id] = composed.piece;
+}
+
+/**
+ * Turn a scenario into the table it describes.
+ *
+ * `packs` is keyed by `PackRef.id`; a placement whose pack is missing from it
+ * is skipped silently — the caller resolved the packs and already knows which
+ * ones failed. Handles v1/v0 scenarios too: with no placements the result is
+ * just the file's own `state` snapshot, so a legacy file seeds as happily as a
+ * pack-referencing one.
+ *
+ * The result is a complete table, not a diff: apply it to an empty lobby and
+ * that lobby is the scenario.
+ */
+export function composeScenario(
+	scenario: Scenario,
+	packs: Map<string, GamePackDef>,
+	options: ComposeScenarioOptions = {}
+): Partial<GameDTO> {
+	const sourceOf = options.sourceOf ?? defaultSourceOf;
+	const refs = new Map((scenario.packs ?? []).map((ref) => [ref.id, ref]));
+
+	const state: Partial<GameDTO> = {
+		players: composePlayers(scenario),
+		cards: {},
+		decks: {},
+		pieces: {},
+		overlays: {},
+		snapPoints: composeSnapPoints(scenario.snapPoints)
+	};
+
+	for (const placement of scenario.placements ?? []) {
+		const pack = packs.get(placement.pack);
+		if (!pack) continue; // unresolvable — the caller reports it
+		const ref = refs.get(placement.pack) ?? { id: placement.pack };
+		place(placement, pack, state, sourceOf(ref, pack), options.shuffleWith);
+	}
+
+	// the raw `state` snapshot is the override layer: ad-hoc pieces, hand-placed
+	// cards, and tweaks to pack content the placements can't express
+	for (const collection of ['cards', 'decks', 'pieces', 'overlays', 'snapPoints'] as const) {
+		const target = (state[collection] ??= {}) as Record<string, unknown>;
+		for (const [id, entity] of Object.entries(scenario.state?.[collection] ?? {})) {
+			target[id] = target[id] ? mergeOver(target[id], entity) : entity;
+		}
+	}
+	return state;
+}
+
+/**
+ * Placements the composer could actually place: everything whose pack
+ * resolved. What `ApplyReport.placed` counts.
+ */
+export function placedCount(scenario: Scenario, packs: Map<string, GamePackDef>): number {
+	return (scenario.placements ?? []).filter((p) => packs.has(p.pack)).length;
+}

--- a/src/lib/hotkeys/__tests__/is-typing.test.ts
+++ b/src/lib/hotkeys/__tests__/is-typing.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Table hotkeys are bare letters bound on `svelte:window`, and every route
+ * carries a tweakpane full of text fields. Tweakpane does not stop propagation,
+ * so without a guard, typing `flag-game` into a scenario name flips a card,
+ * groups a pile and resets the camera — and on /play, which is synced, that
+ * mutation lands on everyone's table (see #112).
+ *
+ * The source-level half is the part that regresses: `isTyping` existing is no
+ * use if a handler forgets to call it, and the failure is silent — the hotkey
+ * simply also fires.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { isTyping } from '../is-typing';
+
+describe('isTyping', () => {
+	it('is true for the fields tweakpane renders', () => {
+		for (const tag of ['input', 'textarea', 'select']) {
+			expect(isTyping(document.createElement(tag)), tag).toBe(true);
+		}
+	});
+
+	// jsdom does not implement `isContentEditable` (it stays undefined however
+	// the attribute is set), so the browser's behaviour has to be stubbed in
+	it('is true for a contenteditable host', () => {
+		const div = document.createElement('div');
+		Object.defineProperty(div, 'isContentEditable', { value: true });
+		expect(isTyping(div)).toBe(true);
+	});
+
+	it('is false for the canvas, plain elements and a null target', () => {
+		expect(isTyping(document.createElement('canvas'))).toBe(false);
+		expect(isTyping(document.createElement('button'))).toBe(false);
+		expect(isTyping(null)).toBe(false);
+	});
+});
+
+const ROUTES = ['create', 'setup', 'play'];
+
+function body(source: string, fn: string) {
+	const start = source.indexOf(`function ${fn}(event: KeyboardEvent) {`);
+	expect(start, fn).toBeGreaterThan(-1);
+	const end = source.indexOf('\n\t}', start);
+	return source.slice(start, end);
+}
+
+describe('route keyboard handlers', () => {
+	for (const route of ROUTES) {
+		const source = readFileSync(join(process.cwd(), 'src/routes', route, '+page.svelte'), 'utf8');
+
+		it(`/${route} imports the shared helper rather than defining its own`, () => {
+			expect(source).toContain("from '$lib/hotkeys/is-typing'");
+			expect(source).not.toMatch(/function isTyping\b/);
+		});
+
+		// keyup matters too: Space's preview HUD is a latch, so a guarded press
+		// with an unguarded release would leave the HUD stuck on
+		for (const fn of ['handleKeyDown', 'handleKeyUp']) {
+			it(`/${route} ${fn} bails out before reading the key`, () => {
+				const source_ = body(source, fn);
+				const guard = source_.indexOf('isTyping(event.target)');
+				expect(guard, 'no isTyping guard').toBeGreaterThan(-1);
+				const firstUse = source_.indexOf('event.code');
+				if (firstUse > -1) expect(guard).toBeLessThan(firstUse);
+			});
+		}
+	}
+});

--- a/src/lib/hotkeys/is-typing.ts
+++ b/src/lib/hotkeys/is-typing.ts
@@ -1,0 +1,24 @@
+/**
+ * Is this key event landing in a text field?
+ *
+ * Every table route binds bare letters as gestures on `svelte:window`, and the
+ * panes are full of text — codes, names, lobby ids, image URLs. Tweakpane does
+ * not stop propagation, so a key typed into a field still reaches the window
+ * handler: naming a scenario `flag-game` would otherwise flip a card, group a
+ * pile and reset the camera. A key that lands in a field is text, not a table
+ * command.
+ *
+ * Call it first in both `handleKeyDown` and `handleKeyUp` — a latch like Space's
+ * preview HUD needs the release guarded too, or it sticks on.
+ */
+export function isTyping(target: EventTarget | null) {
+	const element = target as HTMLElement | null;
+	if (!element) return false;
+	// coerced: `isContentEditable` is absent (undefined) outside a real browser
+	return Boolean(
+		element.tagName === 'INPUT' ||
+			element.tagName === 'TEXTAREA' ||
+			element.tagName === 'SELECT' ||
+			element.isContentEditable
+	);
+}

--- a/src/lib/packs/spawn.ts
+++ b/src/lib/packs/spawn.ts
@@ -1,12 +1,17 @@
 import { get } from 'svelte/store';
 import { gameActions } from '$lib/store/game/actions';
 import { gameStore } from '$lib/store/game/gameStore.svelte';
-import { PIECE_REST_Y } from '$lib/utils/constants-pieces';
+import {
+	composePackDeck,
+	composePackOverlay,
+	composePackPiece,
+	placeholderSeat
+} from '$lib/compose/pack';
 import { BUILTIN_PACKS, PACK_SOURCE_BUILTIN } from './builtin';
 import { hasLibraryPack, PACK_SOURCE_LOCAL } from './library';
 import type { SpreadTile } from './spread';
-import type { GamePackDef, PackDeckDef, PackPieceDef } from './types';
-import type { BagItem, CardDTO, PackOrigin } from '$lib/store/game/types';
+import type { GamePackDef, PackDeckDef } from './types';
+import type { CardDTO } from '$lib/store/game/types';
 
 export type SpawnPackOptions = {
 	/** entity owner — defaults to the local player (the scenario editor passes `seat0`…`seat3`) */
@@ -46,9 +51,7 @@ export type SpawnDeckOptions = SpawnPackOptions & {
  * shape to avoid importing scenario.ts (which imports this package).
  */
 function ownerSeat(ownerId: string): number {
-	const placeholder = /^seat([0-3])$/.exec(ownerId);
-	if (placeholder) return Number(placeholder[1]);
-	return get(gameStore)?.players?.[ownerId]?.seat ?? 0;
+	return placeholderSeat(ownerId) ?? get(gameStore)?.players?.[ownerId]?.seat ?? 0;
 }
 
 /**
@@ -57,74 +60,40 @@ function ownerSeat(ownerId: string): number {
  * which is what makes a pack imported from disk survive a scenario save/load
  * without being hosted anywhere. A pack that is in neither gets no stamp — a
  * scenario referencing it will fail loudly by id rather than silently.
+ *
+ * The browser's answer to the question `compose/` deliberately doesn't ask:
+ * the local library is localStorage, which a headless composer has no access
+ * to and no business inventing.
  */
-function packSource(pack: GamePackDef, source?: string): string | undefined {
+export function packSource(pack: GamePackDef, source?: string): string | undefined {
 	if (source) return source;
 	if (BUILTIN_PACKS[pack.id]) return PACK_SOURCE_BUILTIN;
 	return hasLibraryPack(pack.id) ? PACK_SOURCE_LOCAL : undefined;
 }
 
-function origin(pack: GamePackDef, content: string, source?: string): PackOrigin {
-	const resolved = packSource(pack, source);
-	return { pack: pack.id, content, ...(resolved ? { source: resolved } : {}) };
-}
-
-/** Mirrors addDeck's two-seat defaults, but keyed off the OWNER's seat. */
-function deckDefaults(seat: number, index: number, isFaceUp: boolean) {
-	const x = 8.5 + (isFaceUp ? 2 : 0) + index * 2.5;
-	return seat % 2 === 1
-		? { position: [x, 0.4, -4.7] as Vec3, rotation: [0, Math.PI, 0] as Vec3 }
-		: { position: [x, 0.4, 4.5] as Vec3, rotation: [0, 0, 0] as Vec3 };
-}
-
 /**
- * Spawn one of a pack's decks. Instantiates cards into the gameStore in an
- * explicit order — order and shuffling are the CALLER's choice (tbps v2
- * placements preserve authored order; shuffling is opt-in), never implied.
+ * Spawn one of a pack's decks. Shapes the deck with `composePackDeck` — the
+ * same pure builder a headless scenario composition uses — and writes it to
+ * the gameStore.
+ *
+ * Written directly rather than via `addDeck`: that helper derives id, seat and
+ * position from the LOCAL player, but a pack spawns for an arbitrary owner (a
+ * `seatN` placeholder in the scenario editor). One update per deck keeps each
+ * card list under the server's websocket read limit.
  */
 export function spawnPackDeck(pack: GamePackDef, deck: PackDeckDef, opts: SpawnDeckOptions = {}) {
 	const ownerId = opts.ownerId ?? gameActions.getMyId();
 	if (!ownerId) return console.error('Cannot spawn a deck without an owner id');
 
-	const defs = opts.order
-		? opts.order
-				.map((code) => {
-					const def = deck.cards.find((c) => c.code === code);
-					if (!def)
-						console.warn(`[spawnPackDeck] unknown card code '${code}' in ${pack.id}/${deck.slot}`);
-					return def;
-				})
-				.filter((def) => def !== undefined)
-		: deck.cards;
-
-	let cards = defs.map((card) => ({
-		id: `card:${ownerId}:${deck.slot}-${card.code}`,
-		faceImageUrl: card.face,
-		backImageUrl: deck.back
-	}));
-	if (opts.shuffle) cards = gameActions.shuffleCards(cards) ?? cards;
-
-	const isFaceUp = opts.isFaceUp ?? deck.isFaceUp ?? false;
-	const defaults = deckDefaults(ownerSeat(ownerId), opts.index ?? 0, isFaceUp);
-	const deckId = `deck:${ownerId}:${deck.slot}`;
-	// written directly rather than via addDeck: that helper derives id, seat and
-	// position from the LOCAL player, but a pack spawns for an arbitrary owner
-	// (a `seatN` placeholder in the scenario editor). One update per deck keeps
-	// each card list under the server's websocket read limit.
-	gameStore.updateState({
-		decks: {
-			[deckId]: {
-				id: deckId,
-				isFaceUp,
-				deckBackImageUrl: deck.back,
-				cards,
-				position: opts.position ?? defaults.position,
-				rotation: opts.rotation ?? defaults.rotation,
-				packOrigin: origin(pack, deck.slot, opts.source),
-				...(opts.shuffleOnLoad !== undefined ? { shuffleOnLoad: opts.shuffleOnLoad } : {})
-			}
-		}
+	const composed = composePackDeck(pack, deck, {
+		...opts,
+		ownerId,
+		seat: ownerSeat(ownerId),
+		source: packSource(pack, opts.source),
+		// one shuffle implementation on the client, whatever spawned the deck
+		shuffleWith: (cards) => gameActions.shuffleCards(cards)
 	});
+	gameStore.updateState({ decks: { [composed.id]: composed.deck } });
 }
 
 export type SpawnDeckSpreadOptions = SpawnPackOptions & {
@@ -179,45 +148,20 @@ export type SpawnPieceOptions = SpawnPackOptions & {
 	state?: number;
 };
 
-/**
- * A pack bag item and a live bag item are the same shape by design — the pack
- * says what is in the bag, the store holds that same list as the bag's state.
- * Cloned per spawn so two bags from one pack never share an array.
- */
-function bagContents(def: PackPieceDef): BagItem[] {
-	return (def.contents ?? []).map((item) => ({ ...item }) as BagItem);
-}
-
 /** Spawn one of a pack's pieces (by index into `pack.pieces`). */
 export function spawnPackPiece(pack: GamePackDef, index: number, opts: SpawnPieceOptions = {}) {
-	const def = pack.pieces?.[index];
-	if (!def) return console.error(`[spawnPackPiece] ${pack.id} has no piece[${index}]`);
 	const ownerId = opts.ownerId ?? gameActions.getMyId();
 	if (!ownerId) return console.error('Cannot spawn a piece without an owner id');
 
-	// pack piece positions are authored for seat 0; mirror for the far side
-	const m = ownerSeat(ownerId) % 2 === 1 ? -1 : 1;
-	gameActions.addPiece(def.kind, {
+	const composed = composePackPiece(pack, index, {
+		...opts,
 		ownerId,
-		name: def.name,
-		color: def.color,
-		// states[0] IS the base face (see PackPieceDef.states), so a piece that
-		// declares states never falls back to imageUrl
-		imageUrl: def.states?.length ? def.states[0].face : def.imageUrl,
-		states: def.states,
-		// the placement's choice wins over the pack's own default
-		state: opts.state ?? def.state,
-		radius: def.radius,
-		maxValue: def.maxValue,
-		sides: def.sides,
-		value: opts.value,
-		...(def.kind === 'bag'
-			? { contents: bagContents(def), drawMode: def.drawMode, infinite: def.infinite }
-			: {}),
-		position: opts.position ?? [def.position[0] * m, PIECE_REST_Y, def.position[1] * m],
-		rotation: opts.rotation,
-		packOrigin: origin(pack, String(index), opts.source)
+		seat: ownerSeat(ownerId),
+		source: packSource(pack, opts.source),
+		taken: new Set(Object.keys(get(gameStore)?.pieces ?? {}))
 	});
+	if (!composed) return;
+	gameStore.updateState({ pieces: { [composed.id]: composed.piece } });
 }
 
 export type SpawnOverlayOptions = SpawnPackOptions & {
@@ -228,23 +172,12 @@ export type SpawnOverlayOptions = SpawnPackOptions & {
 
 /** Spawn one of a pack's overlays (by index into `pack.overlays`). */
 export function spawnPackOverlay(pack: GamePackDef, index: number, opts: SpawnOverlayOptions = {}) {
-	const def = pack.overlays?.[index];
-	if (!def) return console.error(`[spawnPackOverlay] ${pack.id} has no overlay[${index}]`);
-	// overlays are table-scoped (claimSeat never renames them) — key by pack
-	const id = `overlay:${pack.id}:${index}`;
-	gameStore.updateState({
-		overlays: {
-			[id]: {
-				id,
-				imageUrl: def.imageUrl,
-				ratio: def.ratio,
-				scale: opts.scale ?? def.scale,
-				position: opts.position ?? [0, 0.255, 0],
-				rotation: opts.rotation ?? [0, 0, 0],
-				packOrigin: origin(pack, String(index), opts.source)
-			}
-		}
+	const composed = composePackOverlay(pack, index, {
+		...opts,
+		source: packSource(pack, opts.source)
 	});
+	if (!composed) return;
+	gameStore.updateState({ overlays: { [composed.id]: composed.overlay } });
 }
 
 /**

--- a/src/lib/scenario/scenario.ts
+++ b/src/lib/scenario/scenario.ts
@@ -15,8 +15,15 @@ import { gameStore } from '$lib/store/game/gameStore.svelte';
 import { gameActions } from '$lib/store/game/actions';
 import { snapPointIds } from '$lib/store/game/actions/snap';
 import { prewarmGameState } from '$lib/packs/prewarm-state';
-import { spawnPackDeck, spawnPackPiece, spawnPackOverlay } from '$lib/packs/spawn';
-import type { GamePackDef } from '$lib/packs/types';
+import { packSource } from '$lib/packs/spawn';
+import {
+	composePlayers,
+	composeScenario,
+	composeSnapPoints,
+	isSeatPlaceholder,
+	placedCount,
+	seatPlaceholderId
+} from '$lib/compose/scenario';
 import type { DeckDTO, GameDTO, OverlayDTO, PackOrigin, PieceDTO } from '$lib/store/game/types';
 import {
 	parseScenarioFile,
@@ -35,8 +42,9 @@ const STORAGE_KEY = 'scenarios:v1';
 export type SeatIndex = 0 | 1 | 2 | 3;
 type StateUpdate = Parameters<typeof gameStore.updateState>[0];
 
-export const seatPlaceholderId = (seat: SeatIndex) => `seat${seat}`;
-export const isSeatPlaceholder = (id: string) => /^seat[0-3]$/.test(id);
+// the seat-placeholder grammar itself lives with the composer, since composing
+// a table headlessly is the other thing that has to agree about it
+export { isSeatPlaceholder, seatPlaceholderId };
 
 export type { Scenario };
 
@@ -152,16 +160,6 @@ function collectSnapPoints(s: Partial<GameDTO> | undefined | null): SnapPoint[] 
 		});
 }
 
-/** The store patch that puts a file's snap points on the table, ids reassigned. */
-function snapPointUpdate(snapPoints: SnapPoint[] | undefined): Record<string, unknown> {
-	const update: Record<string, unknown> = {};
-	(snapPoints ?? []).forEach((point, index) => {
-		const id = `snap:${index}`;
-		update[id] = { id, ...point };
-	});
-	return update;
-}
-
 /**
  * Snapshot the current table as a scenario. Real players (and their trays)
  * are NOT saved — only placeholder seat players survive, so the preset stays
@@ -259,68 +257,33 @@ function clearUpdate(): Record<string, Record<string, unknown>> {
 }
 
 /**
- * v1/v0 load: the scenario's `state` snapshot *is* the table. Synchronous, so
- * legacy scenarios apply in the same tick they always did.
+ * Write a composed table into the store.
+ *
+ * Everything but the decks rides one patch — `base` lets a caller send the
+ * clear along with it, so a legacy load still lands in a single message the
+ * way it always did. Each deck then goes in its own: decks carry full card
+ * lists, and one all-in-one update can blow past the server's websocket read
+ * limit (server/lobby/server.go), after which the server silently drops the
+ * whole seed and joiners sync stale state.
  */
-function applyStateSnapshot(state: Partial<GameDTO> | undefined, snapPoints?: SnapPoint[]) {
-	const update = clearUpdate();
-	Object.assign(update.snapPoints, snapPointUpdate(snapPoints));
-	// small payloads ride with the clear — direct assignment overwrites the
-	// null for reused keys. `state` goes last, since it is the override layer:
-	// a `state.snapPoints` entry beats the top-level array rather than being
-	// silently dropped, same as it does for every other collection.
+function applyComposed(
+	composed: Partial<GameDTO>,
+	base: Record<string, Record<string, unknown>> = {}
+) {
+	const update: Record<string, Record<string, unknown>> = {
+		cards: {},
+		pieces: {},
+		overlays: {},
+		snapPoints: {},
+		players: {},
+		...base
+	};
 	for (const collection of ['cards', 'pieces', 'overlays', 'snapPoints', 'players'] as const) {
-		for (const [key, value] of Object.entries(state?.[collection] ?? {})) {
-			update[collection][key] = value;
-		}
+		Object.assign(update[collection], composed[collection] ?? {});
 	}
 	gameStore.updateState(update as StateUpdate);
-	// each deck in its own message
-	for (const [key, value] of Object.entries(state?.decks ?? {})) {
+	for (const [key, value] of Object.entries(composed.decks ?? {})) {
 		gameStore.updateState({ decks: { [key]: value } } as StateUpdate);
-	}
-}
-
-/** Spawn one placement's content from its resolved pack. */
-function applyPlacement(placement: PackPlacement, pack: GamePackDef, source?: string) {
-	const ownerId = placement.seat !== undefined ? seatPlaceholderId(placement.seat) : undefined;
-	const common = { ownerId, source };
-
-	if (placement.kind === 'deck') {
-		const deck = pack.decks.find((d) => d.slot === placement.content);
-		if (!deck)
-			return console.error(`[scenario] pack '${pack.id}' has no deck '${placement.content}'`);
-		spawnPackDeck(pack, deck, {
-			...common,
-			position: placement.position,
-			rotation: placement.rotation,
-			isFaceUp: placement.isFaceUp,
-			// authored order is the default; shuffling is an explicit opt-in
-			order: placement.order,
-			shuffle: placement.shuffleOnLoad === true,
-			shuffleOnLoad: placement.shuffleOnLoad
-		});
-		return;
-	}
-	const index = Number(placement.content);
-	if (!Number.isInteger(index)) {
-		return console.error(`[scenario] ${placement.kind} placement content must be an index`);
-	}
-	if (placement.kind === 'piece') {
-		spawnPackPiece(pack, index, {
-			...common,
-			position: placement.position,
-			rotation: placement.rotation,
-			value: placement.value,
-			state: placement.state
-		});
-	} else {
-		spawnPackOverlay(pack, index, {
-			...common,
-			position: placement.position,
-			rotation: placement.rotation,
-			scale: placement.scale
-		});
 	}
 }
 
@@ -336,36 +299,31 @@ export type ApplyReport = {
  * /play (ws-wrapped) it broadcasts to the whole lobby. Real player entries are
  * kept. Sheet refs are prewarmed locally, then a re-render sweep repaints.
  *
- * Sent as several messages, one per deck: decks carry full card lists, and a
- * single all-in-one update can blow past the server's websocket read limit —
- * the server then silently drops the whole seed and joiners sync stale state.
+ * A thin wrapper over `compose/scenario.ts`: resolve the pack refs, compose
+ * the table, push it. Everything about *what* the table is — entity ids, seat
+ * placeholders, card order, `packOrigin` stamps — lives in the composer, which
+ * is why a bun script can lay out the same table without a browser
+ * (`scripts/seed-lobby.ts`).
  *
- * v2 scenarios resolve their pack refs first, spawn each placement from the
- * pack, then lay the `state` overrides on top. v1/v0 take the original
- * synchronous snapshot path untouched. Never rejects — an un-awaited call
- * (the /play seed button) can't produce an unhandled rejection; resolution
- * failures come back in the report.
+ * v1/v0 files compose too: with no placements the composition is just their
+ * `state` snapshot, so they still apply synchronously in one tick as they
+ * always did. Never rejects — an un-awaited call (the /play seed button) can't
+ * produce an unhandled rejection; resolution failures come back in the report.
  */
 export async function applyScenario(scenario: Scenario): Promise<ApplyReport> {
 	if (scenarioVersion(scenario) === 1) {
-		applyStateSnapshot(scenario.state, scenario.snapPoints);
+		applyComposed(composeScenario(scenario, new Map()), clearUpdate());
 		prewarmGameState(scenario.state, () => gameStore.updateStateSilently({}));
 		return { version: 1, placed: 0, failedPacks: [] };
 	}
 
-	const placements = scenario.placements ?? [];
-	// clear, and seat the placeholders the placements need, before any await
+	// clear, and seat the placeholders the placements need, before any await:
+	// the table must not sit on the old scenario while packs are being fetched,
+	// and a `?seat=N` joiner can start waiting on its placeholder immediately
 	const update = clearUpdate();
-	for (const [key, value] of Object.entries(scenario.state?.players ?? {})) {
-		update.players[key] = value;
-	}
-	for (const seat of new Set(placements.map((p) => p.seat))) {
-		if (seat === undefined) continue;
-		const id = seatPlaceholderId(seat);
-		update.players[id] ??= { id, seat, joinTimestamp: 0, tray: {}, metadata: {} };
-	}
+	Object.assign(update.players, composePlayers(scenario));
 	// snap points are pure data — they ride with the clear, no pack to resolve
-	Object.assign(update.snapPoints, snapPointUpdate(scenario.snapPoints));
+	Object.assign(update.snapPoints, composeSnapPoints(scenario.snapPoints));
 	gameStore.updateState(update as StateUpdate);
 
 	const { packs, failed } = await resolvePacks(scenario.packs ?? []);
@@ -373,37 +331,21 @@ export async function applyScenario(scenario: Scenario): Promise<ApplyReport> {
 		console.error(`[scenario] could not resolve pack '${ref.id}': ${reason}`);
 	}
 
-	const sources = new Map((scenario.packs ?? []).map((ref) => [ref.id, ref.source]));
-	let placed = 0;
-	for (const placement of placements) {
-		const pack = packs.get(placement.pack);
-		if (!pack) continue; // already reported via failedPacks
-		applyPlacement(placement, pack, sources.get(placement.pack));
-		placed += 1;
-	}
-
-	// overrides land on top of pack-spawned content (ad-hoc pieces, tweaks)
-	const overrides: Record<string, Record<string, unknown>> = {
-		cards: {},
-		pieces: {},
-		overlays: {},
-		snapPoints: {}
-	};
-	for (const collection of ['cards', 'pieces', 'overlays', 'snapPoints'] as const) {
-		for (const [key, value] of Object.entries(scenario.state?.[collection] ?? {})) {
-			overrides[collection][key] = value;
-		}
-	}
-	gameStore.updateState(overrides as StateUpdate);
-	for (const [key, value] of Object.entries(scenario.state?.decks ?? {})) {
-		gameStore.updateState({ decks: { [key]: value } } as StateUpdate);
-	}
+	applyComposed(
+		composeScenario(scenario, packs, {
+			// the browser knows one thing the composer's default doesn't: which
+			// packs live in this device's library, and so re-resolve as 'local'
+			sourceOf: (ref, pack) => packSource(pack, ref.source),
+			// one shuffle implementation on the client, wherever it is called from
+			shuffleWith: (cards) => gameActions.shuffleCards(cards)
+		})
+	);
 
 	// pack content only exists in the store now, so prewarm the result
 	prewarmGameState(get(gameStore), () => gameStore.updateStateSilently({}));
 	return {
 		version: 2,
-		placed,
+		placed: placedCount(scenario, packs),
 		failedPacks: failed.map(({ ref, reason }) => ({ id: ref.id, reason }))
 	};
 }

--- a/src/lib/store/game/actions/piece.ts
+++ b/src/lib/store/game/actions/piece.ts
@@ -2,21 +2,18 @@ import { get } from 'svelte/store';
 import { gameActions } from '.';
 import { gameStore } from '../gameStore.svelte';
 import { degrees } from '$lib/utils/constants-rotation';
+import { DIE_SIDES_DEFAULT, PIECE_REST_Y } from '$lib/utils/constants-pieces';
 import {
-	COUNTER_MAX_DEFAULT,
-	DIE_SIDES_DEFAULT,
-	PIECE_RADIUS,
-	PIECE_REST_Y
-} from '$lib/utils/constants-pieces';
-import type {
-	BagDrawMode,
-	BagItem,
-	DieSides,
-	GameDTO,
-	PackOrigin,
-	PieceKind,
-	PieceStateDTO
-} from '../types';
+	composePiece,
+	currentPieceState,
+	nextPieceId as nextFreePieceId,
+	slugify,
+	type PieceProps
+} from '$lib/compose/piece';
+import type { GameDTO, PieceKind } from '../types';
+
+// re-exported so `slugify` keeps its historical home here (bag.ts imports it)
+export { slugify };
 
 export type PieceState = NonNullable<NonNullable<GameDTO['pieces']>[string]>;
 
@@ -39,19 +36,6 @@ function incrementCounter(pieceId: string, delta: number) {
 	const max = piece.maxValue ?? 99;
 	const value = Math.min(max, Math.max(0, (piece.value ?? max) + delta));
 	return gameStore.updateState({ pieces: { [pieceId]: { value } } });
-}
-
-/**
- * The state index a piece is actually showing: clamped into its `states`
- * array, and 0 for a piece that has none. Shared by the renderer and the
- * cycle/select verbs so they can never disagree about what is on the table.
- */
-function currentPieceState(
-	piece: { states?: PieceStateDTO[]; state?: number } | null | undefined
-): number {
-	const count = piece?.states?.length ?? 0;
-	if (count === 0) return 0;
-	return Math.min(Math.max(Math.trunc(piece?.state ?? 0), 0), count - 1);
 }
 
 /**
@@ -115,22 +99,6 @@ const SPAWN_SPACING = 1.6;
 const SPAWN_PER_ROW = 8;
 const SPAWN_EDGE_Z = 4.5;
 
-const KIND_LABEL: Record<PieceKind, string> = {
-	token: 'Token',
-	pawn: 'Pawn',
-	counter: 'Counter',
-	die: 'Die',
-	bag: 'Bag'
-};
-
-export function slugify(name: string, fallback: string): string {
-	const slug = name
-		.toLowerCase()
-		.replace(/[^a-z0-9]+/g, '-')
-		.replace(/^-+|-+$/g, '');
-	return slug || fallback;
-}
-
 /**
  * Seat of the acting owner. The scenario editor owns entities with
  * `seat0`…`seat3` placeholders (see scenario.ts) — matched here by shape
@@ -162,40 +130,13 @@ function spawnPosition(seat: number, index: number): [number, number, number] {
 
 /** ids are `kind:owner:slug` (claimSeat renames the owner segment) — `-n` disambiguates repeats */
 export function nextPieceId(ownerId: string, slug: string): string {
-	const pieces = get(gameStore)?.pieces ?? {};
-	let n = 0;
-	while (pieces[`piece:${ownerId}:${slug}-${n}`]) n++;
-	return `piece:${ownerId}:${slug}-${n}`;
+	return nextFreePieceId(new Set(Object.keys(get(gameStore)?.pieces ?? {})), ownerId, slug);
 }
 
-export type AddPieceOptions = {
-	name?: string;
-	color?: string;
-	/** resolved like card faces — a plain https:// url works */
-	imageUrl?: string;
-	/** multi-state pieces: every face, `states[0]` being the base one */
-	states?: PieceStateDTO[];
-	/** which of `states` to spawn showing (default 0) */
-	state?: number;
-	radius?: number;
-	/** counters only; the piece spawns full (`value = maxValue`) unless `value` says otherwise */
-	maxValue?: number;
-	/** counters only; restores a saved count (scenario loads) instead of spawning full */
-	value?: number;
-	/** dice only; how many faces (defaults to a d6) */
-	sides?: DieSides;
+export type AddPieceOptions = PieceProps & {
 	/** defaults to the local player; the scenario editor passes placeholder seat ids */
 	ownerId?: string;
 	position?: [number, number, number];
-	rotation?: [number, number, number];
-	/** bags only; the hidden pool a draw pulls from */
-	contents?: BagItem[];
-	/** bags only; defaults to 'random' */
-	drawMode?: BagDrawMode;
-	/** bags only; a draw clones instead of removing */
-	infinite?: boolean;
-	/** set when the piece comes from a pack, so a v2 scenario can reference it */
-	packOrigin?: PackOrigin;
 };
 
 /**
@@ -203,6 +144,10 @@ export type AddPieceOptions = {
  * piece and something else in ONE state patch (a bag draw writes the drawn
  * item and the bag's shrunken contents together) doesn't have to broadcast two.
  * Returns null when there is no owner to spawn for.
+ *
+ * The piece itself is shaped by `compose/piece.ts` — everything this adds is
+ * the two answers only a live table can give: who is acting, and where the
+ * next spawn fans out to. That is what a headless composer supplies for itself.
  */
 export function buildPiece(
 	kind: PieceKind,
@@ -214,52 +159,14 @@ export function buildPiece(
 		return null;
 	}
 
-	const sides = opts.sides ?? DIE_SIDES_DEFAULT;
-	// dice name themselves after their shape: `d20`, not `Die` — the shape is
-	// the only thing that distinguishes one from another at a glance
-	const name = opts.name?.trim() || (kind === 'die' ? `d${sides}` : KIND_LABEL[kind]);
-	const id = nextPieceId(ownerId, slugify(name, kind));
-	const owned = Object.keys(get(gameStore)?.pieces ?? {}).filter((key) =>
-		key.includes(`:${ownerId}:`)
-	).length;
-
-	const piece: Partial<PieceState> = {
-		kind,
-		name,
-		position: opts.position ?? spawnPosition(ownerSeat(ownerId), owned),
-		rotation: opts.rotation ?? [0, 0, 0],
-		radius: opts.radius ?? PIECE_RADIUS[kind]
-	};
-	if (opts.color) piece.color = opts.color;
-	if (opts.imageUrl) piece.imageUrl = opts.imageUrl;
-	// Not on a die or a bag: a die's faces are geometry and a bag's is a pouch,
-	// so states would be dead weight on the wire and would hand either a state
-	// menu it has no use for. Dropped here rather than rejected at parse time so
-	// a pack that carries them anyway still imports — it just spawns plain.
-	if (kind !== 'die' && kind !== 'bag' && opts.states?.length) {
-		piece.states = opts.states.map((s) => ({ face: s.face, ...(s.name ? { name: s.name } : {}) }));
-		piece.state = currentPieceState({ states: opts.states, state: opts.state });
-	}
-	if (opts.packOrigin) piece.packOrigin = opts.packOrigin;
-	if (kind === 'counter') {
-		const maxValue = opts.maxValue ?? COUNTER_MAX_DEFAULT;
-		piece.maxValue = maxValue;
-		piece.value = opts.value ?? maxValue;
-	}
-	if (kind === 'die') {
-		piece.sides = sides;
-		piece.value = opts.value ?? 1;
-		// a fresh die has never been rolled, so nothing animates on spawn
-		piece.rollSeq = 0;
-	}
-	if (kind === 'bag') {
-		// always written, even empty: a bag with no `contents` key would leave
-		// nothing for a return-to-bag patch to merge into
-		piece.contents = opts.contents ?? [];
-		piece.drawMode = opts.drawMode ?? 'random';
-		if (opts.infinite) piece.infinite = true;
-	}
-	return { id, piece };
+	const taken = new Set(Object.keys(get(gameStore)?.pieces ?? {}));
+	const owned = [...taken].filter((key) => key.includes(`:${ownerId}:`)).length;
+	return composePiece(kind, {
+		...opts,
+		ownerId,
+		taken,
+		position: opts.position ?? spawnPosition(ownerSeat(ownerId), owned)
+	});
 }
 
 /**

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -8,23 +8,8 @@
 	import { disconnect } from '$lib/websocket/connection';
 	import CreatePane from './CreatePane.svelte';
 	import { togglePreviewLayout } from './preview-layout';
+	import { isTyping } from '$lib/hotkeys/is-typing';
 	import toast from 'svelte-french-toast';
-
-	/**
-	 * Authoring is mostly typing — codes, names, image URLs — and the editor's
-	 * gestures are bare letters. A key that lands in a pane field is text, not
-	 * a table command.
-	 */
-	function isTyping(target: EventTarget | null) {
-		const element = target as HTMLElement | null;
-		if (!element) return false;
-		return (
-			element.tagName === 'INPUT' ||
-			element.tagName === 'TEXTAREA' ||
-			element.tagName === 'SELECT' ||
-			element.isContentEditable
-		);
-	}
 
 	// same gestures as /setup, so a card pulled out of a preview pile can be
 	// inspected (flip) and arranged without leaving the editor

--- a/src/routes/play/+page.svelte
+++ b/src/routes/play/+page.svelte
@@ -12,6 +12,7 @@
 	import { ungroupHoveredDeck } from '$lib/hotkeys/ungroup';
 	import { shuffleHoveredDeck } from '$lib/hotkeys/shuffle';
 	import { cycleHoveredPieceState } from '$lib/hotkeys/piece-state';
+	import { isTyping } from '$lib/hotkeys/is-typing';
 	import PieceStateMenu from '$lib/PieceStateMenu.svelte';
 	import { startAutoClaim } from '$lib/scenario/autoClaim';
 	import Pane from './Pane.svelte';
@@ -25,6 +26,9 @@
 	import toast from 'svelte-french-toast';
 
 	function handleKeyDown(event: KeyboardEvent) {
+		// a key typed into a pane field is text, not a table command — and this
+		// table is synced, so a stray G would group a pile for everyone
+		if (isTyping(event.target)) return;
 		// hover-target routing: a hovered deck takes the key, otherwise it
 		// falls through to the hovered-card behavior
 		const hoveredDeck = get(dragStore).isDeckHovered;
@@ -53,6 +57,7 @@
 	}
 
 	function handleKeyUp(event: KeyboardEvent) {
+		if (isTyping(event.target)) return;
 		if (event.code === 'Space') cameraTransforms.togglePreviewHud(false);
 	}
 

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -10,11 +10,14 @@
 	import { ungroupHoveredDeck } from '$lib/hotkeys/ungroup';
 	import { shuffleHoveredDeck } from '$lib/hotkeys/shuffle';
 	import { cycleHoveredPieceState } from '$lib/hotkeys/piece-state';
+	import { isTyping } from '$lib/hotkeys/is-typing';
 	import { disconnect } from '$lib/websocket/connection';
 	import PieceStateMenu from '$lib/PieceStateMenu.svelte';
 	import SetupPane from './SetupPane.svelte';
 
 	function handleKeyDown(event: KeyboardEvent) {
+		// a key typed into a pane field is text, not a table command
+		if (isTyping(event.target)) return;
 		// hover-target routing: a hovered deck takes the key, otherwise it
 		// falls through to the hovered-card behavior (mirrors /play)
 		const hoveredDeck = get(dragStore).isDeckHovered;
@@ -43,6 +46,7 @@
 	}
 
 	function handleKeyUp(event: KeyboardEvent) {
+		if (isTyping(event.target)) return;
 		if (event.code === 'Space') cameraTransforms.togglePreviewHud(false);
 	}
 


### PR DESCRIPTION
Task: tableplace-112
Closes #112

Part of epic #107 — targets `feat/pane-ux`, not `main`.

## The bug

Every table route binds bare letters as gestures on `svelte:window`, and tweakpane does not stop propagation — so a key typed into a pane field also reached the route handler.

Naming a scenario `flag-game` on /setup, with the pointer resting over the table, flipped a card (`F`), grouped a loose pile into a deck (`G`) and reset the camera (`C`). On /play the same applied to the Server/Lobby fields and the overlay image URL — and /play is **synced**, so a stray `G` mutated the shared table for everyone. `Space` was the near-miss: typing one toggled the preview HUD.

/create already guarded this, with a comment explaining exactly why. /setup and /play went straight from `handleKeyDown` into `gameActions`.

## The fix

Lift `isTyping()` out of `create/+page.svelte` into `$lib/hotkeys/is-typing.ts`, next to the other shared gestures (`ungroup.ts`, `shuffle.ts`, `piece-state.ts`), and call it first in **both** `handleKeyDown` and `handleKeyUp` on all three routes. Keyup matters too: Space's preview HUD is a latch, so a guarded press with an unguarded release would leave the HUD stuck on.

The helper is unchanged from /create's proven version — `INPUT`, `TEXTAREA`, `SELECT`, `isContentEditable` — except that the result is now coerced to a boolean, since `isContentEditable` is undefined outside a real browser.

## Tests

`src/lib/hotkeys/__tests__/is-typing.test.ts` — behavioural tests for the helper, plus a source-level guard asserting each route imports the shared helper (and defines no local copy) and bails out before reading `event.code` in both handlers. The source-level half is the part that regresses: the helper existing is no use if a handler forgets to call it, and the failure is silent — the hotkey simply also fires.

## Verified

- `bun run test` — 730 passed, 60 files.
- `bun run build` — clean. `prettier --check` + `eslint` clean on every touched file (repo-wide `bun run lint` is red at baseline on 28 unrelated files).
- In the browser on /setup: spawned a 52-card deck, focused the scenario **Name** field, moved the pointer onto the deck and typed `flag c game st rx`. The field read exactly that; the deck stayed face-down, `face up` stayed unchecked, the camera did not reset and the spaces did not toggle the preview HUD. The same sequence against an unpatched dev server flipped the deck face-up mid-word — the bug reproducing. With focus back on the body, hovering the deck and pressing `F` still flips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqkNHxGbBMddseDCJZ86wJ