### PR TITLE
tableplace-108: /create — one inline tabbed pane + a real start state

### DIFF
--- a/src/lib/TableScene.svelte
+++ b/src/lib/TableScene.svelte
@@ -50,7 +50,7 @@
 
 	const isDragging = $derived($dragStore.isDragging !== null);
 	let mesh: THREE.Mesh | undefined = $state();
-	const { camera } = useThrelte();
+	const { camera, canvas } = useThrelte();
 
 	let intersectionPoint: THREE.Vector3 | null = $state(null);
 
@@ -94,9 +94,16 @@
 				}
 			}
 
+			// normalized against the CANVAS, not the viewport: /create insets the
+			// canvas behind a fixed editor column, and window coordinates would put
+			// the ray a third of a screen off — nothing on the table would be
+			// clickable where it is drawn. Identical arithmetic when the canvas
+			// fills the window, which is what /play and /setup do.
 			state.pointer.update((p) => {
-				p.x = (event.clientX / window.innerWidth) * 2 - 1;
-				p.y = -(event.clientY / window.innerHeight) * 2 + 1;
+				const rect = canvas.getBoundingClientRect();
+				if (!rect.width || !rect.height) return p;
+				p.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+				p.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
 				return p;
 			});
 

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -50,14 +50,31 @@
 
 <svelte:window on:keydown={handleKeyDown} on:keyup|preventDefault={handleKeyUp} />
 
-<CreatePane />
-
-<div class="h-screen w-screen overflow-clip bg-gray-700">
-	<Canvas toneMapping={ACESFilmicToneMapping}>
-		{#if isReady}
-			<!-- no hand in the pack editor: a card dropped into the tray lands in
-			     state no pack can represent, and survives every preview respawn -->
-			<TableScene hand={false} />
-		{/if}
-	</Canvas>
+<!--
+	Two columns, not a table with windows floating over it: the editor's pane is
+	laid out `inline` inside a fixed-width scrolling column, so it can neither
+	overlap itself nor cover the felt the preview draws on (#108). Everything
+	right of the column belongs to the table, which is what makes the spread
+	fully visible and clickable.
+-->
+<div class="flex h-screen w-screen overflow-clip bg-gray-700">
+	<!--
+		368 = the pane's 352 plus a stable 16px scrollbar gutter: reserved whether
+		or not the column is scrolling, so the pane's right edge is never under
+		the scrollbar and never shifts when a folder opens.
+	-->
+	<div
+		class="w-[368px] shrink-0 overflow-y-auto border-r border-black/50 bg-neutral-900 [scrollbar-gutter:stable]"
+	>
+		<CreatePane />
+	</div>
+	<div class="min-w-0 flex-1">
+		<Canvas toneMapping={ACESFilmicToneMapping}>
+			{#if isReady}
+				<!-- no hand in the pack editor: a card dropped into the tray lands in
+				     state no pack can represent, and survives every preview respawn -->
+				<TableScene hand={false} />
+			{/if}
+		</Canvas>
+	</div>
 </div>

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -8,6 +8,7 @@
 	import { disconnect } from '$lib/websocket/connection';
 	import CreatePane from './CreatePane.svelte';
 	import { togglePreviewLayout } from './preview-layout';
+	import { EDITOR_GUTTER, editorPaneWidth } from './column';
 	import { isTyping } from '$lib/hotkeys/is-typing';
 	import toast from 'svelte-french-toast';
 
@@ -59,12 +60,15 @@
 -->
 <div class="flex h-screen w-screen overflow-clip bg-gray-700">
 	<!--
-		368 = the pane's 352 plus a stable 16px scrollbar gutter: reserved whether
-		or not the column is scrolling, so the pane's right edge is never under
-		the scrollbar and never shifts when a folder opens.
+		The pane's width plus a stable scrollbar gutter, so the pane's right edge
+		is never under the scrollbar and never shifts when a folder opens. A flex
+		COLUMN, because what is under the pane matters: the tabs are short (File
+		is four rows) and the viewport is not, so CreatePane's footer takes the
+		remainder with `mt-auto` rather than leaving a dark slab.
 	-->
 	<div
-		class="w-[368px] shrink-0 overflow-y-auto border-r border-black/50 bg-neutral-900 [scrollbar-gutter:stable]"
+		class="flex shrink-0 flex-col overflow-y-auto border-r border-black/50 bg-neutral-900 [scrollbar-gutter:stable]"
+		style="width: {$editorPaneWidth + EDITOR_GUTTER}px"
 	>
 		<CreatePane />
 	</div>

--- a/src/routes/create/BulkSheet.svelte
+++ b/src/routes/create/BulkSheet.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Button, Element, Folder, Pane, Stepper, Text, Textarea } from 'svelte-tweakpane-ui';
+	import { Button, Element, Folder, Stepper, Text, Textarea } from 'svelte-tweakpane-ui';
 	import toast from 'svelte-french-toast';
 	import { sliceCell } from '$lib/tts/slice';
 	import type { PackCardDef } from '$lib/packs/types';
@@ -16,6 +16,10 @@
 
 	/**
 	 * Bulk add: define a sheet's grid once, then add every cell as a card.
+	 *
+	 * A folder in whatever pane mounts it, not a pane of its own: it is opened
+	 * from the Cards tab next to the deck the batch lands in, and it used to sit
+	 * open at x=680 over the felt before anyone had a sheet URL (#108).
 	 *
 	 * The pane owns the grid it loaded (`loaded`), not the fields above it —
 	 * retyping the columns doesn't silently re-index the thumbnails you're
@@ -122,15 +126,7 @@
 	}
 </script>
 
-<Pane
-	position="draggable"
-	title="Bulk add from sheet"
-	expanded={true}
-	y={8}
-	x={680}
-	width={340}
-	localStoreId="create-pane-bulk"
->
+<Folder title="Bulk add from sheet" expanded={true}>
 	<Text label="Sheet URL" bind:value={url} />
 	<Stepper label="Columns" bind:value={cols} min={1} step={1} />
 	<Stepper label="Rows" bind:value={rows} min={1} step={1} />
@@ -222,4 +218,4 @@
 			on:click={addCards}
 		/>
 	{/if}
-</Pane>
+</Folder>

--- a/src/routes/create/CreatePane.svelte
+++ b/src/routes/create/CreatePane.svelte
@@ -15,8 +15,7 @@
 		Stepper,
 		TabGroup,
 		TabPage,
-		Text,
-		Textarea
+		Text
 	} from 'svelte-tweakpane-ui';
 	import { tick } from 'svelte';
 	import { get } from 'svelte/store';
@@ -37,6 +36,7 @@
 	} from '$lib/packs/spread';
 	import { onCardPick } from '$lib/store/cardPick';
 	import { previewLayout, type PreviewLayout } from './preview-layout';
+	import { editorPaneWidth } from './column';
 	import { CARD_BACK_DEFAULT, STANDARD_52 } from '$lib/packs/standard52';
 	import { parsePackFile, serializePackFile, packFileName } from '$lib/packs/file';
 	import {
@@ -77,9 +77,6 @@
 
 	/** Everything the /create preview spawns is owned by this placeholder id */
 	const PREVIEW_OWNER = 'preview';
-
-	/** the editor column's width — the pane fills it exactly (see +page.svelte) */
-	const PANE_WIDTH = 352;
 
 	const HELP_TEXT =
 		'A pack is a content library: decks (piles of cards), pieces (including bags — a ' +
@@ -152,6 +149,20 @@
 	const bagItem = $derived(piece?.kind === 'bag' ? piece.contents[bagItemIndex] : undefined);
 	const overlayIndex = $derived(Math.min(overlayCursor, Math.max(0, overlays.length - 1)));
 	const overlay = $derived(overlays[overlayIndex]);
+
+	/**
+	 * What is in the draft, for the column's footer. Counts only — the marker
+	 * for whether it is SAVED is #110's, and belongs in the pane's title.
+	 */
+	const cardCount = $derived(decks.reduce((total, d) => total + d.cards.length, 0));
+	const packSummary = $derived(
+		[
+			`${decks.length} deck${decks.length === 1 ? '' : 's'}`,
+			`${cardCount} card${cardCount === 1 ? '' : 's'}`,
+			...(pieces.length ? [`${pieces.length} piece${pieces.length === 1 ? '' : 's'}`] : []),
+			...(overlays.length ? [`${overlays.length} overlay${overlays.length === 1 ? '' : 's'}`] : [])
+		].join(' · ')
+	);
 
 	const deckOptions = $derived(
 		decks.length
@@ -755,7 +766,7 @@
 		tree: replacing one blade with another tears a tweakpane pane down, while
 		mounting and unmounting a whole <Pane> is plain Svelte and safe.
 	-->
-	<Pane position="inline" title="new pack" userExpandable={false} width={PANE_WIDTH}>
+	<Pane position="inline" title="new pack" userExpandable={false} width={$editorPaneWidth}>
 		<Element>
 			<div class="p-2 font-sans text-[11px] leading-snug text-white/60">
 				A pack is a content library — decks, pieces and board overlays — authored here and kept in
@@ -779,7 +790,7 @@
 		{/if}
 	</Pane>
 {:else}
-	<Pane position="inline" title="pack editor" userExpandable={false} width={PANE_WIDTH}>
+	<Pane position="inline" title="pack editor" userExpandable={false} width={$editorPaneWidth}>
 		<!--
 			The breadcrumb row: what is selected, above the tabs, always mounted so
 			#109 can fill it in with `pack › deck › card N of M` without touching the
@@ -802,11 +813,6 @@
 				/>
 				<Separator />
 				<Button title="Close pack" on:click={closePack} />
-				<!-- collapsed by default, and the home for the per-control help #115
-				     rewrites: the editor should open on controls, not on prose -->
-				<Folder title="How this works" expanded={false}>
-					<Textarea disabled rows={7} value={HELP_TEXT} />
-				</Folder>
 			</TabPage>
 
 			<TabPage title="Cards">
@@ -869,9 +875,6 @@
 
 				<Separator />
 				<Button title="Flip cards on table (F)" on:click={flipTableCards} />
-				<Folder title="How this works" expanded={false}>
-					<Textarea disabled rows={9} value={TABLE_HELP_TEXT} />
-				</Folder>
 			</TabPage>
 
 			<TabPage title="Board">
@@ -1028,5 +1031,38 @@
 		</TabGroup>
 	</Pane>
 {/if}
+
+<!--
+	The column is viewport-tall; a tab's controls are not — File is four rows —
+	so everything under the pane used to be a flat slab down to the bottom edge.
+	It carries the two things the editor otherwise has nowhere to say: how any of
+	this works, and what is in the draft.
+
+	Plain markup rather than a tweakpane folder: this is the home #115 rewrites
+	into per-control help, and prose in a disabled Textarea can neither wrap to
+	the column nor be selected and copied. It takes the remainder (`flex-1`) and
+	centres in it, so what is left over on a tall screen is two small margins
+	rather than one dead half — `safe` centring, so a long tab still scrolls
+	from the top rather than centring its overflow out of reach.
+-->
+<section
+	class="flex flex-1 flex-col [justify-content:safe_center] border-t border-black/40 px-3 pt-2 pb-3 font-sans text-[11px] leading-relaxed text-white/45"
+>
+	<h2 class="mb-1 font-mono text-[10px] tracking-widest text-white/45 uppercase">How this works</h2>
+	<p class="mb-2">{HELP_TEXT}</p>
+	<p>{TABLE_HELP_TEXT}</p>
+</section>
+
+<!--
+	A status bar, and the reason the column has no dead bottom edge at any
+	height: `mt-auto` drops it to the foot of a short column, `sticky` keeps it
+	there while a long one scrolls behind it. Counts only — whether the draft is
+	SAVED is #110's marker, and belongs in the pane's title.
+-->
+<footer
+	class="sticky bottom-0 mt-auto border-t border-black/40 bg-neutral-900 px-3 py-1.5 font-mono text-[10px] tracking-wide text-white/65 uppercase"
+>
+	{pack ? packSummary : 'no pack open'}
+</footer>
 
 <FileDropZone onfile={handleDroppedFile} />

--- a/src/routes/create/CreatePane.svelte
+++ b/src/routes/create/CreatePane.svelte
@@ -2,14 +2,19 @@
 	import {
 		AutoValue,
 		Button,
+		ButtonGrid,
 		Checkbox,
 		Color,
 		Element,
+		File as FileBlade,
 		Folder,
 		List,
 		Pane,
 		Point,
+		Separator,
 		Stepper,
+		TabGroup,
+		TabPage,
 		Text,
 		Textarea
 	} from 'svelte-tweakpane-ui';
@@ -32,7 +37,7 @@
 	} from '$lib/packs/spread';
 	import { onCardPick } from '$lib/store/cardPick';
 	import { previewLayout, type PreviewLayout } from './preview-layout';
-	import { CARD_BACK_DEFAULT } from '$lib/packs/standard52';
+	import { CARD_BACK_DEFAULT, STANDARD_52 } from '$lib/packs/standard52';
 	import { parsePackFile, serializePackFile, packFileName } from '$lib/packs/file';
 	import {
 		listLibraryPacks,
@@ -73,6 +78,9 @@
 	/** Everything the /create preview spawns is owned by this placeholder id */
 	const PREVIEW_OWNER = 'preview';
 
+	/** the editor column's width — the pane fills it exactly (see +page.svelte) */
+	const PANE_WIDTH = 352;
+
 	const HELP_TEXT =
 		'A pack is a content library: decks (piles of cards), pieces (including bags — a ' +
 		'hidden pool you draw from at the table), and board overlays. ' +
@@ -91,25 +99,30 @@
 		'edit respawns the preview from the draft. C recentres the camera, hold Space ' +
 		'for a close-up. The durable start face is the deck’s "Face up" box.';
 
-	function emptyPack(): EditorPack {
+	/**
+	 * A new pack: one empty deck, no cards. The deck is not fabricated content —
+	 * a card has nowhere to go without one, and "Add card" would only toast "add
+	 * a deck first". Everything else (the pack's name, its first card) is the
+	 * author's to type; the old starter pack shipped an Ace of Spades nobody
+	 * asked for, so the first gesture in the editor was deleting it (#108).
+	 */
+	function newPack(): EditorPack {
 		return withEditorDefaults({
 			id: 'my-pack',
 			name: 'My Pack',
 			scope: 'player',
-			decks: [
-				{
-					slot: 'main',
-					name: 'Draw Pile',
-					back: CARD_BACK_DEFAULT,
-					cards: [{ code: 'AS', name: 'Ace of Spades', face: 'gen:std52/AS' }]
-				}
-			]
+			decks: [{ slot: 'main', name: 'Draw Pile', back: CARD_BACK_DEFAULT, cards: [] }]
 		});
 	}
 
-	let pack: EditorPack = $state(emptyPack());
+	/**
+	 * `null` until the author picks a starting point. There is no draft before
+	 * that: the start state is the first screen, not 39 controls on a pack that
+	 * fabricated itself.
+	 */
+	let pack = $state<EditorPack | null>(null);
 	/** the draft as a plain (non-proxy) object, cleaned of editing defaults */
-	const exportable = $derived(cleanForExport($state.snapshot(pack) as EditorPack));
+	const exportable = $derived(pack ? cleanForExport($state.snapshot(pack) as EditorPack) : null);
 
 	// ——— cursors (indexes into the draft's arrays, clamped as arrays shrink) ———
 	let deckCursor = $state(0);
@@ -118,12 +131,18 @@
 	let stateCursor = $state(0);
 	let overlayCursor = $state(0);
 
-	const deckIndex = $derived(Math.min(deckCursor, Math.max(0, pack.decks.length - 1)));
-	const deck = $derived(pack.decks[deckIndex]);
+	// the draft's collections, empty while there is no draft — every cursor and
+	// option list below reads them rather than re-testing `pack` for null
+	const decks = $derived(pack?.decks ?? []);
+	const pieces = $derived(pack?.pieces ?? []);
+	const overlays = $derived(pack?.overlays ?? []);
+
+	const deckIndex = $derived(Math.min(deckCursor, Math.max(0, decks.length - 1)));
+	const deck = $derived(decks[deckIndex]);
 	const cardIndex = $derived(Math.min(cardCursor, Math.max(0, (deck?.cards.length ?? 0) - 1)));
 	const card = $derived(deck?.cards[cardIndex]);
-	const pieceIndex = $derived(Math.min(pieceCursor, Math.max(0, pack.pieces.length - 1)));
-	const piece = $derived(pack.pieces[pieceIndex]);
+	const pieceIndex = $derived(Math.min(pieceCursor, Math.max(0, pieces.length - 1)));
+	const piece = $derived(pieces[pieceIndex]);
 	const stateIndex = $derived(Math.min(stateCursor, Math.max(0, (piece?.states.length ?? 0) - 1)));
 	const pieceState = $derived(piece?.states[stateIndex]);
 	let bagItemCursor = $state(0);
@@ -131,12 +150,12 @@
 		Math.min(bagItemCursor, Math.max(0, (piece?.contents.length ?? 0) - 1))
 	);
 	const bagItem = $derived(piece?.kind === 'bag' ? piece.contents[bagItemIndex] : undefined);
-	const overlayIndex = $derived(Math.min(overlayCursor, Math.max(0, pack.overlays.length - 1)));
-	const overlay = $derived(pack.overlays[overlayIndex]);
+	const overlayIndex = $derived(Math.min(overlayCursor, Math.max(0, overlays.length - 1)));
+	const overlay = $derived(overlays[overlayIndex]);
 
 	const deckOptions = $derived(
-		pack.decks.length
-			? Object.fromEntries(pack.decks.map((d, i) => [`${i}: ${d.slot}`, i]))
+		decks.length
+			? Object.fromEntries(decks.map((d, i) => [`${i}: ${d.slot}`, i]))
 			: { '(no decks)': 0 }
 	);
 	const cardOptions = $derived(
@@ -145,13 +164,13 @@
 			: { '(no cards)': 0 }
 	);
 	const pieceOptions = $derived(
-		pack.pieces.length
-			? Object.fromEntries(pack.pieces.map((p, i) => [`${i}: ${p.kind} ${p.name}`, i]))
+		pieces.length
+			? Object.fromEntries(pieces.map((p, i) => [`${i}: ${p.kind} ${p.name}`, i]))
 			: { '(no pieces)': 0 }
 	);
 	const overlayOptions = $derived(
-		pack.overlays.length
-			? Object.fromEntries(pack.overlays.map((_, i) => [`overlay ${i}`, i]))
+		overlays.length
+			? Object.fromEntries(overlays.map((_, i) => [`overlay ${i}`, i]))
 			: { '(no overlays)': 0 }
 	);
 	const stateOptions = $derived(
@@ -172,6 +191,7 @@
 
 	// ——— structure edits ———
 	function addDeck() {
+		if (!pack) return;
 		pack.decks.push({
 			slot: `deck-${pack.decks.length}`,
 			name: `Deck ${pack.decks.length + 1}`,
@@ -183,7 +203,7 @@
 	}
 
 	function removeDeck() {
-		if (!deck) return;
+		if (!pack || !deck) return;
 		pack.decks.splice(deckIndex, 1);
 		deckCursor = Math.max(0, deckIndex - 1);
 	}
@@ -260,6 +280,7 @@
 	let newBagItemKind: PackBagItemDef['kind'] = $state('token');
 
 	function addPiece() {
+		if (!pack) return;
 		pack.pieces.push({
 			kind: newPieceKind,
 			name: newPieceKind,
@@ -279,7 +300,7 @@
 	}
 
 	function removePiece() {
-		if (!piece) return;
+		if (!pack || !piece) return;
 		pack.pieces.splice(pieceIndex, 1);
 		pieceCursor = Math.max(0, pieceIndex - 1);
 	}
@@ -350,12 +371,13 @@
 	}
 
 	function addOverlay() {
+		if (!pack) return;
 		pack.overlays.push({ imageUrl: '', ratio: 1, scale: 12 });
 		overlayCursor = pack.overlays.length - 1;
 	}
 
 	function removeOverlay() {
-		if (!overlay) return;
+		if (!pack || !overlay) return;
 		pack.overlays.splice(overlayIndex, 1);
 		overlayCursor = Math.max(0, overlayIndex - 1);
 	}
@@ -410,6 +432,18 @@
 	let spreadCursors: Record<string, { deck: number; card: number }> = {};
 
 	/**
+	 * Where Deck mode puts a pile. A pack does not author deck positions, so a
+	 * spawned deck lands on its owner's own deck spot — the near-right corner of
+	 * the felt, which the editor's shot (narrower than a full-width table, with
+	 * the column beside it) cuts in half. The preview centres its piles instead,
+	 * the same reasoning as the spread's fixed origin: what is being previewed
+	 * has to be in the frame.
+	 */
+	function previewPilePosition(index: number, count: number): [number, number, number] {
+		return [(index - (count - 1) / 2) * 3, 0.4, 0];
+	}
+
+	/**
 	 * `selected` is the piece cursor and the state cursor: the selected piece
 	 * previews on the state you are editing, so "preview each state" is just
 	 * picking it in the list. Every other piece shows its base face.
@@ -418,6 +452,7 @@
 		clearPreview();
 		spreadCursors = {};
 		const preview = exportable;
+		if (!preview) return;
 
 		// carpeting the felt with tiles too small to read is worse than a pile,
 		// so past the cap the spread refuses and the CONTROL follows the table —
@@ -449,11 +484,15 @@
 			// spawned per entity rather than through spawnPack: the preview must show
 			// the deck in AUTHORED order (spawnPack shuffles facedown decks), and an
 			// empty deck mid-authoring has no cards[0] for Deck.svelte to render
-			preview.decks
-				.filter((deck) => deck.cards.length > 0)
-				.forEach((deck, index) =>
-					spawnPackDeck(preview, deck, { ownerId: PREVIEW_OWNER, index, shuffle: false })
-				);
+			const piles = preview.decks.filter((deck) => deck.cards.length > 0);
+			piles.forEach((deck, index) =>
+				spawnPackDeck(preview, deck, {
+					ownerId: PREVIEW_OWNER,
+					index,
+					shuffle: false,
+					position: previewPilePosition(index, piles.length)
+				})
+			);
 		}
 
 		preview.pieces?.forEach((_, index) =>
@@ -475,6 +514,9 @@
 		// read the cursors here too: selecting a piece's state must re-lay the
 		// preview, which is how the table shows the state being edited
 		const selected = { piece: pieceIndex, state: stateIndex };
+		// no draft, no preview: closing a pack leaves an empty table, not the
+		// last thing that was on it
+		if (!pack) return clearPreview();
 		const timer = setTimeout(() => respawnPreview(mode, selected), 300);
 		return () => clearTimeout(timer);
 	});
@@ -511,8 +553,8 @@
 	 * work, and every action that REPLACES the draft asks first — losing an hour
 	 * of authoring to a mis-click was the old behavior (#93).
 	 */
-	let savedSnapshot = $state(JSON.stringify(cleanForExport(emptyPack())));
-	const isDirty = $derived(JSON.stringify(exportable) !== savedSnapshot);
+	let savedSnapshot = $state('');
+	const isDirty = $derived(!!exportable && JSON.stringify(exportable) !== savedSnapshot);
 
 	function markSaved(current = exportable) {
 		savedSnapshot = JSON.stringify(current);
@@ -520,16 +562,40 @@
 
 	function confirmDiscard(what: string): boolean {
 		if (!isDirty) return true;
-		return window.confirm(`Discard your unsaved edits to "${pack.name}" and ${what}?`);
+		return window.confirm(`Discard your unsaved edits to "${pack?.name}" and ${what}?`);
 	}
 
 	/** Put a pack in the editor: it becomes the draft, and it is now saved. */
 	function editPack(next: GamePackDef) {
 		pack = withEditorDefaults(next);
+		// every cursor points into the OLD draft's arrays
+		deckCursor = cardCursor = pieceCursor = stateCursor = overlayCursor = bagItemCursor = 0;
 		markSaved(cleanForExport($state.snapshot(pack) as EditorPack));
 	}
 
+	// ——— the start state: the first screen, before there is anything to edit ———
+
+	const START_BUTTONS = ['New empty pack', 'Standard 52 template'];
+
+	function handleStart(label: string) {
+		if (label === START_BUTTONS[1]) {
+			// withEditorDefaults deep-copies decks and cards, so editing the draft
+			// can't reach back into the built-in pack
+			editPack(STANDARD_52);
+			return toast(`Started from ${STANDARD_52.name}`);
+		}
+		editPack(newPack());
+	}
+
+	/** Back to the start state — the only way to reach it again after step 1. */
+	function closePack() {
+		if (!confirmDiscard('start over')) return;
+		pack = null;
+		savedSnapshot = '';
+	}
+
 	function handleSavePack() {
+		if (!pack || !exportable) return;
 		if (!pack.id.trim()) return toast.error('Give the pack an id first');
 		saveLibraryPack(exportable);
 		markSaved();
@@ -554,32 +620,6 @@
 	}
 
 	// ——— open / export ———
-	let ttsFileInput: HTMLInputElement | undefined = $state();
-	let packFileInput: HTMLInputElement | undefined = $state();
-
-	async function handleOpenTts(event: Event) {
-		const input = event.target as HTMLInputElement;
-		const file = input.files?.[0];
-		if (!file) return;
-		try {
-			const parsed = parseSavedObject(JSON.parse(await file.text()));
-			const imported = ttsToPack(parsed);
-			// converted, not authored: it is unsaved work until "Save to library"
-			if (!confirmDiscard(`open "${file.name}"`)) return;
-			pack = withEditorDefaults(imported);
-			const skipped = parsed.skipped.length ? ` (skipped: ${parsed.skipped.join(', ')})` : '';
-			toast(
-				`Opened ${imported.decks.length} deck(s), ${imported.pieces?.length ?? 0} piece(s)${skipped}`,
-				{ duration: 5000 }
-			);
-		} catch (error) {
-			toast.error(
-				`Could not open the file: ${error instanceof Error ? error.message : 'invalid file'}`
-			);
-		} finally {
-			input.value = '';
-		}
-	}
 
 	/**
 	 * Opening a pack file both files it in the library and edits it — one
@@ -598,12 +638,48 @@
 		return true;
 	}
 
-	async function handleOpenPack(event: Event) {
-		const input = event.target as HTMLInputElement;
-		const file = input.files?.[0];
+	/**
+	 * The one file entry point, behind the `File` blade's drop zone (start state
+	 * and the File tab both mount one). A TTS save and a pack file are both
+	 * `.json`, so the routing is by content — `ObjectStates` is TTS's root
+	 * array — rather than by which button you found.
+	 */
+	async function handleOpenFile(picked: unknown) {
+		// `unknown` in, cast here: the blade's own types name its value `File`,
+		// which inside that module resolves to the component class rather than
+		// the DOM type. What it hands over is a DOM File.
+		const file = picked as globalThis.File | undefined;
 		if (!file) return;
+		let json: unknown;
 		try {
-			const imported = parsePackFile(await file.text());
+			json = JSON.parse(await file.text());
+		} catch {
+			return toast.error(`${file.name} is not JSON`);
+		}
+
+		if (json && typeof json === 'object' && 'ObjectStates' in json) {
+			try {
+				const parsed = parseSavedObject(json);
+				const imported = ttsToPack(parsed);
+				// converted, not authored: it is unsaved work until "Save to library"
+				if (!confirmDiscard(`open "${file.name}"`)) return;
+				pack = withEditorDefaults(imported);
+				markSaved(cleanForExport($state.snapshot(pack) as EditorPack));
+				const skipped = parsed.skipped.length ? ` (skipped: ${parsed.skipped.join(', ')})` : '';
+				toast(
+					`Opened ${imported.decks.length} deck(s), ${imported.pieces?.length ?? 0} piece(s)${skipped}`,
+					{ duration: 5000 }
+				);
+			} catch (error) {
+				toast.error(
+					`Could not open the TTS save: ${error instanceof Error ? error.message : 'invalid file'}`
+				);
+			}
+			return;
+		}
+
+		try {
+			const imported = parsePackFile(JSON.stringify(json));
 			toast(
 				openPack(imported)
 					? `Opened pack: ${imported.name} — saved to your pack library`
@@ -614,8 +690,6 @@
 			toast.error(
 				`Could not open the pack: ${error instanceof Error ? error.message : 'invalid file'}`
 			);
-		} finally {
-			input.value = '';
 		}
 	}
 
@@ -625,7 +699,7 @@
 	 * anything else spawned here would vanish on the next keystroke. A scenario
 	 * is saved for /setup and /play but not applied, for the same reason.
 	 */
-	async function handleDroppedFile(file: File) {
+	async function handleDroppedFile(file: globalThis.File) {
 		await openDroppedFile(file, {
 			onPack: (imported) => {
 				// the library keeps it either way — only the editor swap is refusable
@@ -636,6 +710,7 @@
 	}
 
 	function handleExport() {
+		if (!exportable) return;
 		try {
 			const text = serializePackFile(exportable);
 			// validate before download with the same parser importers use, so a
@@ -652,254 +727,306 @@
 			toast.error(`Export failed: ${error instanceof Error ? error.message : 'invalid pack'}`);
 		}
 	}
+
+	/**
+	 * The bulk sheet is a mode, not a fixture: it took prime screen space before
+	 * anyone had a sheet URL, and its only tie to the selected deck was the text
+	 * on its last button (#108). Opened from the Cards tab, next to the deck the
+	 * batch lands in.
+	 */
+	let sheetOpen = $state(false);
 </script>
 
 <!--
-	Four panes, not one: each carries a single concern and remembers its own
-	position and collapse state (`localStoreId`). Authoring a card — the thing
-	this editor is for — is one pane deep, and Save / Export never hides under
-	another section.
+	ONE pane, laid out `inline` so the editor column owns it: the four draggable
+	panes this replaces had hard-coded positions but content-driven heights, so
+	they overlapped each other and covered the felt the preview draws on (#108).
+	Inline means overlap is structurally impossible and clipping becomes the
+	column's scroll.
+
+	Tabs, not folders: only one concern's controls are on screen at a time, and
+	Save / Export stay one tab click away rather than buried under a section
+	(#71 §4).
 -->
 
-<Pane
-	position="draggable"
-	title="Pack (local)"
-	expanded={true}
-	y={8}
-	x={8}
-	width={320}
-	localStoreId="create-pane-pack"
->
-	<Text label="Id" bind:value={pack.id} />
-	<Text label="Name" bind:value={pack.name} />
-	<List
-		label="Scope"
-		bind:value={pack.scope}
-		options={{ 'player (one seat brings it)': 'player', 'table (the shared game)': 'table' }}
-	/>
-	<Textarea disabled rows={5} value={HELP_TEXT} />
-</Pane>
+{#if !pack}
+	<!--
+		Step 1. A separate pane rather than an {#if} inside the editor's blade
+		tree: replacing one blade with another tears a tweakpane pane down, while
+		mounting and unmounting a whole <Pane> is plain Svelte and safe.
+	-->
+	<Pane position="inline" title="new pack" userExpandable={false} width={PANE_WIDTH}>
+		<Element>
+			<div class="p-2 font-sans text-[11px] leading-snug text-white/60">
+				A pack is a content library — decks, pieces and board overlays — authored here and kept in
+				this browser. Start one, or open a file you were sent.
+			</div>
+		</Element>
+		<ButtonGrid buttons={START_BUTTONS} on:click={(e) => handleStart(e.detail.label)} />
+		<Separator />
+		<!-- a real drop target, replacing the hidden <input type=file> + Button
+		     hack: a pack file and a TTS save are both .json, and both land here -->
+		<FileBlade
+			label="Open"
+			extensions={['.json']}
+			rows={3}
+			on:change={(e) => handleOpenFile(e.detail.value)}
+		/>
+		{#if libraryIds.length}
+			<Separator />
+			<List label="Continue" bind:value={selectedPack} options={libraryOptions} />
+			<Button title="Open selected" on:click={handleEditSelected} />
+		{/if}
+	</Pane>
+{:else}
+	<Pane position="inline" title="pack editor" userExpandable={false} width={PANE_WIDTH}>
+		<!--
+			The breadcrumb row: what is selected, above the tabs, always mounted so
+			#109 can fill it in with `pack › deck › card N of M` without touching the
+			blade tree's shape.
+		-->
+		<Element>
+			<div class="truncate p-1 font-sans text-[11px] text-white/70">
+				{pack.name || pack.id}
+			</div>
+		</Element>
 
-<Pane
-	position="draggable"
-	title="Decks & Cards"
-	expanded={true}
-	y={190}
-	x={8}
-	width={320}
-	localStoreId="create-pane-decks"
->
-	<!-- first row, above the cursors: it decides what the whole table shows -->
-	<List
-		label="Layout"
-		bind:value={$previewLayout}
-		options={{ 'Deck — a pile per deck': 'deck', 'Spread — cards side by side (L)': 'spread' }}
-	/>
-	<List label="Deck" bind:value={deckCursor} options={deckOptions} />
-	<Button title="Add deck" on:click={addDeck} />
-	{#if deck}
-		<Folder title="Deck ({deck.slot})" expanded={true}>
-			<Text label="Slot" bind:value={deck.slot} />
-			<Text label="Name" bind:value={deck.name} />
-			<Checkbox label="Face up" bind:value={deck.isFaceUp} />
-			<Button title="Remove deck" on:click={removeDeck} />
-			<!-- keyed on the cursor: a fresh editor for whichever deck is selected -->
-			{#key deckIndex}
-				<FaceRef title="Deck back" value={deck.back} onchange={(ref) => (deck.back = ref)} />
-			{/key}
-		</Folder>
+		<TabGroup>
+			<TabPage title="Pack">
+				<Text label="Id" bind:value={pack.id} />
+				<Text label="Name" bind:value={pack.name} />
+				<List
+					label="Scope"
+					bind:value={pack.scope}
+					options={{ 'player (one seat brings it)': 'player', 'table (the shared game)': 'table' }}
+				/>
+				<Separator />
+				<Button title="Close pack" on:click={closePack} />
+				<!-- collapsed by default, and the home for the per-control help #115
+				     rewrites: the editor should open on controls, not on prose -->
+				<Folder title="How this works" expanded={false}>
+					<Textarea disabled rows={7} value={HELP_TEXT} />
+				</Folder>
+			</TabPage>
 
-		<Folder title="Cards ({deck.cards.length})" expanded={true}>
-			<List label="Card" bind:value={cardCursor} options={cardOptions} />
-			<Button title="Add card" on:click={addCard} />
-			{#if card}
-				<Text label="Code" bind:value={card.code} />
-				<Text label="Name" bind:value={card.name} />
-				<Button title="Duplicate card" on:click={duplicateCard} />
-				<Button title="Remove card" on:click={removeCard} />
-				{#key `${deckIndex}:${cardIndex}`}
-					<FaceRef title="Card face" value={card.face} onchange={(ref) => (card.face = ref)} />
-				{/key}
-			{/if}
-		</Folder>
-	{/if}
-
-	<Button title="Flip cards on table (F)" on:click={flipTableCards} />
-	<Textarea disabled rows={8} value={TABLE_HELP_TEXT} />
-</Pane>
-
-<Pane
-	position="draggable"
-	title="Board"
-	expanded={true}
-	y={8}
-	x={344}
-	width={320}
-	localStoreId="create-pane-board"
->
-	<Folder title="Pieces ({pack.pieces.length})" expanded={false}>
-		<List label="New kind" bind:value={newPieceKind} options={kindOptions} />
-		<Button title="Add {newPieceKind}" on:click={addPiece} />
-		{#if piece}
-			<List label="Piece" bind:value={pieceCursor} options={pieceOptions} />
-			<Text label="Name" bind:value={piece.name} />
-			<Color label="Color" bind:value={piece.color} />
-			{#if piece.kind === 'token' || piece.kind === 'bag'}
-				<Text label="Image URL" bind:value={piece.imageUrl} />
-			{/if}
-			<!--
-				States: the TTS `States` analog — one piece, several faces, cycled in
-				play with X or picked from its right-click menu. State 1 is the BASE
-				face (it replaces "Image URL" on export), so adding the first one
-				copies the image rather than blanking the piece.
-			-->
-			<Folder title="States ({piece.states.length})" expanded={false}>
-				<Button title="Add state" on:click={addPieceState} />
-				{#if piece.states.length > 0}
-					<List label="State" bind:value={stateCursor} options={stateOptions} />
-				{/if}
-				{#if pieceState}
-					<Text label="State name" bind:value={pieceState.name} />
-					<Checkbox
-						label="Spawns on this state"
-						value={piece.state === stateIndex}
-						on:change={(e) => (piece.state = e.detail.value ? stateIndex : 0)}
-					/>
-					<Button title="Remove state" on:click={removePieceState} />
-					<!-- keyed on the cursors: a fresh editor for whichever state is selected -->
-					{#key `${pieceIndex}:${stateIndex}`}
-						<FaceRef
-							title="State face"
-							value={pieceState.face}
-							onchange={(ref) => (pieceState.face = ref)}
-						/>
+			<TabPage title="Cards">
+				<!-- first row, above the cursors: it decides what the whole table shows -->
+				<List
+					label="Layout"
+					bind:value={$previewLayout}
+					options={{
+						'Deck — a pile per deck': 'deck',
+						'Spread — cards side by side (L)': 'spread'
+					}}
+				/>
+				<Separator />
+				<!-- pick, then create/destroy, THEN the selected deck's fields: the
+				     verbs used to sit between the selector and the fields they were
+				     nothing to do with (#108) -->
+				<List label="Deck" bind:value={deckCursor} options={deckOptions} />
+				<ButtonGrid
+					buttons={['Add deck', 'Remove deck']}
+					on:click={(e) => (e.detail.index === 0 ? addDeck() : removeDeck())}
+				/>
+				{#if deck}
+					<Text label="Slot" bind:value={deck.slot} />
+					<Text label="Name" bind:value={deck.name} />
+					<Checkbox label="Face up" bind:value={deck.isFaceUp} />
+					<!-- keyed on the cursor: a fresh editor for whichever deck is selected -->
+					{#key deckIndex}
+						<FaceRef title="Deck back" value={deck.back} onchange={(ref) => (deck.back = ref)} />
 					{/key}
+
+					<Separator />
+					<List label="Card" bind:value={cardCursor} options={cardOptions} />
+					<ButtonGrid
+						columns={3}
+						buttons={['Add card', 'Duplicate card', 'Remove card']}
+						on:click={(e) =>
+							e.detail.index === 0
+								? addCard()
+								: e.detail.index === 1
+									? duplicateCard()
+									: removeCard()}
+					/>
+					{#if card}
+						<Text label="Code" bind:value={card.code} />
+						<Text label="Name" bind:value={card.name} />
+						{#key `${deckIndex}:${cardIndex}`}
+							<FaceRef title="Card face" value={card.face} onchange={(ref) => (card.face = ref)} />
+						{/key}
+					{/if}
+
+					<Separator />
+					<Button
+						title={sheetOpen ? 'Close the sheet adder' : 'Add cards from a sheet…'}
+						on:click={() => (sheetOpen = !sheetOpen)}
+					/>
+					{#if sheetOpen}
+						<BulkSheet deckSlot={deck.slot} takenCodes={[...takenCodes]} onadd={addBulkCards} />
+					{/if}
 				{/if}
-			</Folder>
-			<AutoValue label="Radius" bind:value={piece.radius} />
-			{#if piece.kind === 'counter'}
-				<AutoValue label="Max value" bind:value={piece.maxValue} />
-			{/if}
-			{#if piece.kind === 'die'}
-				<List label="Sides" bind:value={piece.sides} options={sidesOptions} />
-			{/if}
-			{#if piece.kind === 'bag'}
-				<List label="Draw order" bind:value={piece.drawMode} options={drawModeOptions} />
-				<Checkbox label="Infinite" bind:value={piece.infinite} />
-				<Folder title="Bag contents ({piece.contents.length})" expanded={true}>
-					<List label="New item" bind:value={newBagItemKind} options={bagItemKindOptions} />
-					<Button title="Add {newBagItemKind} to bag" on:click={addBagItem} />
-					{#if bagItem}
-						<List label="Item" bind:value={bagItemCursor} options={bagItemOptions} />
-						<!-- one {#if} per field rather than a card/piece if-else pair: an
-						     {#if} that REPLACES a tweakpane blade tears the whole pane
-						     down (see BulkSheet.svelte), while adding and removing is safe -->
-						{#if bagItem.kind === 'card'}
-							<Text label="Code" bind:value={bagItem.code} />
+
+				<Separator />
+				<Button title="Flip cards on table (F)" on:click={flipTableCards} />
+				<Folder title="How this works" expanded={false}>
+					<Textarea disabled rows={9} value={TABLE_HELP_TEXT} />
+				</Folder>
+			</TabPage>
+
+			<TabPage title="Board">
+				<!-- one line while the board is empty, so a pack of cards never has to
+				     read past controls for things it does not have -->
+				<Element>
+					<div class="p-1 font-sans text-[11px] text-white/50">
+						Pieces {pack.pieces.length} · Overlays {pack.overlays.length}{pack.pieces.length +
+							pack.overlays.length ===
+						0
+							? ' — nothing on the board yet'
+							: ''}
+					</div>
+				</Element>
+				<Folder title="Pieces ({pack.pieces.length})" expanded={false}>
+					<List label="New kind" bind:value={newPieceKind} options={kindOptions} />
+					<Button title="Add {newPieceKind}" on:click={addPiece} />
+					{#if piece}
+						<Separator />
+						<List label="Piece" bind:value={pieceCursor} options={pieceOptions} />
+						<Text label="Name" bind:value={piece.name} />
+						<Color label="Color" bind:value={piece.color} />
+						{#if piece.kind === 'token' || piece.kind === 'bag'}
+							<Text label="Image URL" bind:value={piece.imageUrl} />
 						{/if}
-						<Text label="Item name" bind:value={bagItem.name} />
-						{#if bagItem.kind !== 'card'}
-							<Color label="Item color" bind:value={bagItem.color} />
-						{/if}
-						{#if bagItem.kind !== 'card'}
-							<Text label="Item image" bind:value={bagItem.imageUrl} />
-						{/if}
-						{#if bagItem.kind === 'counter'}
-							<Stepper label="Item max" bind:value={bagItem.maxValue} step={1} />
-						{/if}
-						{#if bagItem.kind === 'card'}
-							<!-- keyed on the cursor, like the deck's card face: a fresh
-							     editor for whichever item is selected -->
-							{#key `${pieceIndex}:${bagItemIndex}`}
-								<FaceRef
-									title="Item face"
-									value={bagItem.face}
-									onchange={(ref) => (bagItem.face = ref)}
+						<!--
+							States: the TTS `States` analog — one piece, several faces, cycled in
+							play with X or picked from its right-click menu. State 1 is the BASE
+							face (it replaces "Image URL" on export), so adding the first one
+							copies the image rather than blanking the piece.
+						-->
+						<Folder title="States ({piece.states.length})" expanded={false}>
+							<Button title="Add state" on:click={addPieceState} />
+							{#if piece.states.length > 0}
+								<List label="State" bind:value={stateCursor} options={stateOptions} />
+							{/if}
+							{#if pieceState}
+								<Text label="State name" bind:value={pieceState.name} />
+								<Checkbox
+									label="Spawns on this state"
+									value={piece.state === stateIndex}
+									on:change={(e) => (piece.state = e.detail.value ? stateIndex : 0)}
 								/>
-							{/key}
+								<Button title="Remove state" on:click={removePieceState} />
+								<!-- keyed on the cursors: a fresh editor for whichever state is selected -->
+								{#key `${pieceIndex}:${stateIndex}`}
+									<FaceRef
+										title="State face"
+										value={pieceState.face}
+										onchange={(ref) => (pieceState.face = ref)}
+									/>
+								{/key}
+							{/if}
+						</Folder>
+						<AutoValue label="Radius" bind:value={piece.radius} />
+						{#if piece.kind === 'counter'}
+							<AutoValue label="Max value" bind:value={piece.maxValue} />
 						{/if}
-						{#if bagItem.kind === 'card'}
-							<Text label="Item back" bind:value={bagItem.back} />
+						{#if piece.kind === 'die'}
+							<List label="Sides" bind:value={piece.sides} options={sidesOptions} />
 						{/if}
-						<Button title="Remove item" on:click={removeBagItem} />
+						{#if piece.kind === 'bag'}
+							<List label="Draw order" bind:value={piece.drawMode} options={drawModeOptions} />
+							<Checkbox label="Infinite" bind:value={piece.infinite} />
+							<Folder title="Bag contents ({piece.contents.length})" expanded={true}>
+								<List label="New item" bind:value={newBagItemKind} options={bagItemKindOptions} />
+								<Button title="Add {newBagItemKind} to bag" on:click={addBagItem} />
+								{#if bagItem}
+									<List label="Item" bind:value={bagItemCursor} options={bagItemOptions} />
+									<!-- one {#if} per field rather than a card/piece if-else pair: an
+									     {#if} that REPLACES a tweakpane blade tears the whole pane
+									     down (see BulkSheet.svelte), while adding and removing is safe -->
+									{#if bagItem.kind === 'card'}
+										<Text label="Code" bind:value={bagItem.code} />
+									{/if}
+									<Text label="Item name" bind:value={bagItem.name} />
+									{#if bagItem.kind !== 'card'}
+										<Color label="Item color" bind:value={bagItem.color} />
+									{/if}
+									{#if bagItem.kind !== 'card'}
+										<Text label="Item image" bind:value={bagItem.imageUrl} />
+									{/if}
+									{#if bagItem.kind === 'counter'}
+										<Stepper label="Item max" bind:value={bagItem.maxValue} step={1} />
+									{/if}
+									{#if bagItem.kind === 'card'}
+										<!-- keyed on the cursor, like the deck's card face: a fresh
+										     editor for whichever item is selected -->
+										{#key `${pieceIndex}:${bagItemIndex}`}
+											<FaceRef
+												title="Item face"
+												value={bagItem.face}
+												onchange={(ref) => (bagItem.face = ref)}
+											/>
+										{/key}
+									{/if}
+									{#if bagItem.kind === 'card'}
+										<Text label="Item back" bind:value={bagItem.back} />
+									{/if}
+									<Button title="Remove item" on:click={removeBagItem} />
+								{/if}
+							</Folder>
+						{/if}
+						<Point
+							label="Position"
+							value={{ x: piece.position[0], y: piece.position[1] }}
+							on:change={(e) => {
+								//@ts-expect-error: does exist
+								const x = e.detail.value?.x ?? piece.position[0];
+								//@ts-expect-error: does exist
+								const z = e.detail.value?.y ?? piece.position[1];
+								piece.position = [x, z];
+							}}
+						/>
+						<Button title="Remove piece" on:click={removePiece} />
 					{/if}
 				</Folder>
-			{/if}
-			<Point
-				label="Position"
-				value={{ x: piece.position[0], y: piece.position[1] }}
-				on:change={(e) => {
-					//@ts-expect-error: does exist
-					const x = e.detail.value?.x ?? piece.position[0];
-					//@ts-expect-error: does exist
-					const z = e.detail.value?.y ?? piece.position[1];
-					piece.position = [x, z];
-				}}
-			/>
-			<Button title="Remove piece" on:click={removePiece} />
-		{/if}
-	</Folder>
 
-	<Folder title="Overlays — boards/maps ({pack.overlays.length})" expanded={false}>
-		<Button title="Add overlay" on:click={addOverlay} />
-		{#if overlay}
-			<List label="Overlay" bind:value={overlayCursor} options={overlayOptions} />
-			<Text label="Image URL" bind:value={overlay.imageUrl} />
-			<AutoValue label="Ratio (w/h)" bind:value={overlay.ratio} />
-			<AutoValue label="Scale" bind:value={overlay.scale} />
-			<Button title="Remove overlay" on:click={removeOverlay} />
-		{/if}
-	</Folder>
-</Pane>
+				<Folder title="Overlays — boards/maps ({pack.overlays.length})" expanded={false}>
+					<Button title="Add overlay" on:click={addOverlay} />
+					{#if overlay}
+						<Separator />
+						<List label="Overlay" bind:value={overlayCursor} options={overlayOptions} />
+						<Text label="Image URL" bind:value={overlay.imageUrl} />
+						<AutoValue label="Ratio (w/h)" bind:value={overlay.ratio} />
+						<AutoValue label="Scale" bind:value={overlay.scale} />
+						<Button title="Remove overlay" on:click={removeOverlay} />
+					{/if}
+				</Folder>
+			</TabPage>
 
-<!--
-	`localStoreId` bumped to -v2 with the restructure: tweakpane persists collapse
-	state and position per id, so anyone who had once collapsed or dragged this
-	pane would never see the controls added to it (#93 §6).
--->
-<Pane
-	position="draggable"
-	title="Pack library / File"
-	expanded={true}
-	y={190}
-	x={344}
-	width={320}
-	localStoreId="create-pane-file-v2"
->
-	<Button title={isDirty ? 'Save to library •' : 'Save to library'} on:click={handleSavePack} />
-	<List label="Saved" bind:value={selectedPack} options={libraryOptions} />
-	<Button title="Edit selected" on:click={handleEditSelected} />
-	<Button title="Delete selected" on:click={handleDeleteSelected} />
-	<Button title="Export pack (.tbpp.json)" on:click={handleExport} />
-	<!-- top-level, not inside a folder: opening a file someone sent you is a
-	     starting move, and it was unfindable collapsed at the bottom (#93 §2) -->
-	<Button title="Open a pack (.tbpp.json)" on:click={() => packFileInput?.click()} />
-	<Folder title="Convert from another tool" expanded={false}>
-		<Button title="Open a TTS deck (.json) → pack" on:click={() => ttsFileInput?.click()} />
-	</Folder>
-	<Element>
-		<input
-			bind:this={ttsFileInput}
-			type="file"
-			accept=".json,application/json"
-			class="hidden"
-			onchange={handleOpenTts}
-		/>
-		<input
-			bind:this={packFileInput}
-			type="file"
-			accept=".json,application/json"
-			class="hidden"
-			onchange={handleOpenPack}
-		/>
-	</Element>
-</Pane>
+			<TabPage title="File">
+				<!-- top of the tab, never inside a folder: one tab click from anywhere
+				     in the editor to save or share what you have (#71 §4) -->
+				<Button
+					title={isDirty ? 'Save to library •' : 'Save to library'}
+					on:click={handleSavePack}
+				/>
+				<Button title="Export pack (.tbpp.json)" on:click={handleExport} />
+				<Separator />
+				<FileBlade
+					label="Open"
+					extensions={['.json']}
+					rows={3}
+					on:change={(e) => handleOpenFile(e.detail.value)}
+				/>
+				<Separator />
+				<List label="Saved" bind:value={selectedPack} options={libraryOptions} />
+				<ButtonGrid
+					buttons={['Edit selected', 'Delete selected']}
+					on:click={(e) => (e.detail.index === 0 ? handleEditSelected() : handleDeleteSelected())}
+				/>
+			</TabPage>
+		</TabGroup>
+	</Pane>
+{/if}
 
 <FileDropZone onfile={handleDroppedFile} />
-
-<!--
-	A fifth pane rather than a folder under "Decks & Cards": the grid it shows
-	is wider than a card's controls, and burying it would push Save / Export
-	back under a section (#71 §4).
--->
-<BulkSheet deckSlot={deck?.slot} takenCodes={[...takenCodes]} onadd={addBulkCards} />

--- a/src/routes/create/__tests__/CreatePane.test.ts
+++ b/src/routes/create/__tests__/CreatePane.test.ts
@@ -2,6 +2,10 @@
  * Drives the real tweakpane controls in jsdom rather than calling the editor's
  * functions directly — that's what proves the pane is wired to the draft and
  * that the draft reaches the table as a live preview.
+ *
+ * Every test starts where a first-time author does: the start state, with no
+ * draft at all. `startNew()` / `startWithCard()` press the same buttons a
+ * person would to get past it.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/svelte';
@@ -15,7 +19,7 @@ import { SPREAD_MAX_CARDS, SPREAD_PITCH_X } from '$lib/packs/spread';
 import { serializePackFile } from '$lib/packs/file';
 import type { GamePackDef } from '$lib/packs/types';
 
-// the draggable Pane observes its own size; jsdom has no ResizeObserver
+// the Pane observes its own size; jsdom has no ResizeObserver
 globalThis.ResizeObserver ??= class {
 	observe() {}
 	unobserve() {}
@@ -51,12 +55,13 @@ const listWith = (container: HTMLElement, option: string) =>
  * The card picker's options, which are labelled `<index>: <code>` — the deck
  * picker is labelled the same way and comes first, so this takes the second.
  */
-const cardCodes = (container: HTMLElement) => {
-	const select = [...container.querySelectorAll('select')].filter((s) =>
+const cardList = (container: HTMLElement) =>
+	[...container.querySelectorAll('select')].filter((s) =>
 		[...s.options].some((o) => /^\d+: /.test(o.textContent ?? ''))
 	)[1];
-	return [...(select?.options ?? [])].map((o) => (o.textContent ?? '').replace(/^\d+: /, ''));
-};
+
+const cardCodes = (container: HTMLElement) =>
+	[...(cardList(container)?.options ?? [])].map((o) => (o.textContent ?? '').replace(/^\d+: /, ''));
 
 /** every face-scheme picker on screen, in DOM order (deck back, then card face) */
 const schemePickers = (container: HTMLElement) =>
@@ -74,8 +79,25 @@ function type(element: HTMLInputElement, value: string) {
 	element.dispatchEvent(new Event('change', { bubbles: true }));
 }
 
+/** the editor as it first paints: the start state, no draft */
 async function mount() {
 	const { container } = render(CreatePane);
+	await settle();
+	return container;
+}
+
+/** past the start state: an empty pack with one empty deck */
+async function startNew() {
+	const container = await mount();
+	button(container, 'New empty pack')!.click();
+	await settle();
+	return container;
+}
+
+/** …and one card in it, so there is something to select and preview */
+async function startWithCard() {
+	const container = await startNew();
+	button(container, 'Add card')!.click();
 	await settle();
 	return container;
 }
@@ -87,18 +109,79 @@ describe('CreatePane', () => {
 		previewLayout.set('deck'); // module state: the last test's choice would leak
 	});
 
-	it('mounts with a starter pack and previews it on the table', async () => {
-		await mount();
+	describe('the start state', () => {
+		it('opens on a choice, not on a pack nobody authored', async () => {
+			const container = await mount();
+			await settlePreview();
+
+			expect(button(container, 'New empty pack')).toBeTruthy();
+			expect(button(container, 'Standard 52 template')).toBeTruthy();
+			// no draft means no controls for one, and nothing on the table
+			expect(button(container, 'Add card')).toBeUndefined();
+			expect(get(gameStore).decks ?? {}).toEqual({});
+		});
+
+		it('offers the saved drafts only once there are some', async () => {
+			expect(labels(await mount())).not.toContain('Continue');
+
+			const pack: GamePackDef = {
+				id: 'ember-duel',
+				name: 'Ember Duel',
+				scope: 'player',
+				decks: [{ slot: 'main', name: 'Main', back: CARD_BACK_DEFAULT, cards: [] }]
+			};
+			localStorage.setItem('packs:v1', JSON.stringify({ 'ember-duel': { updatedAt: 1, pack } }));
+
+			const container = await mount();
+			expect(labels(container)).toContain('Continue');
+			button(container, 'Open selected')!.click();
+			await settle();
+			expect(input(container, 'Id')!.value).toBe('ember-duel');
+		});
+
+		it('starts an empty pack with a deck to put cards in, and nothing else', async () => {
+			const container = await startNew();
+			await settlePreview();
+
+			expect(input(container, 'Id')!.value).toBe('my-pack');
+			// one deck to put cards in, and zero cards in it — an empty deck has no
+			// pile to preview, so the table stays clear until the author adds one
+			expect([...listWith(container, '0: main').options].map((o) => o.textContent)).toEqual([
+				'0: main'
+			]);
+			expect(listWith(container, '(no cards)')).toBeTruthy();
+			expect(get(gameStore).decks ?? {}).toEqual({});
+		});
+
+		it('starts from the standard 52 template when asked', async () => {
+			const container = await mount();
+			button(container, 'Standard 52 template')!.click();
+			await settlePreview();
+
+			expect(get(gameStore).decks?.['deck:preview:main'].cards).toHaveLength(52);
+		});
+
+		it('closes a pack back to the start state', async () => {
+			const container = await startNew();
+			button(container, 'Close pack')!.click();
+			await settlePreview();
+
+			expect(button(container, 'New empty pack')).toBeTruthy();
+			expect(get(gameStore).decks ?? {}).toEqual({});
+		});
+	});
+
+	it('previews the draft on the table as it is authored', async () => {
+		await startWithCard();
 		await settlePreview();
 
 		const decks = get(gameStore).decks ?? {};
 		expect(Object.keys(decks)).toEqual(['deck:preview:main']);
 		expect(decks['deck:preview:main'].cards).toHaveLength(1);
-		expect(decks['deck:preview:main'].cards?.[0].faceImageUrl).toBe('gen:std52/AS');
 	});
 
 	it('adding a deck and a card updates the live preview', async () => {
-		const container = await mount();
+		const container = await startWithCard();
 		await settlePreview();
 
 		button(container, 'Add deck')!.click();
@@ -113,15 +196,10 @@ describe('CreatePane', () => {
 	});
 
 	it('exposes the per-kind piece fields and previews spawned pieces', async () => {
-		const container = await mount();
+		const container = await startNew();
 
-		// the Pieces folder's kind list is the second select (Scope is the first)
-		const selects = [...container.querySelectorAll('select')];
-		const kindSelect = selects.find((s) =>
-			[...s.options].some((o) => o.textContent?.includes('Counter'))
-		)!;
-		kindSelect.selectedIndex = 2; // Token, Pawn, Counter
-		kindSelect.dispatchEvent(new Event('change', { bubbles: true }));
+		// the Board tab's kind list is the first offering "Counter"
+		choose(listWith(container, 'Counter'), 'Counter');
 		await settle();
 
 		button(container, 'Add counter')!.click();
@@ -134,7 +212,7 @@ describe('CreatePane', () => {
 	});
 
 	it('authors a multi-state token and previews the selected state', async () => {
-		const container = await mount();
+		const container = await startNew();
 		button(container, 'Add token')!.click(); // the kind list defaults to Token
 		await settle();
 
@@ -173,9 +251,9 @@ describe('CreatePane', () => {
 	});
 
 	it('authors a bag with contents, and previews it as a loaded bag', async () => {
-		const container = await mount();
+		const container = await startNew();
 
-		// Pieces folder → kind list → Bag (Token, Pawn, Counter, Bag)
+		// Board tab → kind list → Bag (Token, Pawn, Counter, Dice, Bag)
 		choose(listWith(container, 'Counter'), 'Bag');
 		await settle();
 		button(container, 'Add bag')!.click();
@@ -209,13 +287,13 @@ describe('CreatePane', () => {
 	});
 
 	it('saves the pack to the library (packs:v1) and re-opens it for editing', async () => {
-		const container = await mount();
+		const container = await startWithCard();
 		button(container, 'Save to library')!.click();
 		await settle();
 
 		const stored = JSON.parse(localStorage.getItem('packs:v1') ?? '{}');
 		expect(Object.keys(stored)).toEqual(['my-pack']);
-		expect(stored['my-pack'].pack.decks[0].cards[0].face).toBe('gen:std52/AS');
+		expect(stored['my-pack'].pack.decks[0].cards[0].face).toBe(CARD_BACK_DEFAULT);
 
 		button(container, 'Edit selected')!.click();
 		await settlePreview();
@@ -223,7 +301,7 @@ describe('CreatePane', () => {
 	});
 
 	it('does not preview a deck that has no cards yet', async () => {
-		const container = await mount();
+		const container = await startWithCard();
 		button(container, 'Add deck')!.click(); // new decks start empty
 		await settlePreview();
 
@@ -232,52 +310,58 @@ describe('CreatePane', () => {
 	});
 
 	it('gives a new card the deck back as its face, so it renders immediately', async () => {
-		const container = await mount();
+		const container = await startNew();
 		button(container, 'Add card')!.click();
 		await settlePreview();
 
 		const cards = get(gameStore).decks?.['deck:preview:main'].cards ?? [];
-		expect(cards).toHaveLength(2);
-		// starter deck's back — a blank face resolves to '' and shows nothing
-		expect(cards[1].faceImageUrl).toBe(CARD_BACK_DEFAULT);
+		expect(cards).toHaveLength(1);
+		// the deck's back — a blank face resolves to '' and shows nothing
+		expect(cards[0].faceImageUrl).toBe(CARD_BACK_DEFAULT);
 	});
 
 	it('gives every card a distinct code — duplicating twice never repeats one', async () => {
-		const container = await mount();
-		// the starter deck holds `AS`; `code` is the entity-id component, so a
-		// repeat would collapse two cards into one table entity
+		const container = await startWithCard();
+		// `code` is the entity-id component, so a repeat would collapse two cards
+		// into one table entity
 		button(container, 'Duplicate card')!.click();
 		await settle();
-		expect(cardCodes(container)).toEqual(['AS', 'AS-2']);
+		expect(cardCodes(container)).toEqual(['card-0', 'card-1']);
 
-		// duplicate the original again: the copy can't be `AS-2` a second time
 		button(container, 'Duplicate card')!.click();
 		await settle();
-		expect(cardCodes(container)).toEqual(['AS', 'AS-2', 'AS-3']);
+		expect(cardCodes(container)).toEqual(['card-0', 'card-1', 'card-2']);
 	});
 
 	it('does not reuse a `card-N` code after a card is removed', async () => {
-		const container = await mount();
+		const container = await startNew();
+		button(container, 'Add card')!.click(); // card-0
+		await settle();
 		button(container, 'Add card')!.click(); // card-1
 		await settle();
-		button(container, 'Add card')!.click(); // card-2
+
+		// remove the FIRST one: `card-${cards.length}` is now `card-1`, and that
+		// is still in use — the old code minted the collision, this steps past it
+		choose(cardList(container), '0: card-0');
 		await settle();
 		button(container, 'Remove card')!.click();
 		await settle();
-		// `card-${cards.length}` is `card-2` again here, and it's still in use —
-		// the old code minted the collision, this one steps past it
 		button(container, 'Add card')!.click();
 		await settle();
 
 		const codes = cardCodes(container);
-		expect(codes).toHaveLength(3);
-		expect(new Set(codes).size).toBe(3);
+		expect(codes).toEqual(['card-1', 'card-2']);
 	});
 
-	it('bulk-adds a sheet grid into the selected deck', async () => {
-		const container = await mount();
+	it('bulk-adds a sheet grid into the selected deck, from the Cards tab', async () => {
+		const container = await startWithCard();
 
-		// the bulk pane's own controls: URL, columns, rows, then Preview grid
+		// closed until asked for: it used to sit open over the felt before anyone
+		// had a sheet URL
+		expect(labels(container)).not.toContain('Sheet URL');
+		button(container, 'Add cards from a sheet…')!.click();
+		await settle();
+
 		type(input(container, 'Sheet URL')!, 'https://example.test/sheet.png');
 		await settle();
 		type(input(container, 'Columns')!, '2');
@@ -291,15 +375,15 @@ describe('CreatePane', () => {
 		await settlePreview();
 
 		const cards = get(gameStore).decks?.['deck:preview:main'].cards ?? [];
-		expect(cards).toHaveLength(5); // the starter Ace plus the grid
+		expect(cards).toHaveLength(5); // the first card plus the grid
 		expect(
 			cards.slice(1).map((c) => JSON.parse(c.faceImageUrl!.slice('sheet:'.length)).index)
 		).toEqual([0, 1, 2, 3]);
-		expect(cardCodes(container)).toEqual(['AS', 'card-1', 'card-2', 'card-3', 'card-4']);
+		expect(cardCodes(container)).toEqual(['card-0', 'card-1', 'card-2', 'card-3', 'card-4']);
 	});
 
 	it('sets the selected card face inline, without a separate builder', async () => {
-		const container = await mount();
+		const container = await startWithCard();
 		// one face editor for the deck back, one for the selected card
 		const pickers = schemePickers(container);
 		expect(pickers).toHaveLength(2);
@@ -314,7 +398,7 @@ describe('CreatePane', () => {
 	});
 
 	it('sets the deck back inline from the deck section', async () => {
-		const container = await mount();
+		const container = await startWithCard();
 		choose(schemePickers(container)[0], 'Image URL');
 		await settle();
 		type(input(container, 'Image URL')!, 'https://example.test/back.png');
@@ -326,22 +410,22 @@ describe('CreatePane', () => {
 	});
 
 	it('flips the cards on the preview table from the pane, no keyboard needed', async () => {
-		const container = await mount();
+		const container = await startWithCard();
 		await settlePreview();
 
 		gameStore.updateState({
 			cards: {
-				'card:preview:main-AS': {
+				'card:preview:main-card-0': {
 					position: [0, 0.3, 0],
 					rotation: [180, 0, 0], // as it arrives off a facedown pile
-					faceImageUrl: 'gen:std52/AS'
+					faceImageUrl: CARD_BACK_DEFAULT
 				}
 			}
 		});
 		button(container, 'Flip cards on table')!.click();
 		await settle();
 
-		expect(get(gameStore).cards?.['card:preview:main-AS'].rotation).toEqual([0, 0, 0]);
+		expect(get(gameStore).cards?.['card:preview:main-card-0'].rotation).toEqual([0, 0, 0]);
 	});
 
 	describe('Spread layout', () => {
@@ -352,7 +436,7 @@ describe('CreatePane', () => {
 		}
 
 		it('lays every card of every deck out face-up, with no piles left', async () => {
-			const container = await mount();
+			const container = await startWithCard();
 			button(container, 'Add deck')!.click();
 			await settle();
 			button(container, 'Add card')!.click();
@@ -363,7 +447,7 @@ describe('CreatePane', () => {
 			expect(Object.keys(state.decks ?? {})).toEqual([]);
 			expect(Object.keys(state.cards ?? {}).sort()).toEqual([
 				'card:preview:deck-1-card-0',
-				'card:preview:main-AS'
+				'card:preview:main-card-0'
 			]);
 			// face-up regardless of the decks' isFaceUp (both start facedown)
 			expect(Object.values(state.cards ?? {}).every((c) => c.rotation?.[0] === 0)).toBe(true);
@@ -376,16 +460,16 @@ describe('CreatePane', () => {
 		});
 
 		it('leaves the other tiles in place when a card is added or edited', async () => {
-			const container = await mount();
+			const container = await startWithCard();
 			await spread(container);
-			const before = get(gameStore).cards!['card:preview:main-AS'].position;
+			const before = get(gameStore).cards!['card:preview:main-card-0'].position;
 
 			button(container, 'Add card')!.click();
 			await settlePreview();
 
 			const cards = get(gameStore).cards!;
 			expect(Object.keys(cards)).toHaveLength(2);
-			expect(cards['card:preview:main-AS'].position).toEqual(before);
+			expect(cards['card:preview:main-card-0'].position).toEqual(before);
 			// the new card is appended one column across, not re-laid out
 			expect(cards['card:preview:main-card-1'].position![0] - before![0]).toBeCloseTo(
 				SPREAD_PITCH_X
@@ -395,7 +479,7 @@ describe('CreatePane', () => {
 			// draft check below is what proves it was the card's
 			type(inputs(container, 'Name')[2]!, 'renamed');
 			await settlePreview();
-			expect(get(gameStore).cards!['card:preview:main-AS'].position).toEqual(before);
+			expect(get(gameStore).cards!['card:preview:main-card-0'].position).toEqual(before);
 			expect(cards['card:preview:main-card-1'].position).toEqual(
 				get(gameStore).cards!['card:preview:main-card-1'].position
 			);
@@ -407,9 +491,9 @@ describe('CreatePane', () => {
 		});
 
 		it('re-forms the piles when switched back to Deck', async () => {
-			const container = await mount();
+			const container = await startWithCard();
 			await spread(container);
-			const spreadPositions = get(gameStore).cards!['card:preview:main-AS'].position;
+			const spreadPositions = get(gameStore).cards!['card:preview:main-card-0'].position;
 
 			choose(listWith(container, 'Spread'), 'Deck');
 			await settlePreview();
@@ -418,7 +502,7 @@ describe('CreatePane', () => {
 
 			await spread(container);
 			expect(Object.keys(get(gameStore).decks ?? {})).toEqual([]);
-			expect(get(gameStore).cards!['card:preview:main-AS'].position).toEqual(spreadPositions);
+			expect(get(gameStore).cards!['card:preview:main-card-0'].position).toEqual(spreadPositions);
 		});
 
 		it('falls back to Deck mode past the card cap', async () => {
@@ -441,8 +525,8 @@ describe('CreatePane', () => {
 			localStorage.setItem('packs:v1', JSON.stringify({ big: { updatedAt: 1, pack } }));
 
 			const container = await mount();
-			await spread(container);
-			button(container, 'Edit selected')!.click();
+			previewLayout.set('spread'); // as it is remembered from the last session
+			button(container, 'Open selected')!.click();
 			await settlePreview();
 
 			// piles, not 61 tiles — and the control follows the table
@@ -452,30 +536,30 @@ describe('CreatePane', () => {
 		});
 
 		it('selects the clicked card in the pane', async () => {
-			const container = await mount();
+			const container = await startWithCard();
 			await spread(container);
 			button(container, 'Add card')!.click(); // cursor follows the new card
 			await settlePreview();
 			expect(input(container, 'Code')!.value).toBe('card-1');
 
-			pickCard('card:preview:main-AS'); // what Card.svelte calls on a click
+			pickCard('card:preview:main-card-0'); // what Card.svelte calls on a click
 			await settle();
-			expect(input(container, 'Code')!.value).toBe('AS');
+			expect(input(container, 'Code')!.value).toBe('card-0');
 		});
 
 		it('ignores a click on a card no spread laid out', async () => {
-			const container = await mount();
+			const container = await startWithCard();
 			await settlePreview(); // Deck mode: cards come off a pile by hand
 			button(container, 'Add card')!.click();
 			await settlePreview();
 
-			pickCard('card:preview:main-AS');
+			pickCard('card:preview:main-card-0');
 			await settle();
 			expect(input(container, 'Code')!.value).toBe('card-1'); // cursor unmoved
 		});
 	});
 
-	describe('opening a pack file', () => {
+	describe('opening a file', () => {
 		const OTHER: GamePackDef = {
 			id: 'ember-duel',
 			name: 'Ember Duel',
@@ -490,29 +574,34 @@ describe('CreatePane', () => {
 			]
 		};
 
-		/** the hidden picker behind "Open a pack (.tbpp.json)" */
-		async function openPackFile(container: HTMLElement) {
-			const input = [...container.querySelectorAll('input[type=file]')].at(-1) as HTMLInputElement;
-			Object.defineProperty(input, 'files', {
-				value: [new File([serializePackFile(OTHER)], 'ember.tbpp.json')],
-				configurable: true
-			});
-			input.dispatchEvent(new Event('change', { bubbles: true }));
+		/** drop a file on the File blade's zone (the last one mounted) */
+		async function drop(container: HTMLElement, file: File) {
+			const picker = [...container.querySelectorAll('input[type=file]')].at(-1) as HTMLInputElement;
+			Object.defineProperty(picker, 'files', { value: [file], configurable: true });
+			picker.dispatchEvent(new Event('change', { bubbles: true }));
 			await settlePreview();
 		}
 
-		it('is reachable without expanding a folder', async () => {
+		const packFile = () => new File([serializePackFile(OTHER)], 'ember.tbpp.json');
+
+		it('is reachable without expanding a folder, from the start state and the editor', async () => {
 			const container = await mount();
-			// tweakpane keeps a collapsed folder's buttons in the DOM, so "visible"
+			// tweakpane keeps a collapsed folder's controls in the DOM, so "visible"
 			// has to mean "not inside a folder" — the bug was a folder, not display
-			const open = button(container, 'Open a pack (.tbpp.json)')!;
-			expect(open).toBeDefined();
-			expect(open.closest('.tp-fldv')).toBeNull();
+			const start = container.querySelector('input[type=file]');
+			expect(start).toBeTruthy();
+			expect(start!.closest('.tp-fldv')).toBeNull();
+
+			button(container, 'New empty pack')!.click();
+			await settle();
+			const editor = container.querySelector('input[type=file]');
+			expect(editor).toBeTruthy();
+			expect(editor!.closest('.tp-fldv')).toBeNull();
 		});
 
-		it('loads the pack into the editor and the library', async () => {
+		it('opens a pack straight from the start state', async () => {
 			const container = await mount();
-			await openPackFile(container);
+			await drop(container, packFile());
 
 			expect(input(container, 'Id')!.value).toBe('ember-duel');
 			expect(Object.keys(JSON.parse(localStorage.getItem('packs:v1') ?? '{}'))).toEqual([
@@ -521,13 +610,39 @@ describe('CreatePane', () => {
 			expect(get(gameStore).decks?.['deck:preview:main'].cards).toHaveLength(1);
 		});
 
-		it('keeps an edited draft when the discard prompt is refused', async () => {
+		it('routes a TTS save through the same drop zone', async () => {
+			const tts = {
+				ObjectStates: [
+					{
+						Name: 'DeckCustom',
+						Nickname: 'Troopers',
+						DeckIDs: [100, 101],
+						CustomDeck: {
+							'1': {
+								FaceURL: 'https://example.com/face.png',
+								BackURL: 'https://example.com/back.png',
+								NumWidth: 2,
+								NumHeight: 1
+							}
+						}
+					}
+				]
+			};
 			const container = await mount();
+			await drop(container, new File([JSON.stringify(tts)], 'save.json'));
+
+			// the deck's slot is slugified from its TTS nickname
+			expect(Object.keys(get(gameStore).decks ?? {})).toEqual(['deck:preview:troopers']);
+			expect(get(gameStore).decks!['deck:preview:troopers'].cards).toHaveLength(2);
+		});
+
+		it('keeps an edited draft when the discard prompt is refused', async () => {
+			const container = await startNew();
 			type(input(container, 'Name')!, 'Half Finished');
 			await settlePreview();
 
 			const confirmed = vi.spyOn(window, 'confirm').mockReturnValue(false);
-			await openPackFile(container);
+			await drop(container, packFile());
 
 			expect(confirmed).toHaveBeenCalled();
 			expect(input(container, 'Id')!.value).toBe('my-pack'); // draft untouched
@@ -538,24 +653,33 @@ describe('CreatePane', () => {
 		});
 
 		it('replaces the draft once the discard prompt is accepted', async () => {
-			const container = await mount();
+			const container = await startNew();
 			type(input(container, 'Name')!, 'Half Finished');
 			await settlePreview();
 
 			vi.spyOn(window, 'confirm').mockReturnValue(true);
-			await openPackFile(container);
+			await drop(container, packFile());
 
 			expect(input(container, 'Id')!.value).toBe('ember-duel');
 		});
 
 		it('does not prompt when the draft is untouched', async () => {
-			const container = await mount();
+			const container = await startNew();
 			const confirmed = vi.spyOn(window, 'confirm').mockReturnValue(false);
-			await openPackFile(container);
+			await drop(container, packFile());
 
 			expect(confirmed).not.toHaveBeenCalled();
 			expect(input(container, 'Id')!.value).toBe('ember-duel');
 		});
+	});
+
+	it('keeps Save and Export out of any folder, one tab from anywhere', async () => {
+		const container = await startNew();
+		for (const title of ['Save to library', 'Export pack']) {
+			const control = button(container, title)!;
+			expect(control).toBeDefined();
+			expect(control.closest('.tp-fldv')).toBeNull();
+		}
 	});
 
 	it('previews only under the preview owner, leaving other entities alone', async () => {
@@ -565,7 +689,7 @@ describe('CreatePane', () => {
 			cards: {},
 			pieces: {}
 		});
-		const container = await mount();
+		const container = await startNew();
 		button(container, 'Add deck')!.click();
 		await settlePreview();
 

--- a/src/routes/create/__tests__/CreatePane.test.ts
+++ b/src/routes/create/__tests__/CreatePane.test.ts
@@ -682,6 +682,45 @@ describe('CreatePane', () => {
 		}
 	});
 
+	describe('the column below the pane', () => {
+		const status = (container: HTMLElement) =>
+			container.querySelector('footer')?.textContent?.trim();
+
+		it('says what is in the draft, on every tab', async () => {
+			const container = await mount();
+			// the start state has no draft to count, and still closes the column
+			expect(status(container)).toBe('no pack open');
+
+			button(container, 'New empty pack')!.click();
+			await settle();
+			expect(status(container)).toBe('1 deck · 0 cards');
+
+			button(container, 'Add card')!.click();
+			await settle();
+			button(container, 'Add deck')!.click();
+			await settle();
+			expect(status(container)).toBe('2 decks · 1 card');
+
+			// pieces and overlays only once the pack has any — a deck of cards
+			// should not have to read past zeroes
+			choose(listWith(container, 'Counter'), 'Counter');
+			await settle();
+			button(container, 'Add counter')!.click();
+			await settle();
+			expect(status(container)).toBe('2 decks · 1 card · 1 piece');
+		});
+
+		it('carries the help the tabs no longer do, outside every folder', async () => {
+			const container = await startNew();
+			const help = container.querySelector('section');
+			expect(help?.textContent).toContain('A pack is a content library');
+			expect(help?.textContent).toContain('Preview table');
+			// it is markup, not a blade: a tweakpane folder would collapse it back
+			// into the pane it was moved out of
+			expect(help?.closest('.tp-fldv')).toBeNull();
+		});
+	});
+
 	it('previews only under the preview owner, leaving other entities alone', async () => {
 		gameStore.set({
 			players: {},

--- a/src/routes/create/column.ts
+++ b/src/routes/create/column.ts
@@ -1,0 +1,35 @@
+/**
+ * The editor column's width, shared by the page (which sizes the column) and
+ * the pane (which is a tweakpane `width` in px, not a CSS length, so the two
+ * have to agree on a number rather than on a class).
+ *
+ * Two steps rather than one fixed width: the column cannot shrink below its
+ * pane without clipping the controls, so on a narrow window it is the felt
+ * that pays. At 1280 — the width /create is expected to work at — nothing
+ * changes; below 1200 the pane steps down and hands the table back ~56px,
+ * which is the difference between a strip and a table on a 1024 laptop.
+ */
+
+import { readable } from 'svelte/store';
+
+export const EDITOR_PANE_WIDE = 352;
+export const EDITOR_PANE_NARROW = 296;
+
+/** Room for the column's scrollbar, reserved whether or not it is scrolling */
+export const EDITOR_GUTTER = 16;
+
+export const EDITOR_NARROW_QUERY = '(max-width: 1199px)';
+
+/**
+ * Widest pane the viewport can afford. Falls back to the wide value wherever
+ * `matchMedia` is not available (SSR, and jsdom in the component tests), which
+ * is also what a component that never resizes should render.
+ */
+export const editorPaneWidth = readable(EDITOR_PANE_WIDE, (set) => {
+	if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+	const query = window.matchMedia(EDITOR_NARROW_QUERY);
+	const apply = () => set(query.matches ? EDITOR_PANE_NARROW : EDITOR_PANE_WIDE);
+	apply();
+	query.addEventListener('change', apply);
+	return () => query.removeEventListener('change', apply);
+});


### PR DESCRIPTION
Task: tableplace-108
Closes #108

Part of epic #107 (`feat/pane-ux`). Base is `feat/pane-ux`, not `main`.

## What was wrong

Five draggable panes with **hard-coded positions but content-driven heights**.
`Decks & Cards` (y=99) covered the bottom of `Pack (local)` and was already
exactly viewport-height with *one* card in the pack — it could not grow, and
its own help text was clipped mid-sentence. All five sat in the top strip,
which is exactly where `SPREAD_ORIGIN_Z = -6` anchors the preview grid, so a
fresh pack's only card could be entirely behind a pane — unviewable and
unclickable.

## What this does

**One pane, `position="inline"`, in a fixed-width scrolling column.** The
table owns everything to its right. Overlap is structurally impossible;
clipping is the column's scroll. Inside it a `TabGroup` — Pack / Cards /
Board / File — so one concern is on screen at a time and Save / Export stay
one tab click away, never under a folder (#71 §4's constraint).

**A real step 1.** First paint is `New empty pack` / `Standard 52 template`,
a `File` drop zone that routes a pack file or a TTS save by content, and a
`Continue` list only when drafts exist. `Close pack` returns to it. A new pack
is one empty deck and no cards — the Ace of Spades it used to fabricate was
the first thing you had to delete.

Also in here:

- The bulk sheet opens from **"Add cards from a sheet…"** in the Cards tab,
  next to the deck the batch lands in, instead of being a fifth pane parked
  over the felt at x=680 before anyone has a sheet URL.
- Board collapses to `Pieces 0 · Overlays 0` until something is in it.
- Create-verbs move out from between a selector and the fields they have
  nothing to do with: `List` → `ButtonGrid` of verbs → `Separator` → fields.
- The `File` blade replaces the hidden `<input type=file>` + Button hack
  (twice here).

### One file outside `src/routes/create/`

`src/lib/TableScene.svelte` normalized the interactivity pointer against
`window.innerWidth/Height`. The canvas is no longer full-bleed on /create, so
window coordinates put the ray ~a third of a screen off — click-to-select in
the spread, and every drag, would land nowhere near the cursor. It now uses
the canvas's own rect, which is identical arithmetic wherever the canvas fills
the window (/play, /setup). No overlap with #112 / #113's files.

Deck-mode piles are also previewed centred: a pack authors no deck position,
so a preview deck landed on the owner's own deck spot at the near-right corner
of the felt, which the editor's narrower shot cuts in half.

## Homes left for the rest of the epic (not implemented)

- **#109** — an always-mounted `Element` breadcrumb row above the tabs.
- **#110** — the pane title.
- **#115** — a collapsed "How this works" folder per tab, holding today's
  help text.

## Acceptance

| criterion | |
|---|---|
| No two panes overlap at 1280×720+, 60-card deck | ✅ there is one pane, in normal flow |
| Spread fully visible and clickable | ✅ verified in Chrome at 1280×720 with the 52-card template: all 52 tiles in frame, clicking K♣ selects `KC` |
| Editor column scrolls; nothing clipped | ✅ `overflow-y:auto` + a stable 16px scrollbar gutter, so the pane's right edge never sits under the scrollbar |
| First paint is the start state | ✅ + test |
| Save / Export ≤ 1 click from any tab | ✅ top of the File tab, not in a folder (+ test) |

## Verification

`bun vitest run` — 725 pass / 59 files (CreatePane.test.ts rewritten to start
where a first-time author does). `bun run check` — 0 errors. `bun run build` —
clean. Prettier + eslint clean on every changed file (repo-wide `bun run lint`
is red at baseline on unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Hvaq4braViHSRgNeJy9U1

---

## Review round 2 — the column's remainder

Rebased onto `origin/feat/pane-ux` (now carrying #112 and #113).

**The slab is gone.** A tab's controls are not viewport-tall and the column
is, so under a short tab (File is four rows) the rest of the column was flat
dark nothing down to the bottom edge. The remainder now carries the two homes
the epic reserved anyway:

- **"How this works"** — the help that was a collapsed folder inside two
  separate tabs — moved out of the pane and into the column, once. It takes
  the leftover and centres in it, so what is left over on a tall screen is two
  small margins rather than one dead half. `safe` centring, so a long tab
  still scrolls from the top rather than centring its overflow out of reach.
  Plain markup, not a blade: #115 rewrites it into per-control help, and prose
  in a disabled `Textarea` could neither wrap to the column nor be selected.
- **A status bar** — `2 decks · 60 cards · 1 piece`, or `no pack open`.
  `mt-auto` drops it to the foot of a short column; `sticky` keeps it at the
  bottom edge while a long one scrolls behind it. So the column has a bottom
  edge at every height and on every tab. Counts only: whether the draft is
  *saved* is still #110's marker, in the pane's title.

Measured at 1280×720, worst tab (Board, folders collapsed): ~90px above and
below the help block, versus ~500px of nothing before. Cards tab with the
sheet adder open: content is 1309px, the bar stays pinned at 692–720.

**Column width.** The column can't shrink below its pane without clipping the
controls, so on a narrow window the felt was paying for it. The pane width is
now two steps — 352 as before, 296 below 1200px — shared by the page and the
pane through `column.ts`, since one is a CSS length and the other a tweakpane
number and they have to agree. **At 1280 nothing changes: the table is exactly
as wide as it was.** At 1100 it gets 788px instead of 732. `matchMedia` is
guarded, so SSR and jsdom keep the wide default.

Re-verified: `bun run test:e2e` **6/6**, `bun vitest run` **743**,
`bun run check` 0 errors, build clean, and by hand in Chrome on all four tabs
plus the start state at 1280×720, 1280×907 and 1100×720.
