### PR TITLE
tableplace-116: default the client to lobby.table.place

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,10 @@ must, in the same change, also update:
 - Runtime configuration is localStorage, not env vars: `serverurl` (host without
   scheme; `ws://` vs `wss://` is chosen automatically, path `/ws`), `myPlayerId`,
   `scenarios:v1`. `/play` also accepts `?lobby=`, `?server=`, `?seat=` query
-  params.
+  params. An empty/absent `serverurl` falls back to the public lobby relay
+  `lobby.table.place` (`connection.ts`) — *not* `api.table.place`, which is
+  reserved for the HTTP lobby-provisioning API. Precedence, widest to narrowest:
+  `?server=` → `localStorage.serverurl` → that default.
 - Sprite-sheet slicing needs canvas pixel access, so it retries through a
   hardcoded third-party CORS proxy (`https://corsproxy.innkeeper1.workers.dev/?url=`)
   when a host sends no CORS headers, and caches sliced cells in IndexedDB — a

--- a/README.md
+++ b/README.md
@@ -68,3 +68,5 @@ localhost:8080
 ```
 
 The client reads this value from `localStorage.serverurl` and automatically prefixes `ws://` for local addresses or `wss://` for secure hosts, then connects at `/ws`.
+
+Leave the field empty and the client uses the public lobby relay, `lobby.table.place`, so a first-time visitor gets real multiplayer without configuring anything. A `?server=` query param on `/play` beats both the field and that default, for one visit only.

--- a/docs/planning/infrastructure-planning.md
+++ b/docs/planning/infrastructure-planning.md
@@ -1,0 +1,51 @@
+# Infrastructure planning — hostnames and the lobby/provisioning split
+
+Where the deployed pieces live, and what each `*.table.place` name is for. Started
+2026-07-25 alongside #116; the earlier backend-shape decisions (why a Go relay at all,
+what would replace it) are in `MULTIPLAYER_OPTIONS.md` and `SPEC.md` §2, not here.
+
+## Hostnames
+
+| Host                | Serves                                                                | Status                                           |
+| ------------------- | --------------------------------------------------------------------- | ------------------------------------------------ |
+| `table.place`       | The SvelteKit client (static)                                         | Live                                             |
+| `lobby.table.place` | The Go websocket relay (`server/`) — `/ws`, `/view`, `/{lobby}/debug` | Live, verified 2026-07-25                        |
+| `api.table.place`   | HTTP lobby-provisioning API                                           | Reserved; still the old relay CNAME until step 3 |
+
+Both `lobby.` and `api.` currently resolve to the same Railway relay behind Cloudflare.
+That is the transitional state, not the target: `api.` gets repointed once the
+provisioning API exists.
+
+## Migration: rename the relay host, free `api.` for provisioning
+
+1. **Stand up `lobby.table.place` against the existing Railway relay.** — **Done**
+   (2026-07-25). `GET /` → `200 OK`; `/ws` → `101 Switching Protocols` through
+   Cloudflare/Railway.
+2. **Flip the client's default websocket host from `api.table.place` to
+   `lobby.table.place`.** — **Done** (#116). `src/lib/websocket/connection.ts`.
+   No dual-host fallback and no state transfer: lobby state is in-memory in
+   `server/lobby/` and is dropped by every Railway redeploy, so losing a lobby to
+   this change is indistinguishable from a routine deploy, and nobody was on the
+   server. An explicitly-set `localStorage.serverurl` still wins and deliberately
+   does not auto-migrate — there are no users to migrate.
+3. **Repoint `api.table.place` at the provisioning API.** — Not started. Safe to do
+   once a client build with step 2 is deployed; anyone still running an older build
+   (or with `api.table.place` pinned in Settings by hand) loses multiplayer at that
+   moment, which is the accepted cost.
+
+## Decision log
+
+### 2026-07-25 — the websocket relay moves to `lobby.table.place`
+
+`api.table.place` was the relay's original name, from when the relay was the only
+backend. It is the natural name for the HTTP lobby-provisioning API, and a name
+cannot be both: a websocket upgrade and a REST surface on one host means either a
+path-prefix split or a passthrough proxy, and both exist only to preserve a name
+that predates the split.
+
+**Decision:** the relay gets its own name, `lobby.table.place`, and the client
+defaults there. `api.table.place` is reserved for provisioning.
+
+**Rejected:** serving `/ws` from `api.table.place` as a passthrough. It keeps a
+transitional shape permanently, and buys nothing — the only thing it would protect
+is old client builds, and there are no users on them.

--- a/e2e/servers.ts
+++ b/e2e/servers.ts
@@ -4,7 +4,7 @@
  * The relay is not optional — `/play` renders `<TableScene>` only once the
  * socket is open, so a harness without one tests an empty canvas. It is also
  * why the harness must never be pointed at the default server: `connection.ts`
- * falls back to `api.table.place` when nothing overrides it, and a test that
+ * falls back to `lobby.table.place` when nothing overrides it, and a test that
  * spawns dice into the public relay is a test that spawns dice into strangers'
  * tables. Both the `?server=` query param and `localStorage.serverurl` are set
  * to localhost, belt and braces.

--- a/src/lib/websocket/__tests__/default-server.test.ts
+++ b/src/lib/websocket/__tests__/default-server.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Regression guard for which host a client actually dials (#116).
+ *
+ * The default lives in a module-level const in `connection.ts`, computed once at
+ * import time from `localStorage.serverurl` — so every case here has to reset
+ * modules and re-import, not just poke localStorage.
+ *
+ * It matters because the default is invisible in normal use: a developer always
+ * has a `serverurl` set, so a wrong default only shows up as first-time visitors
+ * quietly landing on the wrong box. `api.table.place` is being repurposed as the
+ * HTTP lobby-provisioning API; the relay answers at `lobby.table.place`.
+ */
+
+/** Records the URL `connect()` passes to the WebSocket constructor. */
+function stubWebSocket(): { url: () => string | undefined } {
+	let seen: string | undefined;
+	class FakeSocket {
+		onopen: (() => void) | null = null;
+		onclose: (() => void) | null = null;
+		onerror: (() => void) | null = null;
+		onmessage: (() => void) | null = null;
+		constructor(url: string) {
+			seen = url;
+		}
+		send() {}
+		close() {}
+	}
+	vi.stubGlobal('WebSocket', FakeSocket);
+	return { url: () => seen };
+}
+
+/**
+ * `connect()` is async but has no await before `new WebSocket(...)`, so the
+ * socket exists by the time it returns. Nothing resolves the promise (the stub
+ * never fires onopen) — that is fine, we only want the URL. It is deliberately
+ * not awaited.
+ */
+async function dial(serverUrl?: string): Promise<string | undefined> {
+	const socket = stubWebSocket();
+	const { gameActions } = await import('$lib/store/game/actions');
+	gameActions.addPlayer('p1');
+	const { connect } = await import('../connection');
+	void connect('some-lobby', serverUrl);
+	return socket.url();
+}
+
+describe('default websocket host', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		localStorage.clear();
+		localStorage.setItem('myPlayerId', 'p1');
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('dials lobby.table.place when nothing is configured', async () => {
+		expect(await dial()).toBe('wss://lobby.table.place/ws?lobby=some-lobby&player=p1');
+	});
+
+	it('dials lobby.table.place when Settings wrote an empty string', async () => {
+		// connectionStore persists '' before a server is ever chosen — the reason
+		// connection.ts uses `||` and not `??`
+		localStorage.setItem('serverurl', '');
+		expect(await dial()).toBe('wss://lobby.table.place/ws?lobby=some-lobby&player=p1');
+	});
+
+	it('lets an explicitly-set serverurl beat the default', async () => {
+		localStorage.setItem('serverurl', 'relay.example.com');
+		expect(await dial()).toBe('wss://relay.example.com/ws?lobby=some-lobby&player=p1');
+	});
+
+	it('lets ?server= beat both the default and a set serverurl', async () => {
+		localStorage.setItem('serverurl', 'relay.example.com');
+		expect(await dial('wss://other.example.com')).toBe(
+			'wss://other.example.com/ws?lobby=some-lobby&player=p1'
+		);
+	});
+
+	it('keeps localhost on ws://, not wss://', async () => {
+		localStorage.setItem('serverurl', 'localhost:8080');
+		expect(await dial()).toBe('ws://localhost:8080/ws?lobby=some-lobby&player=p1');
+	});
+
+	it('keeps localhost on ws:// when it arrives via ?server=', async () => {
+		expect(await dial('http://localhost:8080/')).toBe(
+			'ws://localhost:8080/ws?lobby=some-lobby&player=p1'
+		);
+	});
+});

--- a/src/lib/websocket/connection.ts
+++ b/src/lib/websocket/connection.ts
@@ -23,11 +23,14 @@ function normalizeServerHost(url: string): string {
 		.replace(/^(https?|wss?):\/\//, '')
 		.replace(/\/+$/, '');
 }
-// Default to the public server so a first-time visitor gets real multiplayer;
-// a non-empty localStorage.serverurl (set in Settings) always wins. `||` (not ??)
-// because connectionStore writes '' to localStorage before a server is ever set.
+// Default to the public lobby server so a first-time visitor gets real
+// multiplayer; a non-empty localStorage.serverurl (set in Settings) always wins.
+// `||` (not ??) because connectionStore writes '' to localStorage before a
+// server is ever set. The host is `lobby.` and not `api.`: `api.table.place` is
+// being repurposed as the HTTP lobby-provisioning API, so the websocket relay
+// answers at its own name.
 const CACHE_SERVER_URL =
-	normalizeServerHost(localStorage.getItem('serverurl') ?? '') || 'api.table.place';
+	normalizeServerHost(localStorage.getItem('serverurl') ?? '') || 'lobby.table.place';
 const SECURITY = CACHE_SERVER_URL.includes('localhost') ? 'ws' : 'wss';
 const WS_SERVER_URL = `${SECURITY}://${CACHE_SERVER_URL}/ws`;
 


### PR DESCRIPTION
Task: tableplace-116

Closes #116

The client's default websocket host was `api.table.place` — the relay's original name, from when the relay was the only backend. That name is being repurposed as the HTTP lobby-provisioning API, so the relay now gets its own: **`lobby.table.place`**.

No migration, per the ticket: nobody was on the server, and lobby state is in-memory (`server/lobby/`) and dropped by every Railway redeploy, so losing a lobby to this change is indistinguishable from a routine deploy. No dual-host fallback, no grace period, and no auto-flip of an explicitly-set `localStorage.serverurl`.

## Changes

- `src/lib/websocket/connection.ts` — default host flipped; the comment keeps its "so a first-time visitor gets real multiplayer" intent and now also says *why* it is `lobby.` and not `api.`
- `src/lib/websocket/__tests__/default-server.test.ts` — **new.** Pins the default and the whole precedence chain. Worth having because the default is invisible in normal use: every developer has a `serverurl` set, so a wrong default only surfaces as first-time visitors quietly landing on the wrong box.
- `AGENTS.md` — the runtime-config gotcha now names the default host and spells out precedence
- `README.md` — the Settings > Connection section now says what an empty field means
- `e2e/servers.ts` — its "never point the harness at the default" comment named the old host
- `docs/planning/infrastructure-planning.md` — **new file.** The ticket asked for a decision-log entry and a migration step reworded from planned to done; the file did not exist in the repo (nor in any branch's history), so it is created here with the hostname table, the three migration steps (1 and 2 done, 3 — repointing `api.` — not started), and the decision entry. Flagging it in case it was meant to live somewhere else.

## Verification

Ran against the **live** `lobby.table.place`, on the production build (`bun run build` + `vite preview`), two tabs on separate origins so they got separate `localStorage` and therefore distinct player ids:

- Seeded a real table through the new host: `bun run seed-lobby --server lobby.table.place` → 2 decks · 104 cards
- **No `serverurl`** in either tab → console shows `Connecting to websocket server at wss://lobby.table.place/ws?lobby=…`; both tabs joined, HUD read "2 players", and both saw the seeded decks
- **Moves propagate**: moving seat 1's deck in tab B moved it live in tab A
- **`?server=localhost:8080`** → `ws://localhost:8080/ws…`, so the override still wins *and* localhost still resolves to `ws://`, not `wss://`
- **Explicit `serverurl`** with no query param → `wss://relay.example.com/ws…`, beating the default
- `grep api.table.place build/` → 0 hits; `lobby.table.place` → 1

`bun run test` 724 passed / 60 files · `bun run check` 0 errors (11 pre-existing warnings) · `bun run build` clean. `bun run lint` is red at baseline on `main` (59 eslint errors, 29 prettier files) and is unchanged by this branch — the two files I touched that prettier flags, `AGENTS.md` and `README.md`, already failed before these edits, so I left their pre-existing formatting alone rather than bury the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TK7kAV9e5jLcqMUz6wehG