### PR TITLE
tableplace-114: /setup — one selection, a visible referent, and a second click

### DIFF
--- a/src/lib/Deck.svelte
+++ b/src/lib/Deck.svelte
@@ -20,6 +20,7 @@
 	import { claimPointerDown } from '$lib/utils/single-hit-dispatch';
 	import { DRAG_THRESHOLD_PX } from '$lib/utils/counter-input';
 	import DropFootprint from './drop/DropFootprint.svelte';
+	import { selectedDeckId, DECK_SELECT_COLOR } from '$lib/store/deckSelection';
 
 	// No interactivity() here on purpose. It calls setContext, so a per-deck call
 	// would shadow TableScene's context — the handlers below would raycast with
@@ -60,6 +61,9 @@
 	});
 
 	const isHovered = $derived(id === $dragStore.isDeckHovered);
+	// the scenario editor's "you are positioning THIS one" outline — set only by
+	// /setup's pane, so it never draws in /play (see store/deckSelection)
+	const isSelected = $derived(id === $selectedDeckId);
 	// dropping here replaces the table landing entirely, so the deck has to be
 	// the cue — the drop indicator suppresses its table footprint while hovered.
 	// Cards only: a dragged deck or piece just settles on the felt (see
@@ -190,6 +194,24 @@
 				<ImageMaterial url={preloadUrl} side={2} radius={0.1} opacity={0} />
 			</T.Mesh>
 		{/key}
+	{/if}
+
+	<!-- Editing outline: a hair wider than the drop footprint and drawn above
+	     it, so a deck that is both selected and a drop target still reads as
+	     both. depthTest={false} for the same reason the drop cue disables it —
+	     at a low camera angle the deck's own body would swallow it. -->
+	{#if isSelected}
+		<T.Group rotation.x={-Math.PI / 2} position.y={height / 2 + 0.05}>
+			<DropFootprint
+				shape="rect"
+				w={CARD_WIDTH + 0.5}
+				h={CARD_HEIGHT + 0.5}
+				color={DECK_SELECT_COLOR}
+				fill={0.08}
+				border={0.07}
+				depthTest={false}
+			/>
+		</T.Group>
 	{/if}
 
 	{#if isDropTarget}

--- a/src/lib/store/deckSelection.ts
+++ b/src/lib/store/deckSelection.ts
@@ -1,0 +1,26 @@
+import { writable } from 'svelte/store';
+
+/**
+ * Which deck the scenario editor is currently pointing its `position` /
+ * `rotation` controls at, so the scene can say so on the table (#114).
+ *
+ * A store rather than a prop for the same reason `snapEditor` is one: the pane
+ * lives outside the `<Canvas>`, and the thing that has to react is a `Deck`
+ * several components deep inside it.
+ *
+ * Only /setup ever sets this — it clears on unmount, so a deck never wears an
+ * editing outline in /play.
+ */
+export const selectedDeckId = writable<string | null>(null);
+
+export function setSelectedDeck(id: string | null) {
+	selectedDeckId.set(id);
+}
+
+/**
+ * Editing outline colour. Deliberately clear of the scene's other signal
+ * colours — the cyan drop highlight (#5ee7ff), the amber stack highlight
+ * (#ffc94a) and the violet snap-point markers — so "this is the deck the pane
+ * is editing" never reads as "drop here".
+ */
+export const DECK_SELECT_COLOR = '#a3e635';

--- a/src/routes/setup/SetupPane.svelte
+++ b/src/routes/setup/SetupPane.svelte
@@ -34,6 +34,7 @@
 		importScenarioFromText,
 		type SeatIndex
 	} from '$lib/scenario/scenario';
+	import { setSelectedDeck } from '$lib/store/deckSelection';
 	import { snapPointIds } from '$lib/store/game/actions/snap';
 	import { snapEditor, setSnapDefaults, setSnapPlacing } from '$lib/store/snapEditor';
 	import { SNAP_RADIUS_DEFAULT } from '$lib/utils/constants-snap';
@@ -41,6 +42,7 @@
 	import FileDropZone from '$lib/files/FileDropZone.svelte';
 	import { openDroppedFile } from '$lib/files/drop';
 	import { purgeUndefinedValues } from '$lib/utils/transforms/data';
+	import { tick } from 'svelte';
 	import { DEG2RAD } from 'three/src/math/MathUtils.js';
 	import type { GameDTO } from '$lib/store/game/types';
 	import toast from 'svelte-french-toast';
@@ -150,11 +152,62 @@
 		toast(`Seat ${activeSeat}: spawned ${STANDARD_52.name}`);
 	}
 
+	// ── second-click guard for the two irreversible buttons ───────────────────
+	// `Clear table` sits directly under `Delete selected`, and neither could be
+	// undone (#114). A browser `confirm()` is out — it steals focus from a
+	// draggable pane — and so is swapping the button for a confirm pair: an
+	// `{#if}` that REPLACES a blade tears the whole pane down (see the note in
+	// create/BulkSheet.svelte). So the button arms itself instead: the first
+	// click renames it to the question and ADDS a Cancel beside it (adding
+	// blades is safe), and only the second click goes through.
+
+	/** an armed button someone walked away from goes back to being safe */
+	const CONFIRM_TIMEOUT_MS = 5000;
+
+	let armed: 'clear' | 'delete' | null = $state(null);
+	let armedTimer: ReturnType<typeof setTimeout> | undefined;
+
+	function arm(which: 'clear' | 'delete') {
+		clearTimeout(armedTimer);
+		armed = which;
+		armedTimer = setTimeout(() => (armed = null), CONFIRM_TIMEOUT_MS);
+	}
+
+	function disarm() {
+		clearTimeout(armedTimer);
+		armed = null;
+	}
+
+	$effect(() => disarm);
+
+	/**
+	 * Nothing to lose: an empty table clears without asking. Overlays are judged
+	 * by their `imageUrl` rather than their presence — the pane's own effect
+	 * keeps an `overlays.table` record alive for the Position/Scale/Rotation
+	 * controls whether or not a map was ever picked, so a bare one isn't content.
+	 */
+	const tableIsEmpty = $derived.by(() => {
+		const s = $gameStore;
+		for (const collection of ['cards', 'decks', 'pieces', 'snapPoints'] as const) {
+			if (Object.values(s?.[collection] ?? {}).some(Boolean)) return false;
+		}
+		if (Object.values(s?.overlays ?? {}).some((o) => o?.imageUrl)) return false;
+		return !Object.keys(s?.players ?? {}).some(isSeatPlaceholder);
+	});
+
 	function handleDelete() {
 		if (!selectedScenario) return;
+		if (armed !== 'delete') return arm('delete');
+		disarm();
 		deleteScenario(selectedScenario);
 		refreshScenarios();
 		selectedScenario = scenarioNames[0] ?? '';
+	}
+
+	function handleClearTable() {
+		if (!tableIsEmpty && armed !== 'clear') return arm('clear');
+		disarm();
+		clearTable();
 	}
 
 	function handleExport() {
@@ -209,6 +262,99 @@
 	function setDeckField(deckId: string, patch: Record<string, unknown>) {
 		gameStore.updateState({ decks: { [deckId]: patch } });
 	}
+
+	// ── one selection, two controls ───────────────────────────────────────────
+	// `activeSeat` (what every Seats button acts on) and the Decks tab strip used
+	// to be unrelated state 80px apart: the strip could read `seat1 main` while
+	// the buttons all said "for seat 0" (#114). They are tied together here —
+	// click a tab and the seat follows it, change the seat and the strip jumps to
+	// that seat's first deck.
+	//
+	// The strip's own cursor is an INDEX, which shifts whenever a deck is spawned
+	// or deleted, so the deck ID is what's canonical: `deckTabIndex` is only the
+	// transport to and from tweakpane, re-derived from the id whenever `deckIds`
+	// moves. `synced` remembers what this component last agreed to, which is how
+	// the effect below tells WHICH of the three inputs actually changed — two
+	// plain effects would fight, and a seat with no decks would have its own
+	// selection undone by the tab strip.
+
+	/** owner seat of `deck:<owner>:<slot>`; undefined for a real player's deck */
+	function deckSeat(deckId: string | undefined): SeatIndex | undefined {
+		const owner = deckId?.split(':')[1];
+		return owner && isSeatPlaceholder(owner) ? (Number(owner.slice(4)) as SeatIndex) : undefined;
+	}
+
+	function firstDeckForSeat(ids: string[], seat: SeatIndex): string | undefined {
+		return ids.find((id) => deckSeat(id) === seat);
+	}
+
+	let selectedDeck: string | null = $state(null);
+	let deckTabIndex = $state(0);
+	let synced = { seat: 0 as number, index: 0, ids: '' };
+
+	/** Move the strip's cursor, recording it so the effect below knows it's ours. */
+	function setTabIndex(index: number, ids: string[]) {
+		deckTabIndex = index;
+		synced = { seat: activeSeat, index, ids: ids.join('\n') };
+	}
+
+	/** Point both controls at one deck. The single writer for either cursor. */
+	function pointAt(deckId: string | null, ids: string[]) {
+		selectedDeck = deckId;
+		const seat = deckSeat(deckId ?? undefined);
+		if (seat !== undefined) activeSeat = seat;
+		setTabIndex(deckId ? Math.max(0, ids.indexOf(deckId)) : 0, ids);
+	}
+
+	/**
+	 * tweakpane builds a tab page from the child component's `onMount`, one flush
+	 * AFTER `deckIds` grows — so an index written in the same flush addresses a
+	 * page that doesn't exist yet, and `TabGroup` only re-applies `selectedIndex`
+	 * when the NUMBER changes, so it never retries. Park the cursor out of range
+	 * (`pages.at()` misses, which is a no-op rather than a selection) and put it
+	 * back once the pages are there. Without this the outline on the table and
+	 * the tab strip disagree the first time a deck spawns for the far seat.
+	 */
+	function reassertTab(ids: string[]) {
+		const want = deckTabIndex;
+		const parked = ids.length;
+		setTabIndex(parked, ids);
+		tick().then(() => {
+			if (deckTabIndex === parked) setTabIndex(want, ids);
+		});
+	}
+
+	$effect(() => {
+		const ids = deckIds;
+		const idsKey = ids.join('\n');
+		const index = deckTabIndex;
+		const seat = activeSeat;
+
+		if (idsKey !== synced.ids) {
+			// decks spawned or went away. A deck just spawned FOR the seat being
+			// edited is what you want to position next, so it wins; otherwise hold
+			// whatever was selected, and only then fall back to the seat's first.
+			const before = synced.ids ? synced.ids.split('\n') : [];
+			const added = ids.find((id) => !before.includes(id) && deckSeat(id) === seat);
+			const keep = selectedDeck && ids.includes(selectedDeck) ? selectedDeck : null;
+			pointAt(added ?? keep ?? firstDeckForSeat(ids, seat) ?? ids[0] ?? null, ids);
+			if (ids.length) reassertTab(ids);
+		} else if (index !== synced.index) {
+			// a tab was clicked — the seat follows it
+			pointAt(ids[index] ?? null, ids);
+		} else if (seat !== synced.seat) {
+			// the seat was changed — the strip follows it, when that seat has a deck
+			const id = firstDeckForSeat(ids, seat);
+			if (id) pointAt(id, ids);
+			else synced.seat = seat;
+		}
+	});
+
+	// publish to the scene, and stop highlighting when the editor goes away
+	$effect(() => {
+		setSelectedDeck(selectedDeck);
+		return () => setSelectedDeck(null);
+	});
 
 	// Snap points — authored placement guides. The scene has the direct
 	// manipulation (click to place while armed, drag a marker to move,
@@ -291,7 +437,7 @@
 	</Folder>
 	{#if deckIds.length > 0}
 		<Folder title="Decks" expanded={true}>
-			<TabGroup>
+			<TabGroup bind:selectedIndex={deckTabIndex}>
 				{#each deckIds as deckId (deckId)}
 					{@const deck = $gameStore?.decks?.[deckId]}
 					{@const position = deck?.position ?? [0, 0.4, 0]}
@@ -411,7 +557,13 @@
 		<Button title="Load selected" on:click={handleLoad} />
 		<Button title="Export selected (.tbps.json)" on:click={handleExport} />
 		<Button title="Open a scenario (.tbps.json)" on:click={() => scenarioFileInput?.click()} />
-		<Button title="Delete selected" on:click={handleDelete} />
+		<Button
+			title={armed === 'delete' ? `Really delete "${selectedScenario}"?` : 'Delete selected'}
+			on:click={handleDelete}
+		/>
+		{#if armed === 'delete'}
+			<Button title="Keep it" on:click={disarm} />
+		{/if}
 		<Element>
 			<input
 				bind:this={scenarioFileInput}
@@ -422,7 +574,13 @@
 			/>
 		</Element>
 	</Folder>
-	<Button title="Clear table" on:click={clearTable} />
+	<Button
+		title={armed === 'clear' ? 'Really clear the whole table?' : 'Clear table'}
+		on:click={handleClearTable}
+	/>
+	{#if armed === 'clear'}
+		<Button title="Leave it alone" on:click={disarm} />
+	{/if}
 	<Textarea
 		disabled
 		rows={6}

--- a/src/routes/setup/__tests__/SetupPane.snap.test.ts
+++ b/src/routes/setup/__tests__/SetupPane.snap.test.ts
@@ -113,7 +113,12 @@ describe('SetupPane — snap points', () => {
 		await fireEvent.click(button(container, 'Add at table centre')!);
 		await settle();
 
+		// non-empty table: the first click only arms the button (#114)
 		await fireEvent.click(button(container, 'Clear table')!);
+		await settle();
+		expect(snapPoints()).not.toEqual({});
+
+		await fireEvent.click(button(container, 'Really clear the whole table?')!);
 		await settle();
 
 		expect(snapPoints()).toEqual({});

--- a/src/routes/setup/__tests__/SetupPane.test.ts
+++ b/src/routes/setup/__tests__/SetupPane.test.ts
@@ -4,13 +4,19 @@
  * blade that tears down takes the WHOLE pane with it — see BulkSheet.svelte's
  * note), and "spawn for the seat I'm editing" wires the seat through, so the
  * same pack can be laid out for both sides without re-picking a file (#93).
+ *
+ * Plus the two #114 fixes: seat selection and the Decks tab strip are one
+ * selection expressed two ways, and the irreversible buttons need a second
+ * click.
  */
 import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, fireEvent, render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import SetupPane from '../SetupPane.svelte';
 import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { selectedDeckId } from '$lib/store/deckSelection';
 import { saveLibraryPack } from '$lib/packs/library';
+import { saveScenario, listScenarios } from '$lib/scenario/scenario';
 import type { GamePackDef } from '$lib/packs/types';
 
 // jsdom has neither observer; the draggable Pane needs one and tweakpane's
@@ -87,5 +93,199 @@ describe('SetupPane', () => {
 		// the placeholder that will own it is seated first, or the scenario would
 		// save a deck belonging to nobody
 		expect(get(gameStore).players?.seat1?.seat).toBe(1);
+	});
+});
+
+/** two decks on the table, one per seat — the state #114 was reported against */
+function twoSeatsWithDecks() {
+	gameStore.set({
+		players: {
+			seat0: { id: 'seat0', seat: 0, joinTimestamp: 0, tray: {}, metadata: {} },
+			seat1: { id: 'seat1', seat: 1, joinTimestamp: 0, tray: {}, metadata: {} }
+		},
+		cards: {},
+		decks: {
+			'deck:seat0:main': { id: 'deck:seat0:main', cards: [], position: [8.5, 0.4, 4.5] },
+			'deck:seat1:main': { id: 'deck:seat1:main', cards: [], position: [8.5, 0.4, -4.7] }
+		},
+		pieces: {},
+		overlays: {}
+	} as unknown as Parameters<typeof gameStore.set>[0]);
+}
+
+/** tweakpane renders tab titles into their own buttons */
+const tab = (container: HTMLElement, title: string) =>
+	[...container.querySelectorAll('button')].find((b) => b.textContent?.trim() === title);
+
+/** …and marks the active one `tp-tbiv-sel` — tweakpane's own idea of selected */
+const selectedTabTitle = (container: HTMLElement) =>
+	container.querySelector('.tp-tbiv-sel')?.textContent?.trim();
+
+describe('SetupPane — seat and deck tab are one selection (#114)', () => {
+	beforeEach(() => {
+		cleanup();
+		localStorage.clear();
+		gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {}, overlays: {} });
+		selectedDeckId.set(null);
+	});
+
+	it('follows the seat when a deck tab is clicked', async () => {
+		twoSeatsWithDecks();
+		const { container } = render(SetupPane);
+		await settle();
+
+		// the strip opens on the seat being edited
+		expect(get(selectedDeckId)).toBe('deck:seat0:main');
+		expect(button(container, 'View table from seat 0')).toBeDefined();
+
+		await fireEvent.click(tab(container, 'seat1 main')!);
+		await settle();
+
+		expect(get(selectedDeckId)).toBe('deck:seat1:main');
+		// every "for seat N" button now agrees with the tab
+		expect(button(container, 'View table from seat 1')).toBeDefined();
+		expect(button(container, 'Spawn selected for seat 1')).toBeDefined();
+	});
+
+	it('moves the tab strip when the seat is changed', async () => {
+		twoSeatsWithDecks();
+		const { container } = render(SetupPane);
+		await settle();
+
+		const seats = listWith(container, 'Seat 1 (far)');
+		seats.selectedIndex = 1;
+		seats.dispatchEvent(new Event('change', { bubbles: true }));
+		await settle();
+
+		expect(get(selectedDeckId)).toBe('deck:seat1:main');
+		expect(selectedTabTitle(container)).toBe('seat1 main');
+		// and the pane is still standing
+		expect(button(container, 'Clear table')).toBeDefined();
+	});
+
+	it('keeps pointing at the same deck when another one spawns', async () => {
+		twoSeatsWithDecks();
+		const { container } = render(SetupPane);
+		await settle();
+
+		await fireEvent.click(tab(container, 'seat1 main')!);
+		await settle();
+
+		gameStore.updateState({
+			decks: { 'deck:seat0:discard': { id: 'deck:seat0:discard', cards: [] } }
+		} as unknown as Parameters<typeof gameStore.updateState>[0]);
+		await settle();
+
+		// the index shifted under the strip; the SELECTION did not
+		expect(get(selectedDeckId)).toBe('deck:seat1:main');
+		expect(button(container, 'View table from seat 1')).toBeDefined();
+	});
+
+	it('stays on the seat a deck was just spawned for, strip included', async () => {
+		saveLibraryPack(PACK);
+		const { container } = render(SetupPane);
+		await settle();
+
+		await fireEvent.click(button(container, 'Spawn selected for seat 0')!);
+		await settle();
+
+		const seats = listWith(container, 'Seat 1 (far)');
+		seats.selectedIndex = 1;
+		seats.dispatchEvent(new Event('change', { bubbles: true }));
+		await settle();
+		await fireEvent.click(button(container, 'Spawn selected for seat 1')!);
+		await settle();
+
+		// the seat you spawned for stays put — it used to snap back to seat 0
+		expect(button(container, 'View table from seat 1')).toBeDefined();
+		expect(get(selectedDeckId)).toBe('deck:seat1:main');
+		// and tweakpane's own cursor agrees with the outline on the table: the
+		// selected page is the only one whose controls are visible
+		expect(selectedTabTitle(container)).toBe('seat1 main');
+	});
+
+	it('stops highlighting once the editor is gone', async () => {
+		twoSeatsWithDecks();
+		const { unmount } = render(SetupPane);
+		await settle();
+		expect(get(selectedDeckId)).toBe('deck:seat0:main');
+
+		unmount();
+		await settle();
+
+		expect(get(selectedDeckId)).toBeNull();
+	});
+});
+
+describe('SetupPane — the irreversible buttons ask twice (#114)', () => {
+	beforeEach(() => {
+		cleanup();
+		localStorage.clear();
+		gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {}, overlays: {} });
+		selectedDeckId.set(null);
+	});
+
+	it('arms Clear table before wiping a non-empty table', async () => {
+		twoSeatsWithDecks();
+		const { container } = render(SetupPane);
+		await settle();
+
+		await fireEvent.click(button(container, 'Clear table')!);
+		await settle();
+
+		// nothing gone yet, and there is a way back
+		expect(Object.values(get(gameStore).decks ?? {}).filter(Boolean)).toHaveLength(2);
+		expect(button(container, 'Leave it alone')).toBeDefined();
+
+		await fireEvent.click(button(container, 'Really clear the whole table?')!);
+		await settle();
+
+		expect(Object.values(get(gameStore).decks ?? {}).filter(Boolean)).toHaveLength(0);
+		// disarmed again, and the pane survived both blades coming and going
+		expect(button(container, 'Leave it alone')).toBeUndefined();
+		expect(button(container, 'Clear table')).toBeDefined();
+		expect(button(container, 'Save scenario')).toBeDefined();
+	});
+
+	it('cancels an armed Clear table', async () => {
+		twoSeatsWithDecks();
+		const { container } = render(SetupPane);
+		await settle();
+
+		await fireEvent.click(button(container, 'Clear table')!);
+		await settle();
+		await fireEvent.click(button(container, 'Leave it alone')!);
+		await settle();
+
+		expect(Object.values(get(gameStore).decks ?? {}).filter(Boolean)).toHaveLength(2);
+		expect(button(container, 'Clear table')).toBeDefined();
+	});
+
+	it('does not bother asking when the table is already empty', async () => {
+		const { container } = render(SetupPane);
+		await settle();
+
+		await fireEvent.click(button(container, 'Clear table')!);
+		await settle();
+
+		expect(button(container, 'Really clear the whole table?')).toBeUndefined();
+	});
+
+	it('arms Delete selected before dropping a saved scenario', async () => {
+		twoSeatsWithDecks();
+		saveScenario('keeper');
+		const { container } = render(SetupPane);
+		await settle();
+
+		await fireEvent.click(button(container, 'Delete selected')!);
+		await settle();
+		expect(listScenarios().map((s) => s.name)).toEqual(['keeper']);
+
+		await fireEvent.click(button(container, 'Really delete "keeper"?')!);
+		await settle();
+
+		expect(listScenarios()).toEqual([]);
+		expect(button(container, 'Delete selected')).toBeDefined();
+		expect(button(container, 'Clear table')).toBeDefined();
 	});
 });


### PR DESCRIPTION
Task: tableplace-114

Closes #114

Part of epic #107 (§3e). Based on `feat/pane-ux`, which already carries #112 and #113.

## What changed

### 1. Seat selection and the deck tab strip are one selection

`Editing seat` decided where a spawn landed and what four buttons were labelled; the Decks `TabGroup` decided which deck the `position` / `rotation` controls moved. Unrelated state, 80px apart, both looking like "the thing I have selected" — the strip could read `seat1 main` while every button said "for seat 0".

Now: clicking a deck tab whose id belongs to seat N sets `activeSeat = N`; changing `Editing seat` selects that seat's first deck tab; and a deck you just spawned **for the seat you're editing** becomes the selection (it used to snap you back to seat 0).

The deck **id** is canonical, not the strip's index — an index shifts whenever a deck spawns or is deleted. Two subtleties are commented in place:

- One effect decides *which* of the three inputs moved, against a `synced` snapshot. Two plain effects fight each other, and a seat with no decks would have its own selection silently undone by the strip.
- A fresh tab page doesn't exist until the flush *after* `deckIds` grows, and `TabGroup` only re-applies `selectedIndex` when the number itself changes — so it never retries. The cursor is parked out of range (`pages.at()` misses, a no-op rather than a selection) and put back once the page is there. Without this the outline on the table and the tab strip disagreed the first time a deck spawned for the far seat.

### 2. The selected deck is identified on the table

An outline + faint fill around the selected deck, built from the same `DropFootprint` primitive the drop cues use, `depthTest={false}` so it survives a low camera angle. Lime (`#a3e635`), deliberately clear of the cyan drop highlight, the amber stack highlight and the violet snap markers.

It rides a small store (`$lib/store/deckSelection`) rather than a prop, for the same reason `snapEditor` does: the pane lives outside the `<Canvas>` and the thing that has to react is a `Deck` several components inside it. Only /setup ever writes it, and it clears on unmount — no deck is ever outlined in /play.

**On §2's aside:** `spawnPack`'s default placement is *already* seat-relative. Observed on localhost: seat 0's deck spawns at `8.50 / 4.50` at 0°, seat 1's at `8.50 / -4.70` at 180° — near and far edges respectively. Nothing needed there, so nothing changed.

### 3. `Clear table` and `Delete selected` need a second click

Both were irreversible, and `Clear table` sits directly below `Delete selected`, so a mis-click after deleting a scenario wiped the arrangement too.

They arm themselves: the first click renames the button to the question (`Really clear the whole table?` / `Really delete "my-scenario"?`) and **adds** a cancel beside it; the second click goes through; an armed button left alone disarms after 5s. Renaming plus adding a blade, never swapping one — an `{#if}` that *replaces* a blade tears the whole pane down (see the note in `create/BulkSheet.svelte`). Per the ticket, an already-empty table still clears without asking; "empty" judges overlays by their `imageUrl`, since the pane keeps a bare `overlays.table` record alive for its own Position/Scale/Rotation controls.

## Verification

`bun run check` 0 errors (11 pre-existing warnings), `bun run build` clean, `bun vitest run` 743 passing (61 files). `bun run lint` is red at baseline on this repo; the one eslint error in `SetupPane.svelte` is the pre-existing `no-useless-mustaches` on the help `Textarea` that #115 owns (line moved, rule and blade unchanged) — prettier and eslint are otherwise clean on every file touched here.

Six new jsdom tests drive the real tweakpane blades, asserting tweakpane's own `.tp-tbiv-sel` cursor rather than just the store, and — following this file's existing discipline — that the pane is still standing after every blade appears and disappears.

**On localhost (`bun run dev`), not just in tests.** Built two seats' decks and watched all four signals move together in both directions: `Editing seat`, the four "for seat N" button labels, the `position` readout, and the lime outline on the felt. Clicking `seat1 main` flipped everything to seat 1 (readout `8.50 / -4.70`, 180°, outline on the far deck); clicking `seat0 main` flipped it all back (`8.50 / 4.50`, 0°, outline on the near deck). Spawning for seat 1 while editing seat 1 kept the seat put and selected the new tab. Round-tripped save → clear → load with both decks and everything came back consistent. Armed and cancelled `Clear table`, armed and confirmed it, and did the same for `Delete selected` (scenario still in `localStorage` while armed, gone after the second click) — pane fully intact throughout, no console errors.

## Scope

Confined to `src/routes/setup/`, one new store module, and the `Deck.svelte` render the highlight needs. `src/routes/create/` (#108) and the help `Textarea` (#115) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWqTGRDR3QgYKhCzegzUyk