### PR TITLE
tableplace-115: help text is prose, not disabled form controls

### DIFF
--- a/src/lib/tweakpane/PaneProse.svelte
+++ b/src/lib/tweakpane/PaneProse.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+	import { getContext, type Snippet } from 'svelte';
+	import type { Writable } from 'svelte/store';
+
+	/**
+	 * Real HTML inside a tweakpane pane — the help/prose blade #115 needs.
+	 *
+	 * `svelte-tweakpane-ui`'s own `<Element>` is meant for exactly this and is
+	 * what /create uses (`BulkSheet.svelte`, `CreatePane.svelte`), but it only
+	 * works in a `position="inline"` pane. In a `position="draggable"` one its
+	 * contents never make it into the pane at all: `<Element>` moves its slot
+	 * into the blade from a Svelte 4 `$:` statement that, in a draggable pane,
+	 * never re-runs once the blade ref lands — the markup is left stranded in the
+	 * pane's container, which is the "the title bar drew straight through it"
+	 * symptom #113 hit in `PaneDecks.svelte`. Verified on localhost before this
+	 * component existed: 0 of 5 `<Element>`s on /play had been moved into the
+	 * pane, against 1 of 1 on /create.
+	 *
+	 * So this does the same job through the same tweakpane contract, but drives
+	 * the move from an `$effect`, which re-runs whenever the blade is recreated.
+	 *
+	 * Same swap hazard as everything else here (`BulkSheet.svelte:135-140`): keep
+	 * one of these mounted and drive its contents by expression rather than
+	 * wrapping it in an `{#if}` that replaces a blade.
+	 */
+
+	type Blade = { element: HTMLElement; dispose: () => void };
+	type BladeContainer = { addBlade: (options: Record<string, unknown>) => Blade };
+
+	let { children }: { children: Snippet } = $props();
+
+	// the container (Pane or Folder) that mounts us — the same context
+	// svelte-tweakpane-ui hands to its own blades
+	const parentStore = getContext<Writable<BladeContainer | undefined>>('parentStore');
+
+	// a zero-size marker left in Svelte's DOM: its position among its siblings is
+	// where this blade belongs in the pane
+	let marker = $state<HTMLDivElement>();
+	let source = $state<HTMLDivElement>();
+
+	/** siblings before the marker, minus the ones that aren't blades themselves */
+	function bladeIndex(el: HTMLElement): number {
+		let index = 0;
+		for (let s = el.previousElementSibling; s !== null; s = s.previousElementSibling) {
+			if (!s.classList.contains('skip-element-index')) index++;
+		}
+		return index;
+	}
+
+	// An explicit subscription rather than `$effect(() => $parentStore)`: a
+	// `<Folder>` hands its children an empty store and only fills it in once its
+	// own blade exists, and that late write is exactly the update the auto-
+	// subscription missed — the bug this component is here to avoid.
+	$effect(() => {
+		if (!marker || !source) return;
+		const anchor = marker;
+		const content = source;
+		let blade: Blade | undefined;
+
+		const unsubscribe = parentStore.subscribe((container) => {
+			blade?.dispose();
+			blade = undefined;
+			if (!container) return;
+			blade = container.addBlade({ index: bladeIndex(anchor), view: 'separator' });
+			blade.element.replaceChildren(content);
+		});
+
+		return () => {
+			unsubscribe();
+			blade?.dispose();
+		};
+	});
+</script>
+
+<div bind:this={marker} style="display: none;"></div>
+<!--
+	`skip-element-index` keeps this out of the blade count while it is still
+	sitting in Svelte's DOM, so the blades after it don't land one row too low.
+-->
+<div bind:this={source} class="skip-element-index tp-prose">
+	{@render children()}
+</div>
+
+<style>
+	/* line the prose up with the blades above it, which are inset by the
+	   container's horizontal padding */
+	.tp-prose {
+		padding-right: var(--cnt-hp);
+		padding-left: var(--cnt-hp);
+	}
+</style>

--- a/src/routes/create/FaceRef.svelte
+++ b/src/routes/create/FaceRef.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
-	import { AutoValue, Folder, List, Text } from 'svelte-tweakpane-ui';
+	import { AutoValue, Folder, List, Monitor, Text } from 'svelte-tweakpane-ui';
 	import { buildFaceRef, parseFaceRef, FACE_SCHEME_OPTIONS, type FaceDraft } from './face-ref';
 	import RefThumb from './RefThumb.svelte';
 
@@ -73,9 +73,16 @@
 		<AutoValue label="Rows" bind:value={sheetRows} {disabled} />
 		<AutoValue label="Cell index" bind:value={sheetIndex} {disabled} />
 	{/if}
-	<!-- the ref row stays: it is the string you copy, and the thumbnail is not
-	     something you can paste into another card -->
-	<Text label="Ref" value={built} disabled />
+	<!--
+		The ref row stays: it is the string you copy, and the thumbnail is not
+		something you can paste into another card. A `Monitor` rather than a
+		permanently-disabled `Text` (#115) — it is derived from the fields above
+		and can never be typed into, and a greyed-out input reads as "you are not
+		allowed to edit this" rather than "this is the output". It still takes
+		`disabled`, so it dims with the rest of the block when there is nothing to
+		edit (#109) instead of looking the same either way.
+	-->
+	<Monitor label="Ref" value={built} {disabled} />
 	<!-- dimmed with the rest of the block when there is nothing to edit: the ref
 	     it is previewing is then the seed for the NEXT card, not art on the table -->
 	<RefThumb value={built} label={title.toLowerCase()} dimmed={disabled} />

--- a/src/routes/play/Pane.svelte
+++ b/src/routes/play/Pane.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { gameStore } from '$lib/store/game/gameStore.svelte';
+	import PaneProse from '$lib/tweakpane/PaneProse.svelte';
 	import {
 		Button,
 		Pane,
@@ -9,7 +10,7 @@
 		AutoValue,
 		Folder,
 		FpsGraph,
-		Textarea
+		Monitor
 	} from 'svelte-tweakpane-ui';
 	import { DEG2RAD } from 'three/src/math/MathUtils.js';
 	import { purgeUndefinedValues } from '$lib/utils/transforms/data';
@@ -124,6 +125,24 @@
 				: `Copied invite — joiner auto-claims seat ${inviteSeat}`
 		);
 	}
+
+	// The reference card, as data rather than as eleven disabled `Text` blades
+	// (#115). Ordered as you meet them: look, then act on one card, then on a
+	// pile, then the drag modifiers.
+	const KEYBINDS: [action: string, key: string][] = [
+		['Reset camera', 'C'],
+		['Preview hovered', 'spacebar'],
+		['Tap card', 'T'],
+		['Reverse Tap card', 'R'],
+		['Flip card', 'F'],
+		['Group stack into deck', 'G'],
+		[`Ungroup deck (max ${UNGROUP_MAX_CARDS} cards)`, 'Shift + G'],
+		['Drop without snapping', 'hold Alt'],
+		['Cancel drag', 'Esc'],
+		['Nudge card higher', 'Arrow Up'],
+		// #113 fixed this label — it is Arrow Down, not the Shift chord it used to claim
+		['Nudge card lower', 'Arrow Down']
+	];
 </script>
 
 <Pane
@@ -136,7 +155,8 @@
 	localStoreId="table-settings"
 >
 	<Folder title="Connection" expanded={false}>
-		<Text label="My ID" value={localStorage.getItem('myPlayerId') ?? ''} disabled />
+		<!-- read-only value, so a `Monitor` rather than an input that refuses you (#115) -->
+		<Monitor label="My ID" value={localStorage.getItem('myPlayerId') ?? ''} />
 		<Text label="Server:" bind:value={$connectionStore.serverUrl} />
 		<Text label="Lobby:" bind:value={lobbyId} />
 		<Button
@@ -148,10 +168,12 @@
 				goto(`/play?${lobbyUrl}`, { invalidateAll: true });
 			}}
 		/>
-		<Textarea
-			disabled
-			value={`Share copies an invite link — whoever opens it is seated at the first open seat and gets its decks.`}
-		/>
+		<PaneProse>
+			<div class="p-1 font-sans text-[11px] leading-snug text-white/50">
+				Share copies an invite link — whoever opens it is seated at the first open seat and gets its
+				decks.
+			</div>
+		</PaneProse>
 	</Folder>
 	<Folder title="Scenarios" expanded={isTableEmpty}>
 		<List label="Preset" bind:value={selectedScenario} options={scenarioOptions} />
@@ -164,11 +186,17 @@
 			<Button title="Claim seat {seat}" on:click={() => handleClaimSeat(seat)} />
 		{/each}
 		<Button title="Copy opponent invite" on:click={copyInvite} />
-		<Textarea
-			disabled
-			rows={3}
-			value={`Build presets at /setup. Seeding replaces the table for the whole lobby; each player then claims a seat to take over its decks.`}
-		/>
+		<!--
+			Always mounted, after the `{#each}` above: a blade computes its index from
+			its own DOM position when it is created, so seats appearing and vanishing
+			insert around this rather than displacing it.
+		-->
+		<PaneProse>
+			<div class="p-1 font-sans text-[11px] leading-snug text-white/50">
+				Build presets at /setup. Seeding replaces the table for the whole lobby; each player then
+				claims a seat to take over its decks.
+			</div>
+		</PaneProse>
 	</Folder>
 	<HUDPieces ownerId={gameActions.getMyId() ?? undefined} />
 	<Folder title="Overlays" expanded={false}>
@@ -184,17 +212,22 @@
 			label="Seat: {$gameStore?.players?.[gameActions?.getMe()?.id ?? 0]?.seat}"
 			title="Next Seat"
 		/>
-		<Text label="Reset camera" value="C" disabled />
-		<Text label="Preview hovered" value="spacebar" disabled />
-		<Text label="Tap card" value="T" disabled />
-		<Text label="Reverse Tap card" value="R" disabled />
-		<Text label="Flip card" value="F" disabled />
-		<Text label="Group stack into deck" value="G" disabled />
-		<Text label="Ungroup deck (max {UNGROUP_MAX_CARDS} cards)" value="Shift + G" disabled />
-		<Text label="Drop without snapping" value="hold Alt" disabled />
-		<Text label="Cancel drag" value="Esc" disabled />
-		<Text label="Nudge card higher" value="Arrow Up" disabled />
-		<Text label="Nudge card lower" value="Arrow Down" disabled />
+		<!--
+			One prose blade where eleven disabled `Text` blades used to be (#115): a
+			keybind is something you read, not a field you were locked out of, and
+			the list now costs one row of the pane's height instead of eleven. The
+			folder stays closed by default — #113.
+		-->
+		<PaneProse>
+			<dl
+				class="grid grid-cols-[1fr_auto] items-baseline gap-x-3 gap-y-0.5 p-1 font-sans text-[11px] leading-snug"
+			>
+				{#each KEYBINDS as [action, key] (action)}
+					<dt class="text-white/50">{action}</dt>
+					<dd class="justify-self-end font-mono text-white/80">{key}</dd>
+				{/each}
+			</dl>
+		</PaneProse>
 	</Folder>
 	<!-- instrumentation, not settings: out of the player's way until asked for -->
 	<Folder title="Debug" expanded={false}>

--- a/src/routes/play/__tests__/Pane.test.ts
+++ b/src/routes/play/__tests__/Pane.test.ts
@@ -96,10 +96,28 @@ describe('/play settings pane on first paint', () => {
 		const { container } = render(Pane);
 		await settle();
 
-		const rows = [...container.querySelectorAll('.tp-lblv')];
-		const row = rows.find((r) =>
-			r.querySelector('.tp-lblv_l')?.textContent?.includes('Nudge card lower')
+		// #115 moved the keybinds out of eleven disabled `Text` blades and into
+		// one `Element` list, so the copy #113 fixed is now a <dt>/<dd> pair
+		const term = [...container.querySelectorAll('dt')].find(
+			(t) => t.textContent?.trim() === 'Nudge card lower'
 		);
-		expect(row?.querySelector('input')?.value).toBe('Arrow Down');
+		expect(term?.nextElementSibling?.textContent?.trim()).toBe('Arrow Down');
+	});
+
+	it('renders help and keybinds as prose, not as disabled form controls', async () => {
+		const { container } = render(Pane);
+		await settle();
+
+		// the whole point of #115: nothing read-only may look like a field you
+		// are locked out of. Every keybind lives in the list...
+		expect(container.querySelectorAll('dt').length).toBe(11);
+		// ...and no blade in the pane is rendered disabled
+		expect(container.querySelectorAll('.tp-lblv-disabled').length).toBe(0);
+		expect([...container.querySelectorAll('input')].filter((i) => i.disabled).length).toBe(0);
+		expect(container.querySelector('textarea')).toBeNull();
+
+		// the share/seed explanations survived the move out of the Textareas
+		expect(container.textContent).toContain('whoever opens it is seated at the first open seat');
+		expect(container.textContent).toContain('Build presets at /setup');
 	});
 });

--- a/src/routes/setup/SetupPane.svelte
+++ b/src/routes/setup/SetupPane.svelte
@@ -6,7 +6,6 @@
 		Folder,
 		List,
 		Text,
-		Textarea,
 		Point,
 		Wheel,
 		AutoValue,
@@ -39,6 +38,7 @@
 	import { snapEditor, setSnapDefaults, setSnapPlacing } from '$lib/store/snapEditor';
 	import { SNAP_RADIUS_DEFAULT } from '$lib/utils/constants-snap';
 	import HUDPieces from '$lib/HUDPieces.svelte';
+	import PaneProse from '$lib/tweakpane/PaneProse.svelte';
 	import FileDropZone from '$lib/files/FileDropZone.svelte';
 	import { openDroppedFile } from '$lib/files/drop';
 	import { purgeUndefinedValues } from '$lib/utils/transforms/data';
@@ -581,11 +581,55 @@
 	{#if armed === 'clear'}
 		<Button title="Leave it alone" on:click={disarm} />
 	{/if}
-	<Textarea
-		disabled
-		rows={6}
-		value={`Everything here is local — no lobby is touched. Open a pack (or drop a .tbpp.json on the table) and it joins your pack library, ready to spawn for any seat without picking the file again. Place the map, arrange, then Save. Pack decks save as a pack reference plus their card order, so a stacked deck reloads exactly; tick "shuffle on load" for a draw pile. Snap points: arm "place on click" and click the felt, drag a ring to move it, right-click it to delete. They ride along in the scenario and pull dropped cards/tokens onto themselves in /play (hold Alt on release to ignore them); the rings only show here. Your library lives in this browser only — share a pack by exporting its .tbpp.json. Seed a lobby from /play → Settings → Scenarios. Note: cards in YOUR hand tray are not saved; keep starting cards on the table.`}
-	/>
+
+	<!--
+		Prose, not a disabled `Textarea` (#115): six rows of dense explanation in a
+		scroll box reads as a broken field, can't wrap to the pane and can't be
+		selected. One always-mounted blade inside a folder that is closed by
+		default — the pane is already the tallest thing on the route, and this is
+		reference you read once. See the swap hazard in `BulkSheet.svelte:135-140`:
+		adding a folder is fine, replacing a blade is not.
+	-->
+	<Folder title="How this works" expanded={false}>
+		<PaneProse>
+			<!--
+				Bounded and scrolled inside itself (`max-h-64`, as `BulkSheet` bounds
+				its grid): this folder is the last thing in the tallest pane on the
+				route and a draggable tweakpane doesn't scroll, so an unbounded block
+				would put its own tail under the bottom of the viewport — the exact
+				failure #115 is about. Prose that scrolls is still prose; it wraps to
+				the pane and can be selected.
+			-->
+			<div
+				class="flex max-h-64 flex-col gap-2 overflow-y-auto p-1 font-sans text-[11px] leading-snug text-white/50"
+			>
+				<p>
+					Everything here is local — no lobby is touched. Open a pack (or drop a
+					<code class="font-mono text-white/65">.tbpp.json</code> on the table) and it joins your pack
+					library, ready to spawn for any seat without picking the file again. Place the map, arrange,
+					then Save.
+				</p>
+				<p>
+					Pack decks save as a pack reference plus their card order, so a stacked deck reloads
+					exactly; tick <em class="text-white/65 not-italic">shuffle on load</em> for a draw pile.
+				</p>
+				<p>
+					<span class="text-white/65">Snap points:</span> arm
+					<em class="text-white/65 not-italic">place on click</em> and click the felt, drag a ring to
+					move it, right-click it to delete. They ride along in the scenario and pull dropped cards/tokens
+					onto themselves in /play (hold Alt on release to ignore them); the rings only show here.
+				</p>
+				<p>
+					Your library lives in this browser only — share a pack by exporting its
+					<code class="font-mono text-white/65">.tbpp.json</code>. Seed a lobby from /play →
+					Settings → Scenarios.
+				</p>
+				<p class="text-white/65">
+					Note: cards in your hand tray are not saved — keep starting cards on the table.
+				</p>
+			</div>
+		</PaneProse>
+	</Folder>
 </Pane>
 
 <FileDropZone onfile={handleDroppedFile} />

--- a/src/routes/setup/__tests__/SetupPane.test.ts
+++ b/src/routes/setup/__tests__/SetupPane.test.ts
@@ -94,6 +94,18 @@ describe('SetupPane', () => {
 		// save a deck belonging to nobody
 		expect(get(gameStore).players?.seat1?.seat).toBe(1);
 	});
+
+	it('explains itself in prose, not in a disabled Textarea', async () => {
+		const { container } = render(SetupPane);
+		await settle();
+
+		// #115: the six-row disabled scroll box is gone, and its copy survived the
+		// move into real markup behind the "How this works" folder
+		expect(container.querySelector('textarea')).toBeNull();
+		expect([...container.querySelectorAll('input')].filter((i) => i.disabled)).toHaveLength(0);
+		expect(container.textContent).toContain('Everything here is local');
+		expect(container.textContent).toContain('cards in your hand tray are not saved');
+	});
 });
 
 /** two decks on the table, one per seat — the state #114 was reported against */


### PR DESCRIPTION
Task: tableplace-115

Closes #115

Part of epic #107 — targets `feat/pane-ux`, not `main`.

Every piece of read-only text in the panes was rendered as a **disabled form control**. A greyed-out field reads as "this is broken" or "you're not allowed to edit this", not as documentation — and it costs height in panes that are already overflowing.

Scope is the corrected one from the ticket: #108 already moved /create's two help `Textarea`s into the editor column, so this is what was left.

| what | before | after |
|---|---|---|
| `create/FaceRef` | `Text disabled` — the built ref | `Monitor` |
| `play/Pane` | `Text disabled` — My ID | `Monitor` |
| `play/Pane` | `Textarea disabled` ×2 — share / seed | prose |
| `play/Pane` | `Text disabled` ×11 — keybinds | one two-column list |
| `setup/SetupPane` | `Textarea disabled rows={6}` | collapsed "How this works" folder |

#113's copy is carried forward exactly — "Nudge card lower" is `Arrow Down`, and the Keybinds folder stays closed by default. The `SetupPane` change is confined to the help blade, so it should rebase cleanly over #114.

## The part worth reviewing: `PaneProse`

The ticket proposed `<Element>` with real HTML, citing `BulkSheet`. That works on /create — and **only** on /create. In a `position="draggable"` pane, `<Element>`'s contents never reach the pane at all: a `<Folder>` hands its children an empty store and only fills it in once its own blade exists, and the Svelte 4 `$:` inside `<Element>` misses that late write, leaving the markup stranded in the pane's container.

That is exactly the "a tweakpane `<Element>` mounts its DOM in the pane's *container*, so the title bar drew straight through it" symptom #113 documented in `PaneDecks.svelte`. It has gone unnoticed because every other `<Element>` in a draggable pane holds a *hidden* file input, where failing to relocate costs nothing.

Measured on localhost before writing the component: **0 of 5** `<Element>`s on /play had been moved into the pane, against **1 of 1** on /create.

`src/lib/tweakpane/PaneProse.svelte` does the same job over the same tweakpane contract, but drives the move from an explicit store subscription that cannot miss the update. Existing `<Element>` uses are left alone.

## Verification

Checked on localhost (`bun run dev`) on all three routes, since there's no deployed preview:

- **/play** — Keybinds opens to a clean two-column list, 11 rows in one blade, `Nudge card lower → Arrow Down`; folder still closed on first paint. Connection shows `My ID` as a flat Monitor, visually distinct from the editable Server/Lobby inputs, with the share explanation as wrapped prose. Scenarios shows the seed prose the same way.
- **/setup** — "How this works" sits collapsed at the foot of the pane; opened, it renders as paragraphs with inline `.tbpp.json` code styling, bounded and scrolled within the viewport.
- **/create** — the `Ref` rows (`gen:std52/AS`, `gen:std52/back`) render as Monitors, flat against the editable `Code` field above them. #108's column is untouched.

`bun run check` 0 errors · `bun run test` 745 passed · `bun run build` clean. `bun run lint` sits at its pre-existing 55 errors, none in the touched files (`prettier --check` and `eslint` are clean on them individually).

Tests: the #113 assertion on "Arrow Down" is re-pointed at the new markup rather than dropped, plus new regression tests on both routes that no help text renders in a disabled control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJQDGvn2xoTmRYaY279Xpo