### PR TITLE
tableplace-111: /create shows the resolved image — thumbnails for card face, deck back, piece and overlay

### DIFF
--- a/src/routes/create/CreatePane.svelte
+++ b/src/routes/create/CreatePane.svelte
@@ -70,6 +70,7 @@
 		type EditorPack
 	} from './normalize';
 	import FaceRef from './FaceRef.svelte';
+	import RefThumb from './RefThumb.svelte';
 	import BulkSheet from './BulkSheet.svelte';
 	import { allocateCode } from './bulk-sheet';
 	import type { PackCardDef } from '$lib/packs/types';
@@ -899,6 +900,7 @@
 						<Color label="Color" bind:value={piece.color} />
 						{#if piece.kind === 'token' || piece.kind === 'bag'}
 							<Text label="Image URL" bind:value={piece.imageUrl} />
+							<RefThumb value={piece.imageUrl} label="piece image" aspect="square" />
 						{/if}
 						<!--
 							States: the TTS `States` analog — one piece, several faces, cycled in
@@ -999,6 +1001,7 @@
 						<Separator />
 						<List label="Overlay" bind:value={overlayCursor} options={overlayOptions} />
 						<Text label="Image URL" bind:value={overlay.imageUrl} />
+						<RefThumb value={overlay.imageUrl} label="overlay image" aspect="wide" />
 						<AutoValue label="Ratio (w/h)" bind:value={overlay.ratio} />
 						<AutoValue label="Scale" bind:value={overlay.scale} />
 						<Button title="Remove overlay" on:click={removeOverlay} />

--- a/src/routes/create/FaceRef.svelte
+++ b/src/routes/create/FaceRef.svelte
@@ -2,6 +2,7 @@
 	import { untrack } from 'svelte';
 	import { AutoValue, Folder, List, Text } from 'svelte-tweakpane-ui';
 	import { buildFaceRef, parseFaceRef, FACE_SCHEME_OPTIONS, type FaceDraft } from './face-ref';
+	import RefThumb from './RefThumb.svelte';
 
 	/**
 	 * Inline face authoring for whatever the pane is editing right now — a
@@ -63,5 +64,8 @@
 		<AutoValue label="Rows" bind:value={sheetRows} />
 		<AutoValue label="Cell index" bind:value={sheetIndex} />
 	{/if}
+	<!-- the ref row stays: it is the string you copy, and the thumbnail is not
+	     something you can paste into another card -->
 	<Text label="Ref" value={built} disabled />
+	<RefThumb value={built} label={title.toLowerCase()} />
 </Folder>

--- a/src/routes/create/RefThumb.svelte
+++ b/src/routes/create/RefThumb.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+	import { Element } from 'svelte-tweakpane-ui';
+	import { resolveRefPreview, PREVIEW_DEBOUNCE_MS, type RefPreview } from './ref-preview';
+
+	/**
+	 * The resolved image, next to the ref that sets it.
+	 *
+	 * Authoring a face used to mean typing a string and then going to look at a
+	 * 3D table to find out whether you got it right — in Deck mode, by dragging a
+	 * card off a pile and flipping it, knowing the next keystroke respawns the
+	 * preview and undoes all of that (#111). This is the same answer the bulk
+	 * sheet already gives per cell, given to the single-ref controls.
+	 *
+	 * ONE `Element` blade, always mounted, its contents driven by expressions:
+	 * an `{#if}` that swaps one blade for another tears the pane down, because
+	 * tweakpane owns that DOM (see BulkSheet.svelte). Everything below is plain
+	 * DOM inside the one element, where Svelte is free to do as it likes.
+	 */
+	let {
+		value,
+		label = 'face',
+		aspect = 'card'
+	}: {
+		/** the ref as it currently stands — `gen:`, `sheet:`, a URL, or empty */
+		value: string | undefined;
+		/** what is missing when it's empty, e.g. "card face", "overlay image" */
+		label?: string;
+		/** the tile's shape; the art is letterboxed inside it either way */
+		aspect?: 'card' | 'square' | 'wide';
+	} = $props();
+
+	const TILE = {
+		card: 'aspect-[3/4] w-16',
+		square: 'aspect-square w-16',
+		wide: 'aspect-[4/3] w-24'
+	} as const;
+
+	let preview = $state<RefPreview>({ kind: 'empty' });
+	/** set by the <img>'s own error: a resolvable ref whose art is a dead link */
+	let broken = $state(false);
+
+	$effect(() => {
+		const ref = (value ?? '').trim();
+		broken = false;
+		if (!ref) {
+			preview = { kind: 'empty' };
+			return;
+		}
+		preview = { kind: 'pending' };
+		// a ref is typed a character at a time and every prefix of a sheet URL is
+		// a fetch, so the ref has to sit still before it is worth resolving
+		let live = true;
+		const timer = setTimeout(async () => {
+			const next = await resolveRefPreview(ref);
+			if (live) preview = next;
+		}, PREVIEW_DEBOUNCE_MS);
+		return () => {
+			live = false;
+			clearTimeout(timer);
+		};
+	});
+
+	const src = $derived(preview.kind === 'image' ? preview.src : '');
+	const failed = $derived(preview.kind === 'unresolvable' || broken);
+	/**
+	 * What the tile is showing, and the one thing a test needs to assert on.
+	 * NOT called `state`: svelte2tsx reads `$state` as a subscription to a store
+	 * named `state`, so a variable by that name breaks every rune in the file.
+	 */
+	const status = $derived(failed ? 'failed' : src ? 'image' : preview.kind);
+
+	const caption = $derived(
+		status === 'failed' ? 'no preview' : status === 'pending' ? 'slicing…' : 'none'
+	);
+	const note = $derived(
+		status === 'failed'
+			? 'Dead link, or the host blocks reads. The ref is still valid — the table falls back the same way.'
+			: status === 'empty'
+				? `No ${label} set — nothing renders on the table.`
+				: ''
+	);
+</script>
+
+<Element>
+	<div class="flex items-center gap-2 p-1">
+		<div
+			class="flex shrink-0 items-center justify-center overflow-hidden rounded bg-white/10 {TILE[
+				aspect
+			]}"
+			data-testid="ref-thumb"
+			data-state={status}
+		>
+			{#if src && !broken}
+				<!-- the ref's own URL, loaded as an image and nothing more: a host
+				     that blocks canvas reads still displays fine here, and a dead
+				     one lands in `onerror` rather than as a broken-image icon -->
+				<img
+					{src}
+					alt=""
+					class="max-h-full max-w-full object-contain"
+					onerror={() => (broken = true)}
+				/>
+			{:else}
+				<span class="px-1 text-center font-sans text-[9px] leading-tight text-white/50">
+					{caption}
+				</span>
+			{/if}
+		</div>
+		{#if note}
+			<div class="min-w-0 flex-1 font-sans text-[10px] leading-snug text-white/45">{note}</div>
+		{/if}
+	</div>
+</Element>

--- a/src/routes/create/__tests__/RefThumb.test.ts
+++ b/src/routes/create/__tests__/RefThumb.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The thumbnail blade itself: what a creator sees for a ref that works, a ref
+ * that doesn't, and a ref they haven't typed yet. `data-state` is the tile's
+ * own account of which of those it is showing.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+import RefThumb from '../RefThumb.svelte';
+import { makeSheetRef } from '$lib/packs/resolve.svelte';
+
+vi.mock('$lib/tts/slice', () => ({
+	sliceCell: vi.fn(async ({ url, index }: { url: string; index: number }) =>
+		url.includes('dead') ? null : `data:image/png;base64,cell${index}`
+	)
+}));
+
+// the Pane observes its own size; jsdom has no ResizeObserver
+globalThis.ResizeObserver ??= class {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+} as unknown as typeof ResizeObserver;
+
+/** past the resolve debounce, plus tweakpane's own async render */
+const settle = (ms = 350) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const tile = (container: HTMLElement) =>
+	container.querySelector<HTMLElement>('[data-testid="ref-thumb"]')!;
+
+describe('RefThumb', () => {
+	it('says what is missing when no ref is set', async () => {
+		const { container } = render(RefThumb, { props: { value: '', label: 'card face' } });
+		await settle();
+		expect(tile(container).dataset.state).toBe('empty');
+		expect(container.textContent).toContain('No card face set');
+	});
+
+	it('shows a URL ref as an image the browser loads itself', async () => {
+		const { container } = render(RefThumb, { props: { value: 'https://example.test/card.png' } });
+		await settle();
+		expect(tile(container).dataset.state).toBe('image');
+		expect(tile(container).querySelector('img')?.getAttribute('src')).toBe(
+			'https://example.test/card.png'
+		);
+	});
+
+	it('falls back to a labelled tile when that image is a dead link', async () => {
+		const { container } = render(RefThumb, { props: { value: 'https://dead.test/gone.png' } });
+		await settle();
+		const img = tile(container).querySelector('img')!;
+		// the load failure a dead link produces, which is the only signal a plain
+		// <img> gives: without this it would sit there as a broken-image icon
+		img.dispatchEvent(new Event('error'));
+		await settle(20);
+		expect(tile(container).dataset.state).toBe('failed');
+		expect(tile(container).querySelector('img')).toBeNull();
+		expect(container.textContent).toContain('no preview');
+	});
+
+	it('slices a sheet: ref to its cell', async () => {
+		const ref = makeSheetRef({ url: 'https://example.test/s.png', cols: 10, rows: 7, index: 2 });
+		const { container } = render(RefThumb, { props: { value: ref } });
+		await settle();
+		expect(tile(container).dataset.state).toBe('image');
+		expect(tile(container).querySelector('img')?.getAttribute('src')).toBe(
+			'data:image/png;base64,cell2'
+		);
+	});
+
+	it('shows "no preview" for a sheet the host will not let it read', async () => {
+		const ref = makeSheetRef({ url: 'https://dead.test/s.png', cols: 2, rows: 2, index: 0 });
+		const { container } = render(RefThumb, { props: { value: ref } });
+		await settle();
+		expect(tile(container).dataset.state).toBe('failed');
+		expect(container.textContent).toContain('the table falls back the same way');
+	});
+
+	it('re-resolves when the ref changes, and drops a stale failure', async () => {
+		const { container, rerender } = render(RefThumb, {
+			props: { value: 'https://dead.test/gone.png' }
+		});
+		await settle();
+		tile(container).querySelector('img')!.dispatchEvent(new Event('error'));
+		await settle(20);
+		expect(tile(container).dataset.state).toBe('failed');
+
+		await rerender({ value: 'https://example.test/other.png' });
+		await settle();
+		expect(tile(container).dataset.state).toBe('image');
+	});
+});

--- a/src/routes/create/__tests__/ref-preview.test.ts
+++ b/src/routes/create/__tests__/ref-preview.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Turning a ref into something an `<img>` can take. The interesting half is
+ * the failures: a preview that lies about a dead sheet is worse than no
+ * preview, so an unslicable cell and an unparseable ref both have to come back
+ * as `unresolvable` rather than as some other card's art.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { resolveRefPreview } from '../ref-preview';
+import { makeSheetRef } from '$lib/packs/resolve.svelte';
+
+/** the CORS-tainted sheet resolves null, exactly as the real slicer does */
+vi.mock('$lib/tts/slice', () => ({
+	sliceCell: vi.fn(async ({ url, index }: { url: string; index: number }) =>
+		url.includes('dead') ? null : `data:image/png;base64,cell${index}`
+	)
+}));
+
+// jsdom has no 2d context, so the real generator can't draw — the drawing
+// itself is resolve.svelte's business, this is about what comes back
+vi.mock('$lib/packs/resolve.svelte', async () => {
+	const actual = await vi.importActual<typeof import('$lib/packs/resolve.svelte')>(
+		'$lib/packs/resolve.svelte'
+	);
+	return {
+		...actual,
+		resolveCardImage: (ref: string) => (ref === 'gen:std52/AS' ? 'data:image/png;base64,ace' : ref)
+	};
+});
+
+describe('resolveRefPreview', () => {
+	it('has nothing to show for an empty ref', async () => {
+		expect(await resolveRefPreview('')).toEqual({ kind: 'empty' });
+		expect(await resolveRefPreview('   ')).toEqual({ kind: 'empty' });
+		expect(await resolveRefPreview(undefined)).toEqual({ kind: 'empty' });
+	});
+
+	it('draws a gen: ref through the resolver', async () => {
+		expect(await resolveRefPreview('gen:std52/AS')).toEqual({
+			kind: 'image',
+			src: 'data:image/png;base64,ace'
+		});
+	});
+
+	it('calls a gen: ref it cannot draw unresolvable, never the ref string', async () => {
+		// the generator passes the ref back when there is nothing to draw with;
+		// handing that to an <img> is a request for `/gen:std52/AS`
+		expect(await resolveRefPreview('gen:nonesuch/AS')).toEqual({ kind: 'unresolvable' });
+	});
+
+	it('slices a sheet: ref to the cell it points at', async () => {
+		const ref = makeSheetRef({
+			url: 'https://example.test/sheet.png',
+			cols: 10,
+			rows: 7,
+			index: 4
+		});
+		expect(await resolveRefPreview(ref)).toEqual({
+			kind: 'image',
+			src: 'data:image/png;base64,cell4'
+		});
+	});
+
+	it('is unresolvable for a sheet that cannot be read, not the table fallback', async () => {
+		const ref = makeSheetRef({ url: 'https://dead.test/sheet.png', cols: 2, rows: 2, index: 0 });
+		expect(await resolveRefPreview(ref)).toEqual({ kind: 'unresolvable' });
+	});
+
+	it('is unresolvable for a sheet ref that is not JSON, or has no url', async () => {
+		expect(await resolveRefPreview('sheet:not json at all')).toEqual({ kind: 'unresolvable' });
+		expect(await resolveRefPreview('sheet:{"cols":2,"rows":2,"index":0}')).toEqual({
+			kind: 'unresolvable'
+		});
+	});
+
+	it('passes a URL through for the <img> to load, as the table does', async () => {
+		expect(await resolveRefPreview('https://example.test/card.png')).toEqual({
+			kind: 'image',
+			src: 'https://example.test/card.png'
+		});
+		// a broken one is still an image request: only the load can tell, and
+		// the thumbnail's own onerror is what turns it into "no preview"
+		expect(await resolveRefPreview('https://dead.test/gone.png')).toEqual({
+			kind: 'image',
+			src: 'https://dead.test/gone.png'
+		});
+	});
+
+	it('clamps a nonsense grid rather than dividing by zero', async () => {
+		const { sliceCell } = await import('$lib/tts/slice');
+		await resolveRefPreview('sheet:{"url":"https://example.test/s.png","cols":0,"rows":-3}');
+		expect(sliceCell).toHaveBeenCalledWith(expect.objectContaining({ cols: 1, rows: 1, index: 0 }));
+	});
+});

--- a/src/routes/create/ref-preview.ts
+++ b/src/routes/create/ref-preview.ts
@@ -1,0 +1,88 @@
+/**
+ * What the pane can SHOW for a ref it is editing.
+ *
+ * A face ref is one opaque string (`https://…`, `gen:std52/AS`, `sheet:{…}`),
+ * and until now the only feedback the editor gave for one was the string
+ * itself. This turns a ref into something an `<img>` can take, through the
+ * same art path the table uses: `resolveCardImage` for `gen:`, the sheet
+ * slicer for `sheet:`, and the URL itself for everything else — which is
+ * exactly what the table hands to its material.
+ *
+ * Two deliberate departures from `resolveCardImage` for `sheet:` refs, which
+ * is why they go to `sliceCell` directly (as BulkSheet's grid does):
+ *
+ * - a dead or CORS-blocked sheet resolves there to a NAMED PROXY CARD. That is
+ *   the right answer for the table, and the wrong one for a preview whose
+ *   whole job is to say whether the art is there — a drawn proxy would read as
+ *   "your ref works".
+ * - a pending slice resolves to `''`, which is indistinguishable from failure.
+ *   Here they must look different: one is a spinner, the other is an answer.
+ */
+
+import { resolveCardImage } from '$lib/packs/resolve.svelte';
+import { sliceCell } from '$lib/tts/slice';
+
+export type RefPreview =
+	/** nothing typed yet — not a failure, just no art to show */
+	| { kind: 'empty' }
+	/** a sheet cell is being fetched and cut */
+	| { kind: 'pending' }
+	/** hand this to an `<img>`; it may still fail to LOAD (dead link) */
+	| { kind: 'image'; src: string }
+	/** the ref cannot produce an image at all */
+	| { kind: 'unresolvable' };
+
+/**
+ * How long the ref sits still before it is resolved. Refs are typed a
+ * character at a time, and every prefix of a sheet URL is a fetch.
+ */
+export const PREVIEW_DEBOUNCE_MS = 250;
+
+function grid(value: unknown): number {
+	const n = Math.round(Number(value));
+	return Number.isFinite(n) && n > 0 ? n : 1;
+}
+
+/** the four fields the slicer needs, or null if this isn't a usable sheet ref */
+function parseSheetCell(ref: string) {
+	try {
+		const payload = JSON.parse(ref.slice('sheet:'.length));
+		const url = typeof payload?.url === 'string' ? payload.url.trim() : '';
+		if (!url) return null;
+		const index = Math.round(Number(payload?.index));
+		return {
+			url,
+			cols: grid(payload?.cols),
+			rows: grid(payload?.rows),
+			index: Number.isFinite(index) && index > 0 ? index : 0
+		};
+	} catch {
+		// a hand-written `sheet:` ref that isn't JSON — still a valid string to
+		// keep in the pack (parseFaceRef preserves it), just not a previewable one
+		return null;
+	}
+}
+
+/** Resolve a ref to something the thumbnail can render. */
+export async function resolveRefPreview(ref: string | undefined | null): Promise<RefPreview> {
+	const value = (ref ?? '').trim();
+	if (!value) return { kind: 'empty' };
+
+	if (value.startsWith('gen:')) {
+		const src = resolveCardImage(value);
+		// the generator hands the ref straight back when it can't draw (an
+		// unknown generator, or no 2d context) — that string is not an image
+		return src && src !== value ? { kind: 'image', src } : { kind: 'unresolvable' };
+	}
+
+	if (value.startsWith('sheet:')) {
+		const cell = parseSheetCell(value);
+		if (!cell) return { kind: 'unresolvable' };
+		const src = await sliceCell(cell);
+		return src ? { kind: 'image', src } : { kind: 'unresolvable' };
+	}
+
+	// every other ref is a URL the table loads as-is, so the preview loads it
+	// as-is too — no proxy, no canvas, and no CORS requirement for display
+	return { kind: 'image', src: value };
+}


### PR DESCRIPTION
Task: tableplace-111

Closes #111

## What

A thumbnail of the **resolved image**, under the ref that sets it, everywhere a ref is edited:

- **card face**, **deck back**, **piece state face**, **bag item face** — one `RefThumb` in `FaceRef.svelte`, so all four inherit it
- **piece image URL** and **overlay image URL** — Board tab

The ref row stays exactly where it was. It is the string you copy, and a thumbnail is not something you can paste into another card.

## How it resolves

Through the table's own art path:

| ref | path |
|---|---|
| `gen:std52/…` | `resolveCardImage` → canvas, cached |
| `sheet:{…}` | `sliceCell` (fetch + cut, memory + IndexedDB cached) |
| URL / anything else | handed to an `<img>`, exactly as the table hands it to its material |

`sheet:` goes to `sliceCell` directly rather than `resolveCardImage`, the same call `BulkSheet`'s grid makes, for two reasons documented in `ref-preview.ts`: the resolver substitutes a **named proxy card** for a dead sheet — right for the table, wrong for a preview whose whole job is to say whether the art is there, since a drawn proxy reads as "your ref works" — and its pending state is `''`, indistinguishable from failure.

## Failure states

- **dead link / unreadable sheet** → a "no preview" tile plus *"Dead link, or the host blocks reads. The ref is still valid — the table falls back the same way."* Never a broken-image icon: a plain URL is rendered by an `<img>` whose own `onerror` flips the tile.
- **empty ref** → *"No card face set — nothing renders on the table."*

## Pane safety

One `Element` blade, **always mounted**, contents driven by expressions — an `{#if}` that swaps one blade for another tears the pane down (`BulkSheet.svelte:135-140`). Verified by switching the Scheme list `gen → url → sheet` on a live card: the blades under it swap, the pane survives, and the thumbnail keeps up.

## Column width

The tile is fixed-width (64px; 96px for a board) with the note beside it in a `min-w-0 flex-1`, so it cannot widen the column. At 1100px viewport — narrow step, column 296 — `scrollWidth === clientWidth === 296`.

## Composing with the other tickets

- **#115** rewrites `FaceRef.svelte:66`'s disabled `Text` into a read-only `Monitor`. This lands *next to* that row, not on it — the diff adds a line after it and does not touch it. If #115 merges first, the rebase keeps its `Monitor` and this line follows it.
- **#109** works the breadcrumb row and cursor logic; nothing here touches either.

## Verified on localhost

Not in jsdom — on `/create` at `localhost:5173`, driving the real controls:

- **`gen:`** — Standard 52 template: `gen:std52/back` renders the blue lattice back under the Deck back ref; `gen:std52/AS` renders the Ace of Spades under the Card face ref.
- **`sheet:`** — a real 10×7 sheet slices to cell 0, and retyping the cell index to 34 re-slices to a different cell live.
- **working URL** — previews letterboxed in the card tile; the overlay's board image previews and matches what then spawns on the felt.
- **dead URL** — `https://example.invalid/no-such-card.png` → "no preview" tile with the note, no broken image.
- **dead sheet** — the R2 sheet in `tts-unmatched-greviousdeck.json` turns out to be genuinely rotted (direct *and* CORS-proxied loads both fail), so it exercised the unreadable-sheet path for real: "no preview", pane intact.
- **empty** — piece and overlay both open on "No … set", and the card face shows it the moment the scheme is switched to an empty URL.

Console carries no errors from this code.

## Checks

- `bun vitest run` — 771 passed (14 new: `ref-preview.test.ts`, `RefThumb.test.ts`)
- `bun run build` — clean
- `bun run check` — 0 errors
- `bun run lint` — red at baseline (58 eslint errors, 28 prettier files, all pre-existing); none in the files touched here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCG1CBPQRTRGhkEdoArNH4