### PR TITLE
pane UX epic — /create, /setup and /play panes (tableplace-108, -112, -113, -114)

### DIFF
--- a/src/lib/Deck.svelte
+++ b/src/lib/Deck.svelte
@@ -20,6 +20,7 @@
 	import { claimPointerDown } from '$lib/utils/single-hit-dispatch';
 	import { DRAG_THRESHOLD_PX } from '$lib/utils/counter-input';
 	import DropFootprint from './drop/DropFootprint.svelte';
+	import { selectedDeckId, DECK_SELECT_COLOR } from '$lib/store/deckSelection';
 
 	// No interactivity() here on purpose. It calls setContext, so a per-deck call
 	// would shadow TableScene's context — the handlers below would raycast with
@@ -60,6 +61,9 @@
 	});
 
 	const isHovered = $derived(id === $dragStore.isDeckHovered);
+	// the scenario editor's "you are positioning THIS one" outline — set only by
+	// /setup's pane, so it never draws in /play (see store/deckSelection)
+	const isSelected = $derived(id === $selectedDeckId);
 	// dropping here replaces the table landing entirely, so the deck has to be
 	// the cue — the drop indicator suppresses its table footprint while hovered.
 	// Cards only: a dragged deck or piece just settles on the felt (see
@@ -190,6 +194,24 @@
 				<ImageMaterial url={preloadUrl} side={2} radius={0.1} opacity={0} />
 			</T.Mesh>
 		{/key}
+	{/if}
+
+	<!-- Editing outline: a hair wider than the drop footprint and drawn above
+	     it, so a deck that is both selected and a drop target still reads as
+	     both. depthTest={false} for the same reason the drop cue disables it —
+	     at a low camera angle the deck's own body would swallow it. -->
+	{#if isSelected}
+		<T.Group rotation.x={-Math.PI / 2} position.y={height / 2 + 0.05}>
+			<DropFootprint
+				shape="rect"
+				w={CARD_WIDTH + 0.5}
+				h={CARD_HEIGHT + 0.5}
+				color={DECK_SELECT_COLOR}
+				fill={0.08}
+				border={0.07}
+				depthTest={false}
+			/>
+		</T.Group>
 	{/if}
 
 	{#if isDropTarget}

--- a/src/lib/TableScene.svelte
+++ b/src/lib/TableScene.svelte
@@ -50,7 +50,7 @@
 
 	const isDragging = $derived($dragStore.isDragging !== null);
 	let mesh: THREE.Mesh | undefined = $state();
-	const { camera } = useThrelte();
+	const { camera, canvas } = useThrelte();
 
 	let intersectionPoint: THREE.Vector3 | null = $state(null);
 
@@ -94,9 +94,16 @@
 				}
 			}
 
+			// normalized against the CANVAS, not the viewport: /create insets the
+			// canvas behind a fixed editor column, and window coordinates would put
+			// the ray a third of a screen off — nothing on the table would be
+			// clickable where it is drawn. Identical arithmetic when the canvas
+			// fills the window, which is what /play and /setup do.
 			state.pointer.update((p) => {
-				p.x = (event.clientX / window.innerWidth) * 2 - 1;
-				p.y = -(event.clientY / window.innerHeight) * 2 + 1;
+				const rect = canvas.getBoundingClientRect();
+				if (!rect.width || !rect.height) return p;
+				p.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+				p.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
 				return p;
 			});
 

--- a/src/lib/hotkeys/__tests__/is-typing.test.ts
+++ b/src/lib/hotkeys/__tests__/is-typing.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Table hotkeys are bare letters bound on `svelte:window`, and every route
+ * carries a tweakpane full of text fields. Tweakpane does not stop propagation,
+ * so without a guard, typing `flag-game` into a scenario name flips a card,
+ * groups a pile and resets the camera — and on /play, which is synced, that
+ * mutation lands on everyone's table (see #112).
+ *
+ * The source-level half is the part that regresses: `isTyping` existing is no
+ * use if a handler forgets to call it, and the failure is silent — the hotkey
+ * simply also fires.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { isTyping } from '../is-typing';
+
+describe('isTyping', () => {
+	it('is true for the fields tweakpane renders', () => {
+		for (const tag of ['input', 'textarea', 'select']) {
+			expect(isTyping(document.createElement(tag)), tag).toBe(true);
+		}
+	});
+
+	// jsdom does not implement `isContentEditable` (it stays undefined however
+	// the attribute is set), so the browser's behaviour has to be stubbed in
+	it('is true for a contenteditable host', () => {
+		const div = document.createElement('div');
+		Object.defineProperty(div, 'isContentEditable', { value: true });
+		expect(isTyping(div)).toBe(true);
+	});
+
+	it('is false for the canvas, plain elements and a null target', () => {
+		expect(isTyping(document.createElement('canvas'))).toBe(false);
+		expect(isTyping(document.createElement('button'))).toBe(false);
+		expect(isTyping(null)).toBe(false);
+	});
+});
+
+const ROUTES = ['create', 'setup', 'play'];
+
+function body(source: string, fn: string) {
+	const start = source.indexOf(`function ${fn}(event: KeyboardEvent) {`);
+	expect(start, fn).toBeGreaterThan(-1);
+	const end = source.indexOf('\n\t}', start);
+	return source.slice(start, end);
+}
+
+describe('route keyboard handlers', () => {
+	for (const route of ROUTES) {
+		const source = readFileSync(join(process.cwd(), 'src/routes', route, '+page.svelte'), 'utf8');
+
+		it(`/${route} imports the shared helper rather than defining its own`, () => {
+			expect(source).toContain("from '$lib/hotkeys/is-typing'");
+			expect(source).not.toMatch(/function isTyping\b/);
+		});
+
+		// keyup matters too: Space's preview HUD is a latch, so a guarded press
+		// with an unguarded release would leave the HUD stuck on
+		for (const fn of ['handleKeyDown', 'handleKeyUp']) {
+			it(`/${route} ${fn} bails out before reading the key`, () => {
+				const source_ = body(source, fn);
+				const guard = source_.indexOf('isTyping(event.target)');
+				expect(guard, 'no isTyping guard').toBeGreaterThan(-1);
+				const firstUse = source_.indexOf('event.code');
+				if (firstUse > -1) expect(guard).toBeLessThan(firstUse);
+			});
+		}
+	}
+});

--- a/src/lib/hotkeys/is-typing.ts
+++ b/src/lib/hotkeys/is-typing.ts
@@ -1,0 +1,24 @@
+/**
+ * Is this key event landing in a text field?
+ *
+ * Every table route binds bare letters as gestures on `svelte:window`, and the
+ * panes are full of text — codes, names, lobby ids, image URLs. Tweakpane does
+ * not stop propagation, so a key typed into a field still reaches the window
+ * handler: naming a scenario `flag-game` would otherwise flip a card, group a
+ * pile and reset the camera. A key that lands in a field is text, not a table
+ * command.
+ *
+ * Call it first in both `handleKeyDown` and `handleKeyUp` — a latch like Space's
+ * preview HUD needs the release guarded too, or it sticks on.
+ */
+export function isTyping(target: EventTarget | null) {
+	const element = target as HTMLElement | null;
+	if (!element) return false;
+	// coerced: `isContentEditable` is absent (undefined) outside a real browser
+	return Boolean(
+		element.tagName === 'INPUT' ||
+			element.tagName === 'TEXTAREA' ||
+			element.tagName === 'SELECT' ||
+			element.isContentEditable
+	);
+}

--- a/src/lib/store/deckSelection.ts
+++ b/src/lib/store/deckSelection.ts
@@ -1,0 +1,26 @@
+import { writable } from 'svelte/store';
+
+/**
+ * Which deck the scenario editor is currently pointing its `position` /
+ * `rotation` controls at, so the scene can say so on the table (#114).
+ *
+ * A store rather than a prop for the same reason `snapEditor` is one: the pane
+ * lives outside the `<Canvas>`, and the thing that has to react is a `Deck`
+ * several components deep inside it.
+ *
+ * Only /setup ever sets this — it clears on unmount, so a deck never wears an
+ * editing outline in /play.
+ */
+export const selectedDeckId = writable<string | null>(null);
+
+export function setSelectedDeck(id: string | null) {
+	selectedDeckId.set(id);
+}
+
+/**
+ * Editing outline colour. Deliberately clear of the scene's other signal
+ * colours — the cyan drop highlight (#5ee7ff), the amber stack highlight
+ * (#ffc94a) and the violet snap-point markers — so "this is the deck the pane
+ * is editing" never reads as "drop here".
+ */
+export const DECK_SELECT_COLOR = '#a3e635';

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -50,14 +50,31 @@
 
 <svelte:window on:keydown={handleKeyDown} on:keyup|preventDefault={handleKeyUp} />
 
-<CreatePane />
-
-<div class="h-screen w-screen overflow-clip bg-gray-700">
-	<Canvas toneMapping={ACESFilmicToneMapping}>
-		{#if isReady}
-			<!-- no hand in the pack editor: a card dropped into the tray lands in
-			     state no pack can represent, and survives every preview respawn -->
-			<TableScene hand={false} />
-		{/if}
-	</Canvas>
+<!--
+	Two columns, not a table with windows floating over it: the editor's pane is
+	laid out `inline` inside a fixed-width scrolling column, so it can neither
+	overlap itself nor cover the felt the preview draws on (#108). Everything
+	right of the column belongs to the table, which is what makes the spread
+	fully visible and clickable.
+-->
+<div class="flex h-screen w-screen overflow-clip bg-gray-700">
+	<!--
+		368 = the pane's 352 plus a stable 16px scrollbar gutter: reserved whether
+		or not the column is scrolling, so the pane's right edge is never under
+		the scrollbar and never shifts when a folder opens.
+	-->
+	<div
+		class="w-[368px] shrink-0 overflow-y-auto border-r border-black/50 bg-neutral-900 [scrollbar-gutter:stable]"
+	>
+		<CreatePane />
+	</div>
+	<div class="min-w-0 flex-1">
+		<Canvas toneMapping={ACESFilmicToneMapping}>
+			{#if isReady}
+				<!-- no hand in the pack editor: a card dropped into the tray lands in
+				     state no pack can represent, and survives every preview respawn -->
+				<TableScene hand={false} />
+			{/if}
+		</Canvas>
+	</div>
 </div>

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -8,23 +8,8 @@
 	import { disconnect } from '$lib/websocket/connection';
 	import CreatePane from './CreatePane.svelte';
 	import { togglePreviewLayout } from './preview-layout';
+	import { isTyping } from '$lib/hotkeys/is-typing';
 	import toast from 'svelte-french-toast';
-
-	/**
-	 * Authoring is mostly typing — codes, names, image URLs — and the editor's
-	 * gestures are bare letters. A key that lands in a pane field is text, not
-	 * a table command.
-	 */
-	function isTyping(target: EventTarget | null) {
-		const element = target as HTMLElement | null;
-		if (!element) return false;
-		return (
-			element.tagName === 'INPUT' ||
-			element.tagName === 'TEXTAREA' ||
-			element.tagName === 'SELECT' ||
-			element.isContentEditable
-		);
-	}
 
 	// same gestures as /setup, so a card pulled out of a preview pile can be
 	// inspected (flip) and arranged without leaving the editor

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -8,6 +8,7 @@
 	import { disconnect } from '$lib/websocket/connection';
 	import CreatePane from './CreatePane.svelte';
 	import { togglePreviewLayout } from './preview-layout';
+	import { EDITOR_GUTTER, editorPaneWidth } from './column';
 	import { isTyping } from '$lib/hotkeys/is-typing';
 	import toast from 'svelte-french-toast';
 
@@ -59,12 +60,15 @@
 -->
 <div class="flex h-screen w-screen overflow-clip bg-gray-700">
 	<!--
-		368 = the pane's 352 plus a stable 16px scrollbar gutter: reserved whether
-		or not the column is scrolling, so the pane's right edge is never under
-		the scrollbar and never shifts when a folder opens.
+		The pane's width plus a stable scrollbar gutter, so the pane's right edge
+		is never under the scrollbar and never shifts when a folder opens. A flex
+		COLUMN, because what is under the pane matters: the tabs are short (File
+		is four rows) and the viewport is not, so CreatePane's footer takes the
+		remainder with `mt-auto` rather than leaving a dark slab.
 	-->
 	<div
-		class="w-[368px] shrink-0 overflow-y-auto border-r border-black/50 bg-neutral-900 [scrollbar-gutter:stable]"
+		class="flex shrink-0 flex-col overflow-y-auto border-r border-black/50 bg-neutral-900 [scrollbar-gutter:stable]"
+		style="width: {$editorPaneWidth + EDITOR_GUTTER}px"
 	>
 		<CreatePane />
 	</div>

--- a/src/routes/create/BulkSheet.svelte
+++ b/src/routes/create/BulkSheet.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Button, Element, Folder, Pane, Stepper, Text, Textarea } from 'svelte-tweakpane-ui';
+	import { Button, Element, Folder, Stepper, Text, Textarea } from 'svelte-tweakpane-ui';
 	import toast from 'svelte-french-toast';
 	import { sliceCell } from '$lib/tts/slice';
 	import type { PackCardDef } from '$lib/packs/types';
@@ -16,6 +16,10 @@
 
 	/**
 	 * Bulk add: define a sheet's grid once, then add every cell as a card.
+	 *
+	 * A folder in whatever pane mounts it, not a pane of its own: it is opened
+	 * from the Cards tab next to the deck the batch lands in, and it used to sit
+	 * open at x=680 over the felt before anyone had a sheet URL (#108).
 	 *
 	 * The pane owns the grid it loaded (`loaded`), not the fields above it —
 	 * retyping the columns doesn't silently re-index the thumbnails you're
@@ -122,15 +126,7 @@
 	}
 </script>
 
-<Pane
-	position="draggable"
-	title="Bulk add from sheet"
-	expanded={true}
-	y={8}
-	x={680}
-	width={340}
-	localStoreId="create-pane-bulk"
->
+<Folder title="Bulk add from sheet" expanded={true}>
 	<Text label="Sheet URL" bind:value={url} />
 	<Stepper label="Columns" bind:value={cols} min={1} step={1} />
 	<Stepper label="Rows" bind:value={rows} min={1} step={1} />
@@ -222,4 +218,4 @@
 			on:click={addCards}
 		/>
 	{/if}
-</Pane>
+</Folder>

--- a/src/routes/create/CreatePane.svelte
+++ b/src/routes/create/CreatePane.svelte
@@ -15,8 +15,7 @@
 		Stepper,
 		TabGroup,
 		TabPage,
-		Text,
-		Textarea
+		Text
 	} from 'svelte-tweakpane-ui';
 	import { tick } from 'svelte';
 	import { get } from 'svelte/store';
@@ -37,6 +36,7 @@
 	} from '$lib/packs/spread';
 	import { onCardPick } from '$lib/store/cardPick';
 	import { previewLayout, type PreviewLayout } from './preview-layout';
+	import { editorPaneWidth } from './column';
 	import { CARD_BACK_DEFAULT, STANDARD_52 } from '$lib/packs/standard52';
 	import { parsePackFile, serializePackFile, packFileName } from '$lib/packs/file';
 	import {
@@ -77,9 +77,6 @@
 
 	/** Everything the /create preview spawns is owned by this placeholder id */
 	const PREVIEW_OWNER = 'preview';
-
-	/** the editor column's width — the pane fills it exactly (see +page.svelte) */
-	const PANE_WIDTH = 352;
 
 	const HELP_TEXT =
 		'A pack is a content library: decks (piles of cards), pieces (including bags — a ' +
@@ -152,6 +149,20 @@
 	const bagItem = $derived(piece?.kind === 'bag' ? piece.contents[bagItemIndex] : undefined);
 	const overlayIndex = $derived(Math.min(overlayCursor, Math.max(0, overlays.length - 1)));
 	const overlay = $derived(overlays[overlayIndex]);
+
+	/**
+	 * What is in the draft, for the column's footer. Counts only — the marker
+	 * for whether it is SAVED is #110's, and belongs in the pane's title.
+	 */
+	const cardCount = $derived(decks.reduce((total, d) => total + d.cards.length, 0));
+	const packSummary = $derived(
+		[
+			`${decks.length} deck${decks.length === 1 ? '' : 's'}`,
+			`${cardCount} card${cardCount === 1 ? '' : 's'}`,
+			...(pieces.length ? [`${pieces.length} piece${pieces.length === 1 ? '' : 's'}`] : []),
+			...(overlays.length ? [`${overlays.length} overlay${overlays.length === 1 ? '' : 's'}`] : [])
+		].join(' · ')
+	);
 
 	const deckOptions = $derived(
 		decks.length
@@ -755,7 +766,7 @@
 		tree: replacing one blade with another tears a tweakpane pane down, while
 		mounting and unmounting a whole <Pane> is plain Svelte and safe.
 	-->
-	<Pane position="inline" title="new pack" userExpandable={false} width={PANE_WIDTH}>
+	<Pane position="inline" title="new pack" userExpandable={false} width={$editorPaneWidth}>
 		<Element>
 			<div class="p-2 font-sans text-[11px] leading-snug text-white/60">
 				A pack is a content library — decks, pieces and board overlays — authored here and kept in
@@ -779,7 +790,7 @@
 		{/if}
 	</Pane>
 {:else}
-	<Pane position="inline" title="pack editor" userExpandable={false} width={PANE_WIDTH}>
+	<Pane position="inline" title="pack editor" userExpandable={false} width={$editorPaneWidth}>
 		<!--
 			The breadcrumb row: what is selected, above the tabs, always mounted so
 			#109 can fill it in with `pack › deck › card N of M` without touching the
@@ -802,11 +813,6 @@
 				/>
 				<Separator />
 				<Button title="Close pack" on:click={closePack} />
-				<!-- collapsed by default, and the home for the per-control help #115
-				     rewrites: the editor should open on controls, not on prose -->
-				<Folder title="How this works" expanded={false}>
-					<Textarea disabled rows={7} value={HELP_TEXT} />
-				</Folder>
 			</TabPage>
 
 			<TabPage title="Cards">
@@ -869,9 +875,6 @@
 
 				<Separator />
 				<Button title="Flip cards on table (F)" on:click={flipTableCards} />
-				<Folder title="How this works" expanded={false}>
-					<Textarea disabled rows={9} value={TABLE_HELP_TEXT} />
-				</Folder>
 			</TabPage>
 
 			<TabPage title="Board">
@@ -1028,5 +1031,38 @@
 		</TabGroup>
 	</Pane>
 {/if}
+
+<!--
+	The column is viewport-tall; a tab's controls are not — File is four rows —
+	so everything under the pane used to be a flat slab down to the bottom edge.
+	It carries the two things the editor otherwise has nowhere to say: how any of
+	this works, and what is in the draft.
+
+	Plain markup rather than a tweakpane folder: this is the home #115 rewrites
+	into per-control help, and prose in a disabled Textarea can neither wrap to
+	the column nor be selected and copied. It takes the remainder (`flex-1`) and
+	centres in it, so what is left over on a tall screen is two small margins
+	rather than one dead half — `safe` centring, so a long tab still scrolls
+	from the top rather than centring its overflow out of reach.
+-->
+<section
+	class="flex flex-1 flex-col [justify-content:safe_center] border-t border-black/40 px-3 pt-2 pb-3 font-sans text-[11px] leading-relaxed text-white/45"
+>
+	<h2 class="mb-1 font-mono text-[10px] tracking-widest text-white/45 uppercase">How this works</h2>
+	<p class="mb-2">{HELP_TEXT}</p>
+	<p>{TABLE_HELP_TEXT}</p>
+</section>
+
+<!--
+	A status bar, and the reason the column has no dead bottom edge at any
+	height: `mt-auto` drops it to the foot of a short column, `sticky` keeps it
+	there while a long one scrolls behind it. Counts only — whether the draft is
+	SAVED is #110's marker, and belongs in the pane's title.
+-->
+<footer
+	class="sticky bottom-0 mt-auto border-t border-black/40 bg-neutral-900 px-3 py-1.5 font-mono text-[10px] tracking-wide text-white/65 uppercase"
+>
+	{pack ? packSummary : 'no pack open'}
+</footer>
 
 <FileDropZone onfile={handleDroppedFile} />

--- a/src/routes/create/CreatePane.svelte
+++ b/src/routes/create/CreatePane.svelte
@@ -2,14 +2,19 @@
 	import {
 		AutoValue,
 		Button,
+		ButtonGrid,
 		Checkbox,
 		Color,
 		Element,
+		File as FileBlade,
 		Folder,
 		List,
 		Pane,
 		Point,
+		Separator,
 		Stepper,
+		TabGroup,
+		TabPage,
 		Text,
 		Textarea
 	} from 'svelte-tweakpane-ui';
@@ -32,7 +37,7 @@
 	} from '$lib/packs/spread';
 	import { onCardPick } from '$lib/store/cardPick';
 	import { previewLayout, type PreviewLayout } from './preview-layout';
-	import { CARD_BACK_DEFAULT } from '$lib/packs/standard52';
+	import { CARD_BACK_DEFAULT, STANDARD_52 } from '$lib/packs/standard52';
 	import { parsePackFile, serializePackFile, packFileName } from '$lib/packs/file';
 	import {
 		listLibraryPacks,
@@ -73,6 +78,9 @@
 	/** Everything the /create preview spawns is owned by this placeholder id */
 	const PREVIEW_OWNER = 'preview';
 
+	/** the editor column's width — the pane fills it exactly (see +page.svelte) */
+	const PANE_WIDTH = 352;
+
 	const HELP_TEXT =
 		'A pack is a content library: decks (piles of cards), pieces (including bags — a ' +
 		'hidden pool you draw from at the table), and board overlays. ' +
@@ -91,25 +99,30 @@
 		'edit respawns the preview from the draft. C recentres the camera, hold Space ' +
 		'for a close-up. The durable start face is the deck’s "Face up" box.';
 
-	function emptyPack(): EditorPack {
+	/**
+	 * A new pack: one empty deck, no cards. The deck is not fabricated content —
+	 * a card has nowhere to go without one, and "Add card" would only toast "add
+	 * a deck first". Everything else (the pack's name, its first card) is the
+	 * author's to type; the old starter pack shipped an Ace of Spades nobody
+	 * asked for, so the first gesture in the editor was deleting it (#108).
+	 */
+	function newPack(): EditorPack {
 		return withEditorDefaults({
 			id: 'my-pack',
 			name: 'My Pack',
 			scope: 'player',
-			decks: [
-				{
-					slot: 'main',
-					name: 'Draw Pile',
-					back: CARD_BACK_DEFAULT,
-					cards: [{ code: 'AS', name: 'Ace of Spades', face: 'gen:std52/AS' }]
-				}
-			]
+			decks: [{ slot: 'main', name: 'Draw Pile', back: CARD_BACK_DEFAULT, cards: [] }]
 		});
 	}
 
-	let pack: EditorPack = $state(emptyPack());
+	/**
+	 * `null` until the author picks a starting point. There is no draft before
+	 * that: the start state is the first screen, not 39 controls on a pack that
+	 * fabricated itself.
+	 */
+	let pack = $state<EditorPack | null>(null);
 	/** the draft as a plain (non-proxy) object, cleaned of editing defaults */
-	const exportable = $derived(cleanForExport($state.snapshot(pack) as EditorPack));
+	const exportable = $derived(pack ? cleanForExport($state.snapshot(pack) as EditorPack) : null);
 
 	// ——— cursors (indexes into the draft's arrays, clamped as arrays shrink) ———
 	let deckCursor = $state(0);
@@ -118,12 +131,18 @@
 	let stateCursor = $state(0);
 	let overlayCursor = $state(0);
 
-	const deckIndex = $derived(Math.min(deckCursor, Math.max(0, pack.decks.length - 1)));
-	const deck = $derived(pack.decks[deckIndex]);
+	// the draft's collections, empty while there is no draft — every cursor and
+	// option list below reads them rather than re-testing `pack` for null
+	const decks = $derived(pack?.decks ?? []);
+	const pieces = $derived(pack?.pieces ?? []);
+	const overlays = $derived(pack?.overlays ?? []);
+
+	const deckIndex = $derived(Math.min(deckCursor, Math.max(0, decks.length - 1)));
+	const deck = $derived(decks[deckIndex]);
 	const cardIndex = $derived(Math.min(cardCursor, Math.max(0, (deck?.cards.length ?? 0) - 1)));
 	const card = $derived(deck?.cards[cardIndex]);
-	const pieceIndex = $derived(Math.min(pieceCursor, Math.max(0, pack.pieces.length - 1)));
-	const piece = $derived(pack.pieces[pieceIndex]);
+	const pieceIndex = $derived(Math.min(pieceCursor, Math.max(0, pieces.length - 1)));
+	const piece = $derived(pieces[pieceIndex]);
 	const stateIndex = $derived(Math.min(stateCursor, Math.max(0, (piece?.states.length ?? 0) - 1)));
 	const pieceState = $derived(piece?.states[stateIndex]);
 	let bagItemCursor = $state(0);
@@ -131,12 +150,12 @@
 		Math.min(bagItemCursor, Math.max(0, (piece?.contents.length ?? 0) - 1))
 	);
 	const bagItem = $derived(piece?.kind === 'bag' ? piece.contents[bagItemIndex] : undefined);
-	const overlayIndex = $derived(Math.min(overlayCursor, Math.max(0, pack.overlays.length - 1)));
-	const overlay = $derived(pack.overlays[overlayIndex]);
+	const overlayIndex = $derived(Math.min(overlayCursor, Math.max(0, overlays.length - 1)));
+	const overlay = $derived(overlays[overlayIndex]);
 
 	const deckOptions = $derived(
-		pack.decks.length
-			? Object.fromEntries(pack.decks.map((d, i) => [`${i}: ${d.slot}`, i]))
+		decks.length
+			? Object.fromEntries(decks.map((d, i) => [`${i}: ${d.slot}`, i]))
 			: { '(no decks)': 0 }
 	);
 	const cardOptions = $derived(
@@ -145,13 +164,13 @@
 			: { '(no cards)': 0 }
 	);
 	const pieceOptions = $derived(
-		pack.pieces.length
-			? Object.fromEntries(pack.pieces.map((p, i) => [`${i}: ${p.kind} ${p.name}`, i]))
+		pieces.length
+			? Object.fromEntries(pieces.map((p, i) => [`${i}: ${p.kind} ${p.name}`, i]))
 			: { '(no pieces)': 0 }
 	);
 	const overlayOptions = $derived(
-		pack.overlays.length
-			? Object.fromEntries(pack.overlays.map((_, i) => [`overlay ${i}`, i]))
+		overlays.length
+			? Object.fromEntries(overlays.map((_, i) => [`overlay ${i}`, i]))
 			: { '(no overlays)': 0 }
 	);
 	const stateOptions = $derived(
@@ -172,6 +191,7 @@
 
 	// ——— structure edits ———
 	function addDeck() {
+		if (!pack) return;
 		pack.decks.push({
 			slot: `deck-${pack.decks.length}`,
 			name: `Deck ${pack.decks.length + 1}`,
@@ -183,7 +203,7 @@
 	}
 
 	function removeDeck() {
-		if (!deck) return;
+		if (!pack || !deck) return;
 		pack.decks.splice(deckIndex, 1);
 		deckCursor = Math.max(0, deckIndex - 1);
 	}
@@ -260,6 +280,7 @@
 	let newBagItemKind: PackBagItemDef['kind'] = $state('token');
 
 	function addPiece() {
+		if (!pack) return;
 		pack.pieces.push({
 			kind: newPieceKind,
 			name: newPieceKind,
@@ -279,7 +300,7 @@
 	}
 
 	function removePiece() {
-		if (!piece) return;
+		if (!pack || !piece) return;
 		pack.pieces.splice(pieceIndex, 1);
 		pieceCursor = Math.max(0, pieceIndex - 1);
 	}
@@ -350,12 +371,13 @@
 	}
 
 	function addOverlay() {
+		if (!pack) return;
 		pack.overlays.push({ imageUrl: '', ratio: 1, scale: 12 });
 		overlayCursor = pack.overlays.length - 1;
 	}
 
 	function removeOverlay() {
-		if (!overlay) return;
+		if (!pack || !overlay) return;
 		pack.overlays.splice(overlayIndex, 1);
 		overlayCursor = Math.max(0, overlayIndex - 1);
 	}
@@ -410,6 +432,18 @@
 	let spreadCursors: Record<string, { deck: number; card: number }> = {};
 
 	/**
+	 * Where Deck mode puts a pile. A pack does not author deck positions, so a
+	 * spawned deck lands on its owner's own deck spot — the near-right corner of
+	 * the felt, which the editor's shot (narrower than a full-width table, with
+	 * the column beside it) cuts in half. The preview centres its piles instead,
+	 * the same reasoning as the spread's fixed origin: what is being previewed
+	 * has to be in the frame.
+	 */
+	function previewPilePosition(index: number, count: number): [number, number, number] {
+		return [(index - (count - 1) / 2) * 3, 0.4, 0];
+	}
+
+	/**
 	 * `selected` is the piece cursor and the state cursor: the selected piece
 	 * previews on the state you are editing, so "preview each state" is just
 	 * picking it in the list. Every other piece shows its base face.
@@ -418,6 +452,7 @@
 		clearPreview();
 		spreadCursors = {};
 		const preview = exportable;
+		if (!preview) return;
 
 		// carpeting the felt with tiles too small to read is worse than a pile,
 		// so past the cap the spread refuses and the CONTROL follows the table —
@@ -449,11 +484,15 @@
 			// spawned per entity rather than through spawnPack: the preview must show
 			// the deck in AUTHORED order (spawnPack shuffles facedown decks), and an
 			// empty deck mid-authoring has no cards[0] for Deck.svelte to render
-			preview.decks
-				.filter((deck) => deck.cards.length > 0)
-				.forEach((deck, index) =>
-					spawnPackDeck(preview, deck, { ownerId: PREVIEW_OWNER, index, shuffle: false })
-				);
+			const piles = preview.decks.filter((deck) => deck.cards.length > 0);
+			piles.forEach((deck, index) =>
+				spawnPackDeck(preview, deck, {
+					ownerId: PREVIEW_OWNER,
+					index,
+					shuffle: false,
+					position: previewPilePosition(index, piles.length)
+				})
+			);
 		}
 
 		preview.pieces?.forEach((_, index) =>
@@ -475,6 +514,9 @@
 		// read the cursors here too: selecting a piece's state must re-lay the
 		// preview, which is how the table shows the state being edited
 		const selected = { piece: pieceIndex, state: stateIndex };
+		// no draft, no preview: closing a pack leaves an empty table, not the
+		// last thing that was on it
+		if (!pack) return clearPreview();
 		const timer = setTimeout(() => respawnPreview(mode, selected), 300);
 		return () => clearTimeout(timer);
 	});
@@ -511,8 +553,8 @@
 	 * work, and every action that REPLACES the draft asks first — losing an hour
 	 * of authoring to a mis-click was the old behavior (#93).
 	 */
-	let savedSnapshot = $state(JSON.stringify(cleanForExport(emptyPack())));
-	const isDirty = $derived(JSON.stringify(exportable) !== savedSnapshot);
+	let savedSnapshot = $state('');
+	const isDirty = $derived(!!exportable && JSON.stringify(exportable) !== savedSnapshot);
 
 	function markSaved(current = exportable) {
 		savedSnapshot = JSON.stringify(current);
@@ -520,16 +562,40 @@
 
 	function confirmDiscard(what: string): boolean {
 		if (!isDirty) return true;
-		return window.confirm(`Discard your unsaved edits to "${pack.name}" and ${what}?`);
+		return window.confirm(`Discard your unsaved edits to "${pack?.name}" and ${what}?`);
 	}
 
 	/** Put a pack in the editor: it becomes the draft, and it is now saved. */
 	function editPack(next: GamePackDef) {
 		pack = withEditorDefaults(next);
+		// every cursor points into the OLD draft's arrays
+		deckCursor = cardCursor = pieceCursor = stateCursor = overlayCursor = bagItemCursor = 0;
 		markSaved(cleanForExport($state.snapshot(pack) as EditorPack));
 	}
 
+	// ——— the start state: the first screen, before there is anything to edit ———
+
+	const START_BUTTONS = ['New empty pack', 'Standard 52 template'];
+
+	function handleStart(label: string) {
+		if (label === START_BUTTONS[1]) {
+			// withEditorDefaults deep-copies decks and cards, so editing the draft
+			// can't reach back into the built-in pack
+			editPack(STANDARD_52);
+			return toast(`Started from ${STANDARD_52.name}`);
+		}
+		editPack(newPack());
+	}
+
+	/** Back to the start state — the only way to reach it again after step 1. */
+	function closePack() {
+		if (!confirmDiscard('start over')) return;
+		pack = null;
+		savedSnapshot = '';
+	}
+
 	function handleSavePack() {
+		if (!pack || !exportable) return;
 		if (!pack.id.trim()) return toast.error('Give the pack an id first');
 		saveLibraryPack(exportable);
 		markSaved();
@@ -554,32 +620,6 @@
 	}
 
 	// ——— open / export ———
-	let ttsFileInput: HTMLInputElement | undefined = $state();
-	let packFileInput: HTMLInputElement | undefined = $state();
-
-	async function handleOpenTts(event: Event) {
-		const input = event.target as HTMLInputElement;
-		const file = input.files?.[0];
-		if (!file) return;
-		try {
-			const parsed = parseSavedObject(JSON.parse(await file.text()));
-			const imported = ttsToPack(parsed);
-			// converted, not authored: it is unsaved work until "Save to library"
-			if (!confirmDiscard(`open "${file.name}"`)) return;
-			pack = withEditorDefaults(imported);
-			const skipped = parsed.skipped.length ? ` (skipped: ${parsed.skipped.join(', ')})` : '';
-			toast(
-				`Opened ${imported.decks.length} deck(s), ${imported.pieces?.length ?? 0} piece(s)${skipped}`,
-				{ duration: 5000 }
-			);
-		} catch (error) {
-			toast.error(
-				`Could not open the file: ${error instanceof Error ? error.message : 'invalid file'}`
-			);
-		} finally {
-			input.value = '';
-		}
-	}
 
 	/**
 	 * Opening a pack file both files it in the library and edits it — one
@@ -598,12 +638,48 @@
 		return true;
 	}
 
-	async function handleOpenPack(event: Event) {
-		const input = event.target as HTMLInputElement;
-		const file = input.files?.[0];
+	/**
+	 * The one file entry point, behind the `File` blade's drop zone (start state
+	 * and the File tab both mount one). A TTS save and a pack file are both
+	 * `.json`, so the routing is by content — `ObjectStates` is TTS's root
+	 * array — rather than by which button you found.
+	 */
+	async function handleOpenFile(picked: unknown) {
+		// `unknown` in, cast here: the blade's own types name its value `File`,
+		// which inside that module resolves to the component class rather than
+		// the DOM type. What it hands over is a DOM File.
+		const file = picked as globalThis.File | undefined;
 		if (!file) return;
+		let json: unknown;
 		try {
-			const imported = parsePackFile(await file.text());
+			json = JSON.parse(await file.text());
+		} catch {
+			return toast.error(`${file.name} is not JSON`);
+		}
+
+		if (json && typeof json === 'object' && 'ObjectStates' in json) {
+			try {
+				const parsed = parseSavedObject(json);
+				const imported = ttsToPack(parsed);
+				// converted, not authored: it is unsaved work until "Save to library"
+				if (!confirmDiscard(`open "${file.name}"`)) return;
+				pack = withEditorDefaults(imported);
+				markSaved(cleanForExport($state.snapshot(pack) as EditorPack));
+				const skipped = parsed.skipped.length ? ` (skipped: ${parsed.skipped.join(', ')})` : '';
+				toast(
+					`Opened ${imported.decks.length} deck(s), ${imported.pieces?.length ?? 0} piece(s)${skipped}`,
+					{ duration: 5000 }
+				);
+			} catch (error) {
+				toast.error(
+					`Could not open the TTS save: ${error instanceof Error ? error.message : 'invalid file'}`
+				);
+			}
+			return;
+		}
+
+		try {
+			const imported = parsePackFile(JSON.stringify(json));
 			toast(
 				openPack(imported)
 					? `Opened pack: ${imported.name} — saved to your pack library`
@@ -614,8 +690,6 @@
 			toast.error(
 				`Could not open the pack: ${error instanceof Error ? error.message : 'invalid file'}`
 			);
-		} finally {
-			input.value = '';
 		}
 	}
 
@@ -625,7 +699,7 @@
 	 * anything else spawned here would vanish on the next keystroke. A scenario
 	 * is saved for /setup and /play but not applied, for the same reason.
 	 */
-	async function handleDroppedFile(file: File) {
+	async function handleDroppedFile(file: globalThis.File) {
 		await openDroppedFile(file, {
 			onPack: (imported) => {
 				// the library keeps it either way — only the editor swap is refusable
@@ -636,6 +710,7 @@
 	}
 
 	function handleExport() {
+		if (!exportable) return;
 		try {
 			const text = serializePackFile(exportable);
 			// validate before download with the same parser importers use, so a
@@ -652,254 +727,306 @@
 			toast.error(`Export failed: ${error instanceof Error ? error.message : 'invalid pack'}`);
 		}
 	}
+
+	/**
+	 * The bulk sheet is a mode, not a fixture: it took prime screen space before
+	 * anyone had a sheet URL, and its only tie to the selected deck was the text
+	 * on its last button (#108). Opened from the Cards tab, next to the deck the
+	 * batch lands in.
+	 */
+	let sheetOpen = $state(false);
 </script>
 
 <!--
-	Four panes, not one: each carries a single concern and remembers its own
-	position and collapse state (`localStoreId`). Authoring a card — the thing
-	this editor is for — is one pane deep, and Save / Export never hides under
-	another section.
+	ONE pane, laid out `inline` so the editor column owns it: the four draggable
+	panes this replaces had hard-coded positions but content-driven heights, so
+	they overlapped each other and covered the felt the preview draws on (#108).
+	Inline means overlap is structurally impossible and clipping becomes the
+	column's scroll.
+
+	Tabs, not folders: only one concern's controls are on screen at a time, and
+	Save / Export stay one tab click away rather than buried under a section
+	(#71 §4).
 -->
 
-<Pane
-	position="draggable"
-	title="Pack (local)"
-	expanded={true}
-	y={8}
-	x={8}
-	width={320}
-	localStoreId="create-pane-pack"
->
-	<Text label="Id" bind:value={pack.id} />
-	<Text label="Name" bind:value={pack.name} />
-	<List
-		label="Scope"
-		bind:value={pack.scope}
-		options={{ 'player (one seat brings it)': 'player', 'table (the shared game)': 'table' }}
-	/>
-	<Textarea disabled rows={5} value={HELP_TEXT} />
-</Pane>
+{#if !pack}
+	<!--
+		Step 1. A separate pane rather than an {#if} inside the editor's blade
+		tree: replacing one blade with another tears a tweakpane pane down, while
+		mounting and unmounting a whole <Pane> is plain Svelte and safe.
+	-->
+	<Pane position="inline" title="new pack" userExpandable={false} width={PANE_WIDTH}>
+		<Element>
+			<div class="p-2 font-sans text-[11px] leading-snug text-white/60">
+				A pack is a content library — decks, pieces and board overlays — authored here and kept in
+				this browser. Start one, or open a file you were sent.
+			</div>
+		</Element>
+		<ButtonGrid buttons={START_BUTTONS} on:click={(e) => handleStart(e.detail.label)} />
+		<Separator />
+		<!-- a real drop target, replacing the hidden <input type=file> + Button
+		     hack: a pack file and a TTS save are both .json, and both land here -->
+		<FileBlade
+			label="Open"
+			extensions={['.json']}
+			rows={3}
+			on:change={(e) => handleOpenFile(e.detail.value)}
+		/>
+		{#if libraryIds.length}
+			<Separator />
+			<List label="Continue" bind:value={selectedPack} options={libraryOptions} />
+			<Button title="Open selected" on:click={handleEditSelected} />
+		{/if}
+	</Pane>
+{:else}
+	<Pane position="inline" title="pack editor" userExpandable={false} width={PANE_WIDTH}>
+		<!--
+			The breadcrumb row: what is selected, above the tabs, always mounted so
+			#109 can fill it in with `pack › deck › card N of M` without touching the
+			blade tree's shape.
+		-->
+		<Element>
+			<div class="truncate p-1 font-sans text-[11px] text-white/70">
+				{pack.name || pack.id}
+			</div>
+		</Element>
 
-<Pane
-	position="draggable"
-	title="Decks & Cards"
-	expanded={true}
-	y={190}
-	x={8}
-	width={320}
-	localStoreId="create-pane-decks"
->
-	<!-- first row, above the cursors: it decides what the whole table shows -->
-	<List
-		label="Layout"
-		bind:value={$previewLayout}
-		options={{ 'Deck — a pile per deck': 'deck', 'Spread — cards side by side (L)': 'spread' }}
-	/>
-	<List label="Deck" bind:value={deckCursor} options={deckOptions} />
-	<Button title="Add deck" on:click={addDeck} />
-	{#if deck}
-		<Folder title="Deck ({deck.slot})" expanded={true}>
-			<Text label="Slot" bind:value={deck.slot} />
-			<Text label="Name" bind:value={deck.name} />
-			<Checkbox label="Face up" bind:value={deck.isFaceUp} />
-			<Button title="Remove deck" on:click={removeDeck} />
-			<!-- keyed on the cursor: a fresh editor for whichever deck is selected -->
-			{#key deckIndex}
-				<FaceRef title="Deck back" value={deck.back} onchange={(ref) => (deck.back = ref)} />
-			{/key}
-		</Folder>
+		<TabGroup>
+			<TabPage title="Pack">
+				<Text label="Id" bind:value={pack.id} />
+				<Text label="Name" bind:value={pack.name} />
+				<List
+					label="Scope"
+					bind:value={pack.scope}
+					options={{ 'player (one seat brings it)': 'player', 'table (the shared game)': 'table' }}
+				/>
+				<Separator />
+				<Button title="Close pack" on:click={closePack} />
+				<!-- collapsed by default, and the home for the per-control help #115
+				     rewrites: the editor should open on controls, not on prose -->
+				<Folder title="How this works" expanded={false}>
+					<Textarea disabled rows={7} value={HELP_TEXT} />
+				</Folder>
+			</TabPage>
 
-		<Folder title="Cards ({deck.cards.length})" expanded={true}>
-			<List label="Card" bind:value={cardCursor} options={cardOptions} />
-			<Button title="Add card" on:click={addCard} />
-			{#if card}
-				<Text label="Code" bind:value={card.code} />
-				<Text label="Name" bind:value={card.name} />
-				<Button title="Duplicate card" on:click={duplicateCard} />
-				<Button title="Remove card" on:click={removeCard} />
-				{#key `${deckIndex}:${cardIndex}`}
-					<FaceRef title="Card face" value={card.face} onchange={(ref) => (card.face = ref)} />
-				{/key}
-			{/if}
-		</Folder>
-	{/if}
-
-	<Button title="Flip cards on table (F)" on:click={flipTableCards} />
-	<Textarea disabled rows={8} value={TABLE_HELP_TEXT} />
-</Pane>
-
-<Pane
-	position="draggable"
-	title="Board"
-	expanded={true}
-	y={8}
-	x={344}
-	width={320}
-	localStoreId="create-pane-board"
->
-	<Folder title="Pieces ({pack.pieces.length})" expanded={false}>
-		<List label="New kind" bind:value={newPieceKind} options={kindOptions} />
-		<Button title="Add {newPieceKind}" on:click={addPiece} />
-		{#if piece}
-			<List label="Piece" bind:value={pieceCursor} options={pieceOptions} />
-			<Text label="Name" bind:value={piece.name} />
-			<Color label="Color" bind:value={piece.color} />
-			{#if piece.kind === 'token' || piece.kind === 'bag'}
-				<Text label="Image URL" bind:value={piece.imageUrl} />
-			{/if}
-			<!--
-				States: the TTS `States` analog — one piece, several faces, cycled in
-				play with X or picked from its right-click menu. State 1 is the BASE
-				face (it replaces "Image URL" on export), so adding the first one
-				copies the image rather than blanking the piece.
-			-->
-			<Folder title="States ({piece.states.length})" expanded={false}>
-				<Button title="Add state" on:click={addPieceState} />
-				{#if piece.states.length > 0}
-					<List label="State" bind:value={stateCursor} options={stateOptions} />
-				{/if}
-				{#if pieceState}
-					<Text label="State name" bind:value={pieceState.name} />
-					<Checkbox
-						label="Spawns on this state"
-						value={piece.state === stateIndex}
-						on:change={(e) => (piece.state = e.detail.value ? stateIndex : 0)}
-					/>
-					<Button title="Remove state" on:click={removePieceState} />
-					<!-- keyed on the cursors: a fresh editor for whichever state is selected -->
-					{#key `${pieceIndex}:${stateIndex}`}
-						<FaceRef
-							title="State face"
-							value={pieceState.face}
-							onchange={(ref) => (pieceState.face = ref)}
-						/>
+			<TabPage title="Cards">
+				<!-- first row, above the cursors: it decides what the whole table shows -->
+				<List
+					label="Layout"
+					bind:value={$previewLayout}
+					options={{
+						'Deck — a pile per deck': 'deck',
+						'Spread — cards side by side (L)': 'spread'
+					}}
+				/>
+				<Separator />
+				<!-- pick, then create/destroy, THEN the selected deck's fields: the
+				     verbs used to sit between the selector and the fields they were
+				     nothing to do with (#108) -->
+				<List label="Deck" bind:value={deckCursor} options={deckOptions} />
+				<ButtonGrid
+					buttons={['Add deck', 'Remove deck']}
+					on:click={(e) => (e.detail.index === 0 ? addDeck() : removeDeck())}
+				/>
+				{#if deck}
+					<Text label="Slot" bind:value={deck.slot} />
+					<Text label="Name" bind:value={deck.name} />
+					<Checkbox label="Face up" bind:value={deck.isFaceUp} />
+					<!-- keyed on the cursor: a fresh editor for whichever deck is selected -->
+					{#key deckIndex}
+						<FaceRef title="Deck back" value={deck.back} onchange={(ref) => (deck.back = ref)} />
 					{/key}
+
+					<Separator />
+					<List label="Card" bind:value={cardCursor} options={cardOptions} />
+					<ButtonGrid
+						columns={3}
+						buttons={['Add card', 'Duplicate card', 'Remove card']}
+						on:click={(e) =>
+							e.detail.index === 0
+								? addCard()
+								: e.detail.index === 1
+									? duplicateCard()
+									: removeCard()}
+					/>
+					{#if card}
+						<Text label="Code" bind:value={card.code} />
+						<Text label="Name" bind:value={card.name} />
+						{#key `${deckIndex}:${cardIndex}`}
+							<FaceRef title="Card face" value={card.face} onchange={(ref) => (card.face = ref)} />
+						{/key}
+					{/if}
+
+					<Separator />
+					<Button
+						title={sheetOpen ? 'Close the sheet adder' : 'Add cards from a sheet…'}
+						on:click={() => (sheetOpen = !sheetOpen)}
+					/>
+					{#if sheetOpen}
+						<BulkSheet deckSlot={deck.slot} takenCodes={[...takenCodes]} onadd={addBulkCards} />
+					{/if}
 				{/if}
-			</Folder>
-			<AutoValue label="Radius" bind:value={piece.radius} />
-			{#if piece.kind === 'counter'}
-				<AutoValue label="Max value" bind:value={piece.maxValue} />
-			{/if}
-			{#if piece.kind === 'die'}
-				<List label="Sides" bind:value={piece.sides} options={sidesOptions} />
-			{/if}
-			{#if piece.kind === 'bag'}
-				<List label="Draw order" bind:value={piece.drawMode} options={drawModeOptions} />
-				<Checkbox label="Infinite" bind:value={piece.infinite} />
-				<Folder title="Bag contents ({piece.contents.length})" expanded={true}>
-					<List label="New item" bind:value={newBagItemKind} options={bagItemKindOptions} />
-					<Button title="Add {newBagItemKind} to bag" on:click={addBagItem} />
-					{#if bagItem}
-						<List label="Item" bind:value={bagItemCursor} options={bagItemOptions} />
-						<!-- one {#if} per field rather than a card/piece if-else pair: an
-						     {#if} that REPLACES a tweakpane blade tears the whole pane
-						     down (see BulkSheet.svelte), while adding and removing is safe -->
-						{#if bagItem.kind === 'card'}
-							<Text label="Code" bind:value={bagItem.code} />
+
+				<Separator />
+				<Button title="Flip cards on table (F)" on:click={flipTableCards} />
+				<Folder title="How this works" expanded={false}>
+					<Textarea disabled rows={9} value={TABLE_HELP_TEXT} />
+				</Folder>
+			</TabPage>
+
+			<TabPage title="Board">
+				<!-- one line while the board is empty, so a pack of cards never has to
+				     read past controls for things it does not have -->
+				<Element>
+					<div class="p-1 font-sans text-[11px] text-white/50">
+						Pieces {pack.pieces.length} · Overlays {pack.overlays.length}{pack.pieces.length +
+							pack.overlays.length ===
+						0
+							? ' — nothing on the board yet'
+							: ''}
+					</div>
+				</Element>
+				<Folder title="Pieces ({pack.pieces.length})" expanded={false}>
+					<List label="New kind" bind:value={newPieceKind} options={kindOptions} />
+					<Button title="Add {newPieceKind}" on:click={addPiece} />
+					{#if piece}
+						<Separator />
+						<List label="Piece" bind:value={pieceCursor} options={pieceOptions} />
+						<Text label="Name" bind:value={piece.name} />
+						<Color label="Color" bind:value={piece.color} />
+						{#if piece.kind === 'token' || piece.kind === 'bag'}
+							<Text label="Image URL" bind:value={piece.imageUrl} />
 						{/if}
-						<Text label="Item name" bind:value={bagItem.name} />
-						{#if bagItem.kind !== 'card'}
-							<Color label="Item color" bind:value={bagItem.color} />
-						{/if}
-						{#if bagItem.kind !== 'card'}
-							<Text label="Item image" bind:value={bagItem.imageUrl} />
-						{/if}
-						{#if bagItem.kind === 'counter'}
-							<Stepper label="Item max" bind:value={bagItem.maxValue} step={1} />
-						{/if}
-						{#if bagItem.kind === 'card'}
-							<!-- keyed on the cursor, like the deck's card face: a fresh
-							     editor for whichever item is selected -->
-							{#key `${pieceIndex}:${bagItemIndex}`}
-								<FaceRef
-									title="Item face"
-									value={bagItem.face}
-									onchange={(ref) => (bagItem.face = ref)}
+						<!--
+							States: the TTS `States` analog — one piece, several faces, cycled in
+							play with X or picked from its right-click menu. State 1 is the BASE
+							face (it replaces "Image URL" on export), so adding the first one
+							copies the image rather than blanking the piece.
+						-->
+						<Folder title="States ({piece.states.length})" expanded={false}>
+							<Button title="Add state" on:click={addPieceState} />
+							{#if piece.states.length > 0}
+								<List label="State" bind:value={stateCursor} options={stateOptions} />
+							{/if}
+							{#if pieceState}
+								<Text label="State name" bind:value={pieceState.name} />
+								<Checkbox
+									label="Spawns on this state"
+									value={piece.state === stateIndex}
+									on:change={(e) => (piece.state = e.detail.value ? stateIndex : 0)}
 								/>
-							{/key}
+								<Button title="Remove state" on:click={removePieceState} />
+								<!-- keyed on the cursors: a fresh editor for whichever state is selected -->
+								{#key `${pieceIndex}:${stateIndex}`}
+									<FaceRef
+										title="State face"
+										value={pieceState.face}
+										onchange={(ref) => (pieceState.face = ref)}
+									/>
+								{/key}
+							{/if}
+						</Folder>
+						<AutoValue label="Radius" bind:value={piece.radius} />
+						{#if piece.kind === 'counter'}
+							<AutoValue label="Max value" bind:value={piece.maxValue} />
 						{/if}
-						{#if bagItem.kind === 'card'}
-							<Text label="Item back" bind:value={bagItem.back} />
+						{#if piece.kind === 'die'}
+							<List label="Sides" bind:value={piece.sides} options={sidesOptions} />
 						{/if}
-						<Button title="Remove item" on:click={removeBagItem} />
+						{#if piece.kind === 'bag'}
+							<List label="Draw order" bind:value={piece.drawMode} options={drawModeOptions} />
+							<Checkbox label="Infinite" bind:value={piece.infinite} />
+							<Folder title="Bag contents ({piece.contents.length})" expanded={true}>
+								<List label="New item" bind:value={newBagItemKind} options={bagItemKindOptions} />
+								<Button title="Add {newBagItemKind} to bag" on:click={addBagItem} />
+								{#if bagItem}
+									<List label="Item" bind:value={bagItemCursor} options={bagItemOptions} />
+									<!-- one {#if} per field rather than a card/piece if-else pair: an
+									     {#if} that REPLACES a tweakpane blade tears the whole pane
+									     down (see BulkSheet.svelte), while adding and removing is safe -->
+									{#if bagItem.kind === 'card'}
+										<Text label="Code" bind:value={bagItem.code} />
+									{/if}
+									<Text label="Item name" bind:value={bagItem.name} />
+									{#if bagItem.kind !== 'card'}
+										<Color label="Item color" bind:value={bagItem.color} />
+									{/if}
+									{#if bagItem.kind !== 'card'}
+										<Text label="Item image" bind:value={bagItem.imageUrl} />
+									{/if}
+									{#if bagItem.kind === 'counter'}
+										<Stepper label="Item max" bind:value={bagItem.maxValue} step={1} />
+									{/if}
+									{#if bagItem.kind === 'card'}
+										<!-- keyed on the cursor, like the deck's card face: a fresh
+										     editor for whichever item is selected -->
+										{#key `${pieceIndex}:${bagItemIndex}`}
+											<FaceRef
+												title="Item face"
+												value={bagItem.face}
+												onchange={(ref) => (bagItem.face = ref)}
+											/>
+										{/key}
+									{/if}
+									{#if bagItem.kind === 'card'}
+										<Text label="Item back" bind:value={bagItem.back} />
+									{/if}
+									<Button title="Remove item" on:click={removeBagItem} />
+								{/if}
+							</Folder>
+						{/if}
+						<Point
+							label="Position"
+							value={{ x: piece.position[0], y: piece.position[1] }}
+							on:change={(e) => {
+								//@ts-expect-error: does exist
+								const x = e.detail.value?.x ?? piece.position[0];
+								//@ts-expect-error: does exist
+								const z = e.detail.value?.y ?? piece.position[1];
+								piece.position = [x, z];
+							}}
+						/>
+						<Button title="Remove piece" on:click={removePiece} />
 					{/if}
 				</Folder>
-			{/if}
-			<Point
-				label="Position"
-				value={{ x: piece.position[0], y: piece.position[1] }}
-				on:change={(e) => {
-					//@ts-expect-error: does exist
-					const x = e.detail.value?.x ?? piece.position[0];
-					//@ts-expect-error: does exist
-					const z = e.detail.value?.y ?? piece.position[1];
-					piece.position = [x, z];
-				}}
-			/>
-			<Button title="Remove piece" on:click={removePiece} />
-		{/if}
-	</Folder>
 
-	<Folder title="Overlays — boards/maps ({pack.overlays.length})" expanded={false}>
-		<Button title="Add overlay" on:click={addOverlay} />
-		{#if overlay}
-			<List label="Overlay" bind:value={overlayCursor} options={overlayOptions} />
-			<Text label="Image URL" bind:value={overlay.imageUrl} />
-			<AutoValue label="Ratio (w/h)" bind:value={overlay.ratio} />
-			<AutoValue label="Scale" bind:value={overlay.scale} />
-			<Button title="Remove overlay" on:click={removeOverlay} />
-		{/if}
-	</Folder>
-</Pane>
+				<Folder title="Overlays — boards/maps ({pack.overlays.length})" expanded={false}>
+					<Button title="Add overlay" on:click={addOverlay} />
+					{#if overlay}
+						<Separator />
+						<List label="Overlay" bind:value={overlayCursor} options={overlayOptions} />
+						<Text label="Image URL" bind:value={overlay.imageUrl} />
+						<AutoValue label="Ratio (w/h)" bind:value={overlay.ratio} />
+						<AutoValue label="Scale" bind:value={overlay.scale} />
+						<Button title="Remove overlay" on:click={removeOverlay} />
+					{/if}
+				</Folder>
+			</TabPage>
 
-<!--
-	`localStoreId` bumped to -v2 with the restructure: tweakpane persists collapse
-	state and position per id, so anyone who had once collapsed or dragged this
-	pane would never see the controls added to it (#93 §6).
--->
-<Pane
-	position="draggable"
-	title="Pack library / File"
-	expanded={true}
-	y={190}
-	x={344}
-	width={320}
-	localStoreId="create-pane-file-v2"
->
-	<Button title={isDirty ? 'Save to library •' : 'Save to library'} on:click={handleSavePack} />
-	<List label="Saved" bind:value={selectedPack} options={libraryOptions} />
-	<Button title="Edit selected" on:click={handleEditSelected} />
-	<Button title="Delete selected" on:click={handleDeleteSelected} />
-	<Button title="Export pack (.tbpp.json)" on:click={handleExport} />
-	<!-- top-level, not inside a folder: opening a file someone sent you is a
-	     starting move, and it was unfindable collapsed at the bottom (#93 §2) -->
-	<Button title="Open a pack (.tbpp.json)" on:click={() => packFileInput?.click()} />
-	<Folder title="Convert from another tool" expanded={false}>
-		<Button title="Open a TTS deck (.json) → pack" on:click={() => ttsFileInput?.click()} />
-	</Folder>
-	<Element>
-		<input
-			bind:this={ttsFileInput}
-			type="file"
-			accept=".json,application/json"
-			class="hidden"
-			onchange={handleOpenTts}
-		/>
-		<input
-			bind:this={packFileInput}
-			type="file"
-			accept=".json,application/json"
-			class="hidden"
-			onchange={handleOpenPack}
-		/>
-	</Element>
-</Pane>
+			<TabPage title="File">
+				<!-- top of the tab, never inside a folder: one tab click from anywhere
+				     in the editor to save or share what you have (#71 §4) -->
+				<Button
+					title={isDirty ? 'Save to library •' : 'Save to library'}
+					on:click={handleSavePack}
+				/>
+				<Button title="Export pack (.tbpp.json)" on:click={handleExport} />
+				<Separator />
+				<FileBlade
+					label="Open"
+					extensions={['.json']}
+					rows={3}
+					on:change={(e) => handleOpenFile(e.detail.value)}
+				/>
+				<Separator />
+				<List label="Saved" bind:value={selectedPack} options={libraryOptions} />
+				<ButtonGrid
+					buttons={['Edit selected', 'Delete selected']}
+					on:click={(e) => (e.detail.index === 0 ? handleEditSelected() : handleDeleteSelected())}
+				/>
+			</TabPage>
+		</TabGroup>
+	</Pane>
+{/if}
 
 <FileDropZone onfile={handleDroppedFile} />
-
-<!--
-	A fifth pane rather than a folder under "Decks & Cards": the grid it shows
-	is wider than a card's controls, and burying it would push Save / Export
-	back under a section (#71 §4).
--->
-<BulkSheet deckSlot={deck?.slot} takenCodes={[...takenCodes]} onadd={addBulkCards} />

--- a/src/routes/create/__tests__/CreatePane.test.ts
+++ b/src/routes/create/__tests__/CreatePane.test.ts
@@ -2,6 +2,10 @@
  * Drives the real tweakpane controls in jsdom rather than calling the editor's
  * functions directly — that's what proves the pane is wired to the draft and
  * that the draft reaches the table as a live preview.
+ *
+ * Every test starts where a first-time author does: the start state, with no
+ * draft at all. `startNew()` / `startWithCard()` press the same buttons a
+ * person would to get past it.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/svelte';
@@ -15,7 +19,7 @@ import { SPREAD_MAX_CARDS, SPREAD_PITCH_X } from '$lib/packs/spread';
 import { serializePackFile } from '$lib/packs/file';
 import type { GamePackDef } from '$lib/packs/types';
 
-// the draggable Pane observes its own size; jsdom has no ResizeObserver
+// the Pane observes its own size; jsdom has no ResizeObserver
 globalThis.ResizeObserver ??= class {
 	observe() {}
 	unobserve() {}
@@ -51,12 +55,13 @@ const listWith = (container: HTMLElement, option: string) =>
  * The card picker's options, which are labelled `<index>: <code>` — the deck
  * picker is labelled the same way and comes first, so this takes the second.
  */
-const cardCodes = (container: HTMLElement) => {
-	const select = [...container.querySelectorAll('select')].filter((s) =>
+const cardList = (container: HTMLElement) =>
+	[...container.querySelectorAll('select')].filter((s) =>
 		[...s.options].some((o) => /^\d+: /.test(o.textContent ?? ''))
 	)[1];
-	return [...(select?.options ?? [])].map((o) => (o.textContent ?? '').replace(/^\d+: /, ''));
-};
+
+const cardCodes = (container: HTMLElement) =>
+	[...(cardList(container)?.options ?? [])].map((o) => (o.textContent ?? '').replace(/^\d+: /, ''));
 
 /** every face-scheme picker on screen, in DOM order (deck back, then card face) */
 const schemePickers = (container: HTMLElement) =>
@@ -74,8 +79,25 @@ function type(element: HTMLInputElement, value: string) {
 	element.dispatchEvent(new Event('change', { bubbles: true }));
 }
 
+/** the editor as it first paints: the start state, no draft */
 async function mount() {
 	const { container } = render(CreatePane);
+	await settle();
+	return container;
+}
+
+/** past the start state: an empty pack with one empty deck */
+async function startNew() {
+	const container = await mount();
+	button(container, 'New empty pack')!.click();
+	await settle();
+	return container;
+}
+
+/** …and one card in it, so there is something to select and preview */
+async function startWithCard() {
+	const container = await startNew();
+	button(container, 'Add card')!.click();
 	await settle();
 	return container;
 }
@@ -87,18 +109,79 @@ describe('CreatePane', () => {
 		previewLayout.set('deck'); // module state: the last test's choice would leak
 	});
 
-	it('mounts with a starter pack and previews it on the table', async () => {
-		await mount();
+	describe('the start state', () => {
+		it('opens on a choice, not on a pack nobody authored', async () => {
+			const container = await mount();
+			await settlePreview();
+
+			expect(button(container, 'New empty pack')).toBeTruthy();
+			expect(button(container, 'Standard 52 template')).toBeTruthy();
+			// no draft means no controls for one, and nothing on the table
+			expect(button(container, 'Add card')).toBeUndefined();
+			expect(get(gameStore).decks ?? {}).toEqual({});
+		});
+
+		it('offers the saved drafts only once there are some', async () => {
+			expect(labels(await mount())).not.toContain('Continue');
+
+			const pack: GamePackDef = {
+				id: 'ember-duel',
+				name: 'Ember Duel',
+				scope: 'player',
+				decks: [{ slot: 'main', name: 'Main', back: CARD_BACK_DEFAULT, cards: [] }]
+			};
+			localStorage.setItem('packs:v1', JSON.stringify({ 'ember-duel': { updatedAt: 1, pack } }));
+
+			const container = await mount();
+			expect(labels(container)).toContain('Continue');
+			button(container, 'Open selected')!.click();
+			await settle();
+			expect(input(container, 'Id')!.value).toBe('ember-duel');
+		});
+
+		it('starts an empty pack with a deck to put cards in, and nothing else', async () => {
+			const container = await startNew();
+			await settlePreview();
+
+			expect(input(container, 'Id')!.value).toBe('my-pack');
+			// one deck to put cards in, and zero cards in it — an empty deck has no
+			// pile to preview, so the table stays clear until the author adds one
+			expect([...listWith(container, '0: main').options].map((o) => o.textContent)).toEqual([
+				'0: main'
+			]);
+			expect(listWith(container, '(no cards)')).toBeTruthy();
+			expect(get(gameStore).decks ?? {}).toEqual({});
+		});
+
+		it('starts from the standard 52 template when asked', async () => {
+			const container = await mount();
+			button(container, 'Standard 52 template')!.click();
+			await settlePreview();
+
+			expect(get(gameStore).decks?.['deck:preview:main'].cards).toHaveLength(52);
+		});
+
+		it('closes a pack back to the start state', async () => {
+			const container = await startNew();
+			button(container, 'Close pack')!.click();
+			await settlePreview();
+
+			expect(button(container, 'New empty pack')).toBeTruthy();
+			expect(get(gameStore).decks ?? {}).toEqual({});
+		});
+	});
+
+	it('previews the draft on the table as it is authored', async () => {
+		await startWithCard();
 		await settlePreview();
 
 		const decks = get(gameStore).decks ?? {};
 		expect(Object.keys(decks)).toEqual(['deck:preview:main']);
 		expect(decks['deck:preview:main'].cards).toHaveLength(1);
-		expect(decks['deck:preview:main'].cards?.[0].faceImageUrl).toBe('gen:std52/AS');
 	});
 
 	it('adding a deck and a card updates the live preview', async () => {
-		const container = await mount();
+		const container = await startWithCard();
 		await settlePreview();
 
 		button(container, 'Add deck')!.click();
@@ -113,15 +196,10 @@ describe('CreatePane', () => {
 	});
 
 	it('exposes the per-kind piece fields and previews spawned pieces', async () => {
-		const container = await mount();
+		const container = await startNew();
 
-		// the Pieces folder's kind list is the second select (Scope is the first)
-		const selects = [...container.querySelectorAll('select')];
-		const kindSelect = selects.find((s) =>
-			[...s.options].some((o) => o.textContent?.includes('Counter'))
-		)!;
-		kindSelect.selectedIndex = 2; // Token, Pawn, Counter
-		kindSelect.dispatchEvent(new Event('change', { bubbles: true }));
+		// the Board tab's kind list is the first offering "Counter"
+		choose(listWith(container, 'Counter'), 'Counter');
 		await settle();
 
 		button(container, 'Add counter')!.click();
@@ -134,7 +212,7 @@ describe('CreatePane', () => {
 	});
 
 	it('authors a multi-state token and previews the selected state', async () => {
-		const container = await mount();
+		const container = await startNew();
 		button(container, 'Add token')!.click(); // the kind list defaults to Token
 		await settle();
 
@@ -173,9 +251,9 @@ describe('CreatePane', () => {
 	});
 
 	it('authors a bag with contents, and previews it as a loaded bag', async () => {
-		const container = await mount();
+		const container = await startNew();
 
-		// Pieces folder → kind list → Bag (Token, Pawn, Counter, Bag)
+		// Board tab → kind list → Bag (Token, Pawn, Counter, Dice, Bag)
 		choose(listWith(container, 'Counter'), 'Bag');
 		await settle();
 		button(container, 'Add bag')!.click();
@@ -209,13 +287,13 @@ describe('CreatePane', () => {
 	});
 
 	it('saves the pack to the library (packs:v1) and re-opens it for editing', async () => {
-		const container = await mount();
+		const container = await startWithCard();
 		button(container, 'Save to library')!.click();
 		await settle();
 
 		const stored = JSON.parse(localStorage.getItem('packs:v1') ?? '{}');
 		expect(Object.keys(stored)).toEqual(['my-pack']);
-		expect(stored['my-pack'].pack.decks[0].cards[0].face).toBe('gen:std52/AS');
+		expect(stored['my-pack'].pack.decks[0].cards[0].face).toBe(CARD_BACK_DEFAULT);
 
 		button(container, 'Edit selected')!.click();
 		await settlePreview();
@@ -223,7 +301,7 @@ describe('CreatePane', () => {
 	});
 
 	it('does not preview a deck that has no cards yet', async () => {
-		const container = await mount();
+		const container = await startWithCard();
 		button(container, 'Add deck')!.click(); // new decks start empty
 		await settlePreview();
 
@@ -232,52 +310,58 @@ describe('CreatePane', () => {
 	});
 
 	it('gives a new card the deck back as its face, so it renders immediately', async () => {
-		const container = await mount();
+		const container = await startNew();
 		button(container, 'Add card')!.click();
 		await settlePreview();
 
 		const cards = get(gameStore).decks?.['deck:preview:main'].cards ?? [];
-		expect(cards).toHaveLength(2);
-		// starter deck's back — a blank face resolves to '' and shows nothing
-		expect(cards[1].faceImageUrl).toBe(CARD_BACK_DEFAULT);
+		expect(cards).toHaveLength(1);
+		// the deck's back — a blank face resolves to '' and shows nothing
+		expect(cards[0].faceImageUrl).toBe(CARD_BACK_DEFAULT);
 	});
 
 	it('gives every card a distinct code — duplicating twice never repeats one', async () => {
-		const container = await mount();
-		// the starter deck holds `AS`; `code` is the entity-id component, so a
-		// repeat would collapse two cards into one table entity
+		const container = await startWithCard();
+		// `code` is the entity-id component, so a repeat would collapse two cards
+		// into one table entity
 		button(container, 'Duplicate card')!.click();
 		await settle();
-		expect(cardCodes(container)).toEqual(['AS', 'AS-2']);
+		expect(cardCodes(container)).toEqual(['card-0', 'card-1']);
 
-		// duplicate the original again: the copy can't be `AS-2` a second time
 		button(container, 'Duplicate card')!.click();
 		await settle();
-		expect(cardCodes(container)).toEqual(['AS', 'AS-2', 'AS-3']);
+		expect(cardCodes(container)).toEqual(['card-0', 'card-1', 'card-2']);
 	});
 
 	it('does not reuse a `card-N` code after a card is removed', async () => {
-		const container = await mount();
+		const container = await startNew();
+		button(container, 'Add card')!.click(); // card-0
+		await settle();
 		button(container, 'Add card')!.click(); // card-1
 		await settle();
-		button(container, 'Add card')!.click(); // card-2
+
+		// remove the FIRST one: `card-${cards.length}` is now `card-1`, and that
+		// is still in use — the old code minted the collision, this steps past it
+		choose(cardList(container), '0: card-0');
 		await settle();
 		button(container, 'Remove card')!.click();
 		await settle();
-		// `card-${cards.length}` is `card-2` again here, and it's still in use —
-		// the old code minted the collision, this one steps past it
 		button(container, 'Add card')!.click();
 		await settle();
 
 		const codes = cardCodes(container);
-		expect(codes).toHaveLength(3);
-		expect(new Set(codes).size).toBe(3);
+		expect(codes).toEqual(['card-1', 'card-2']);
 	});
 
-	it('bulk-adds a sheet grid into the selected deck', async () => {
-		const container = await mount();
+	it('bulk-adds a sheet grid into the selected deck, from the Cards tab', async () => {
+		const container = await startWithCard();
 
-		// the bulk pane's own controls: URL, columns, rows, then Preview grid
+		// closed until asked for: it used to sit open over the felt before anyone
+		// had a sheet URL
+		expect(labels(container)).not.toContain('Sheet URL');
+		button(container, 'Add cards from a sheet…')!.click();
+		await settle();
+
 		type(input(container, 'Sheet URL')!, 'https://example.test/sheet.png');
 		await settle();
 		type(input(container, 'Columns')!, '2');
@@ -291,15 +375,15 @@ describe('CreatePane', () => {
 		await settlePreview();
 
 		const cards = get(gameStore).decks?.['deck:preview:main'].cards ?? [];
-		expect(cards).toHaveLength(5); // the starter Ace plus the grid
+		expect(cards).toHaveLength(5); // the first card plus the grid
 		expect(
 			cards.slice(1).map((c) => JSON.parse(c.faceImageUrl!.slice('sheet:'.length)).index)
 		).toEqual([0, 1, 2, 3]);
-		expect(cardCodes(container)).toEqual(['AS', 'card-1', 'card-2', 'card-3', 'card-4']);
+		expect(cardCodes(container)).toEqual(['card-0', 'card-1', 'card-2', 'card-3', 'card-4']);
 	});
 
 	it('sets the selected card face inline, without a separate builder', async () => {
-		const container = await mount();
+		const container = await startWithCard();
 		// one face editor for the deck back, one for the selected card
 		const pickers = schemePickers(container);
 		expect(pickers).toHaveLength(2);
@@ -314,7 +398,7 @@ describe('CreatePane', () => {
 	});
 
 	it('sets the deck back inline from the deck section', async () => {
-		const container = await mount();
+		const container = await startWithCard();
 		choose(schemePickers(container)[0], 'Image URL');
 		await settle();
 		type(input(container, 'Image URL')!, 'https://example.test/back.png');
@@ -326,22 +410,22 @@ describe('CreatePane', () => {
 	});
 
 	it('flips the cards on the preview table from the pane, no keyboard needed', async () => {
-		const container = await mount();
+		const container = await startWithCard();
 		await settlePreview();
 
 		gameStore.updateState({
 			cards: {
-				'card:preview:main-AS': {
+				'card:preview:main-card-0': {
 					position: [0, 0.3, 0],
 					rotation: [180, 0, 0], // as it arrives off a facedown pile
-					faceImageUrl: 'gen:std52/AS'
+					faceImageUrl: CARD_BACK_DEFAULT
 				}
 			}
 		});
 		button(container, 'Flip cards on table')!.click();
 		await settle();
 
-		expect(get(gameStore).cards?.['card:preview:main-AS'].rotation).toEqual([0, 0, 0]);
+		expect(get(gameStore).cards?.['card:preview:main-card-0'].rotation).toEqual([0, 0, 0]);
 	});
 
 	describe('Spread layout', () => {
@@ -352,7 +436,7 @@ describe('CreatePane', () => {
 		}
 
 		it('lays every card of every deck out face-up, with no piles left', async () => {
-			const container = await mount();
+			const container = await startWithCard();
 			button(container, 'Add deck')!.click();
 			await settle();
 			button(container, 'Add card')!.click();
@@ -363,7 +447,7 @@ describe('CreatePane', () => {
 			expect(Object.keys(state.decks ?? {})).toEqual([]);
 			expect(Object.keys(state.cards ?? {}).sort()).toEqual([
 				'card:preview:deck-1-card-0',
-				'card:preview:main-AS'
+				'card:preview:main-card-0'
 			]);
 			// face-up regardless of the decks' isFaceUp (both start facedown)
 			expect(Object.values(state.cards ?? {}).every((c) => c.rotation?.[0] === 0)).toBe(true);
@@ -376,16 +460,16 @@ describe('CreatePane', () => {
 		});
 
 		it('leaves the other tiles in place when a card is added or edited', async () => {
-			const container = await mount();
+			const container = await startWithCard();
 			await spread(container);
-			const before = get(gameStore).cards!['card:preview:main-AS'].position;
+			const before = get(gameStore).cards!['card:preview:main-card-0'].position;
 
 			button(container, 'Add card')!.click();
 			await settlePreview();
 
 			const cards = get(gameStore).cards!;
 			expect(Object.keys(cards)).toHaveLength(2);
-			expect(cards['card:preview:main-AS'].position).toEqual(before);
+			expect(cards['card:preview:main-card-0'].position).toEqual(before);
 			// the new card is appended one column across, not re-laid out
 			expect(cards['card:preview:main-card-1'].position![0] - before![0]).toBeCloseTo(
 				SPREAD_PITCH_X
@@ -395,7 +479,7 @@ describe('CreatePane', () => {
 			// draft check below is what proves it was the card's
 			type(inputs(container, 'Name')[2]!, 'renamed');
 			await settlePreview();
-			expect(get(gameStore).cards!['card:preview:main-AS'].position).toEqual(before);
+			expect(get(gameStore).cards!['card:preview:main-card-0'].position).toEqual(before);
 			expect(cards['card:preview:main-card-1'].position).toEqual(
 				get(gameStore).cards!['card:preview:main-card-1'].position
 			);
@@ -407,9 +491,9 @@ describe('CreatePane', () => {
 		});
 
 		it('re-forms the piles when switched back to Deck', async () => {
-			const container = await mount();
+			const container = await startWithCard();
 			await spread(container);
-			const spreadPositions = get(gameStore).cards!['card:preview:main-AS'].position;
+			const spreadPositions = get(gameStore).cards!['card:preview:main-card-0'].position;
 
 			choose(listWith(container, 'Spread'), 'Deck');
 			await settlePreview();
@@ -418,7 +502,7 @@ describe('CreatePane', () => {
 
 			await spread(container);
 			expect(Object.keys(get(gameStore).decks ?? {})).toEqual([]);
-			expect(get(gameStore).cards!['card:preview:main-AS'].position).toEqual(spreadPositions);
+			expect(get(gameStore).cards!['card:preview:main-card-0'].position).toEqual(spreadPositions);
 		});
 
 		it('falls back to Deck mode past the card cap', async () => {
@@ -441,8 +525,8 @@ describe('CreatePane', () => {
 			localStorage.setItem('packs:v1', JSON.stringify({ big: { updatedAt: 1, pack } }));
 
 			const container = await mount();
-			await spread(container);
-			button(container, 'Edit selected')!.click();
+			previewLayout.set('spread'); // as it is remembered from the last session
+			button(container, 'Open selected')!.click();
 			await settlePreview();
 
 			// piles, not 61 tiles — and the control follows the table
@@ -452,30 +536,30 @@ describe('CreatePane', () => {
 		});
 
 		it('selects the clicked card in the pane', async () => {
-			const container = await mount();
+			const container = await startWithCard();
 			await spread(container);
 			button(container, 'Add card')!.click(); // cursor follows the new card
 			await settlePreview();
 			expect(input(container, 'Code')!.value).toBe('card-1');
 
-			pickCard('card:preview:main-AS'); // what Card.svelte calls on a click
+			pickCard('card:preview:main-card-0'); // what Card.svelte calls on a click
 			await settle();
-			expect(input(container, 'Code')!.value).toBe('AS');
+			expect(input(container, 'Code')!.value).toBe('card-0');
 		});
 
 		it('ignores a click on a card no spread laid out', async () => {
-			const container = await mount();
+			const container = await startWithCard();
 			await settlePreview(); // Deck mode: cards come off a pile by hand
 			button(container, 'Add card')!.click();
 			await settlePreview();
 
-			pickCard('card:preview:main-AS');
+			pickCard('card:preview:main-card-0');
 			await settle();
 			expect(input(container, 'Code')!.value).toBe('card-1'); // cursor unmoved
 		});
 	});
 
-	describe('opening a pack file', () => {
+	describe('opening a file', () => {
 		const OTHER: GamePackDef = {
 			id: 'ember-duel',
 			name: 'Ember Duel',
@@ -490,29 +574,34 @@ describe('CreatePane', () => {
 			]
 		};
 
-		/** the hidden picker behind "Open a pack (.tbpp.json)" */
-		async function openPackFile(container: HTMLElement) {
-			const input = [...container.querySelectorAll('input[type=file]')].at(-1) as HTMLInputElement;
-			Object.defineProperty(input, 'files', {
-				value: [new File([serializePackFile(OTHER)], 'ember.tbpp.json')],
-				configurable: true
-			});
-			input.dispatchEvent(new Event('change', { bubbles: true }));
+		/** drop a file on the File blade's zone (the last one mounted) */
+		async function drop(container: HTMLElement, file: File) {
+			const picker = [...container.querySelectorAll('input[type=file]')].at(-1) as HTMLInputElement;
+			Object.defineProperty(picker, 'files', { value: [file], configurable: true });
+			picker.dispatchEvent(new Event('change', { bubbles: true }));
 			await settlePreview();
 		}
 
-		it('is reachable without expanding a folder', async () => {
+		const packFile = () => new File([serializePackFile(OTHER)], 'ember.tbpp.json');
+
+		it('is reachable without expanding a folder, from the start state and the editor', async () => {
 			const container = await mount();
-			// tweakpane keeps a collapsed folder's buttons in the DOM, so "visible"
+			// tweakpane keeps a collapsed folder's controls in the DOM, so "visible"
 			// has to mean "not inside a folder" — the bug was a folder, not display
-			const open = button(container, 'Open a pack (.tbpp.json)')!;
-			expect(open).toBeDefined();
-			expect(open.closest('.tp-fldv')).toBeNull();
+			const start = container.querySelector('input[type=file]');
+			expect(start).toBeTruthy();
+			expect(start!.closest('.tp-fldv')).toBeNull();
+
+			button(container, 'New empty pack')!.click();
+			await settle();
+			const editor = container.querySelector('input[type=file]');
+			expect(editor).toBeTruthy();
+			expect(editor!.closest('.tp-fldv')).toBeNull();
 		});
 
-		it('loads the pack into the editor and the library', async () => {
+		it('opens a pack straight from the start state', async () => {
 			const container = await mount();
-			await openPackFile(container);
+			await drop(container, packFile());
 
 			expect(input(container, 'Id')!.value).toBe('ember-duel');
 			expect(Object.keys(JSON.parse(localStorage.getItem('packs:v1') ?? '{}'))).toEqual([
@@ -521,13 +610,39 @@ describe('CreatePane', () => {
 			expect(get(gameStore).decks?.['deck:preview:main'].cards).toHaveLength(1);
 		});
 
-		it('keeps an edited draft when the discard prompt is refused', async () => {
+		it('routes a TTS save through the same drop zone', async () => {
+			const tts = {
+				ObjectStates: [
+					{
+						Name: 'DeckCustom',
+						Nickname: 'Troopers',
+						DeckIDs: [100, 101],
+						CustomDeck: {
+							'1': {
+								FaceURL: 'https://example.com/face.png',
+								BackURL: 'https://example.com/back.png',
+								NumWidth: 2,
+								NumHeight: 1
+							}
+						}
+					}
+				]
+			};
 			const container = await mount();
+			await drop(container, new File([JSON.stringify(tts)], 'save.json'));
+
+			// the deck's slot is slugified from its TTS nickname
+			expect(Object.keys(get(gameStore).decks ?? {})).toEqual(['deck:preview:troopers']);
+			expect(get(gameStore).decks!['deck:preview:troopers'].cards).toHaveLength(2);
+		});
+
+		it('keeps an edited draft when the discard prompt is refused', async () => {
+			const container = await startNew();
 			type(input(container, 'Name')!, 'Half Finished');
 			await settlePreview();
 
 			const confirmed = vi.spyOn(window, 'confirm').mockReturnValue(false);
-			await openPackFile(container);
+			await drop(container, packFile());
 
 			expect(confirmed).toHaveBeenCalled();
 			expect(input(container, 'Id')!.value).toBe('my-pack'); // draft untouched
@@ -538,24 +653,33 @@ describe('CreatePane', () => {
 		});
 
 		it('replaces the draft once the discard prompt is accepted', async () => {
-			const container = await mount();
+			const container = await startNew();
 			type(input(container, 'Name')!, 'Half Finished');
 			await settlePreview();
 
 			vi.spyOn(window, 'confirm').mockReturnValue(true);
-			await openPackFile(container);
+			await drop(container, packFile());
 
 			expect(input(container, 'Id')!.value).toBe('ember-duel');
 		});
 
 		it('does not prompt when the draft is untouched', async () => {
-			const container = await mount();
+			const container = await startNew();
 			const confirmed = vi.spyOn(window, 'confirm').mockReturnValue(false);
-			await openPackFile(container);
+			await drop(container, packFile());
 
 			expect(confirmed).not.toHaveBeenCalled();
 			expect(input(container, 'Id')!.value).toBe('ember-duel');
 		});
+	});
+
+	it('keeps Save and Export out of any folder, one tab from anywhere', async () => {
+		const container = await startNew();
+		for (const title of ['Save to library', 'Export pack']) {
+			const control = button(container, title)!;
+			expect(control).toBeDefined();
+			expect(control.closest('.tp-fldv')).toBeNull();
+		}
 	});
 
 	it('previews only under the preview owner, leaving other entities alone', async () => {
@@ -565,7 +689,7 @@ describe('CreatePane', () => {
 			cards: {},
 			pieces: {}
 		});
-		const container = await mount();
+		const container = await startNew();
 		button(container, 'Add deck')!.click();
 		await settlePreview();
 

--- a/src/routes/create/__tests__/CreatePane.test.ts
+++ b/src/routes/create/__tests__/CreatePane.test.ts
@@ -682,6 +682,45 @@ describe('CreatePane', () => {
 		}
 	});
 
+	describe('the column below the pane', () => {
+		const status = (container: HTMLElement) =>
+			container.querySelector('footer')?.textContent?.trim();
+
+		it('says what is in the draft, on every tab', async () => {
+			const container = await mount();
+			// the start state has no draft to count, and still closes the column
+			expect(status(container)).toBe('no pack open');
+
+			button(container, 'New empty pack')!.click();
+			await settle();
+			expect(status(container)).toBe('1 deck · 0 cards');
+
+			button(container, 'Add card')!.click();
+			await settle();
+			button(container, 'Add deck')!.click();
+			await settle();
+			expect(status(container)).toBe('2 decks · 1 card');
+
+			// pieces and overlays only once the pack has any — a deck of cards
+			// should not have to read past zeroes
+			choose(listWith(container, 'Counter'), 'Counter');
+			await settle();
+			button(container, 'Add counter')!.click();
+			await settle();
+			expect(status(container)).toBe('2 decks · 1 card · 1 piece');
+		});
+
+		it('carries the help the tabs no longer do, outside every folder', async () => {
+			const container = await startNew();
+			const help = container.querySelector('section');
+			expect(help?.textContent).toContain('A pack is a content library');
+			expect(help?.textContent).toContain('Preview table');
+			// it is markup, not a blade: a tweakpane folder would collapse it back
+			// into the pane it was moved out of
+			expect(help?.closest('.tp-fldv')).toBeNull();
+		});
+	});
+
 	it('previews only under the preview owner, leaving other entities alone', async () => {
 		gameStore.set({
 			players: {},

--- a/src/routes/create/column.ts
+++ b/src/routes/create/column.ts
@@ -1,0 +1,35 @@
+/**
+ * The editor column's width, shared by the page (which sizes the column) and
+ * the pane (which is a tweakpane `width` in px, not a CSS length, so the two
+ * have to agree on a number rather than on a class).
+ *
+ * Two steps rather than one fixed width: the column cannot shrink below its
+ * pane without clipping the controls, so on a narrow window it is the felt
+ * that pays. At 1280 — the width /create is expected to work at — nothing
+ * changes; below 1200 the pane steps down and hands the table back ~56px,
+ * which is the difference between a strip and a table on a 1024 laptop.
+ */
+
+import { readable } from 'svelte/store';
+
+export const EDITOR_PANE_WIDE = 352;
+export const EDITOR_PANE_NARROW = 296;
+
+/** Room for the column's scrollbar, reserved whether or not it is scrolling */
+export const EDITOR_GUTTER = 16;
+
+export const EDITOR_NARROW_QUERY = '(max-width: 1199px)';
+
+/**
+ * Widest pane the viewport can afford. Falls back to the wide value wherever
+ * `matchMedia` is not available (SSR, and jsdom in the component tests), which
+ * is also what a component that never resizes should render.
+ */
+export const editorPaneWidth = readable(EDITOR_PANE_WIDE, (set) => {
+	if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+	const query = window.matchMedia(EDITOR_NARROW_QUERY);
+	const apply = () => set(query.matches ? EDITOR_PANE_NARROW : EDITOR_PANE_WIDE);
+	apply();
+	query.addEventListener('change', apply);
+	return () => query.removeEventListener('change', apply);
+});

--- a/src/routes/play/+page.svelte
+++ b/src/routes/play/+page.svelte
@@ -8,6 +8,7 @@
 	import { initWebsocket } from '$lib/websocket';
 	import { get } from 'svelte/store';
 	import { gameActions } from '$lib/store/game/actions';
+	import { gameStore } from '$lib/store/game/gameStore.svelte';
 	import { dragStore } from '$lib/store/dragStore.svelte';
 	import { ungroupHoveredDeck } from '$lib/hotkeys/ungroup';
 	import { shuffleHoveredDeck } from '$lib/hotkeys/shuffle';
@@ -58,6 +59,11 @@
 
 	initWrappers();
 	let isConnected = $state(false);
+
+	// nothing on the felt yet — point at the Decks pane rather than leaving a
+	// player staring at bare green. Deliberately not gated on `isConnected`: the
+	// hint's job is to be there on the very first paint.
+	const isTableEmpty = $derived(Object.keys($gameStore?.decks ?? {}).length === 0);
 
 	// ?seat=N invite links: keep trying to claim that seat's placeholder until
 	// it succeeds; a give-up is announced, never silent (see autoClaim.ts)
@@ -123,3 +129,13 @@
 		{/if}
 	</Canvas>
 </div>
+
+<!-- centred so it clears every pane (Settings left, Decks top, Players right) at
+     1280x720 and up, and never eats a click meant for the table -->
+{#if isTableEmpty}
+	<div class="pointer-events-none fixed inset-0 flex items-center justify-center">
+		<span class="animate-pulse font-sans text-sm tracking-widest text-white uppercase opacity-40">
+			Spawn a deck to get started
+		</span>
+	</div>
+{/if}

--- a/src/routes/play/+page.svelte
+++ b/src/routes/play/+page.svelte
@@ -12,6 +12,7 @@
 	import { ungroupHoveredDeck } from '$lib/hotkeys/ungroup';
 	import { shuffleHoveredDeck } from '$lib/hotkeys/shuffle';
 	import { cycleHoveredPieceState } from '$lib/hotkeys/piece-state';
+	import { isTyping } from '$lib/hotkeys/is-typing';
 	import PieceStateMenu from '$lib/PieceStateMenu.svelte';
 	import { startAutoClaim } from '$lib/scenario/autoClaim';
 	import Pane from './Pane.svelte';
@@ -25,6 +26,9 @@
 	import toast from 'svelte-french-toast';
 
 	function handleKeyDown(event: KeyboardEvent) {
+		// a key typed into a pane field is text, not a table command — and this
+		// table is synced, so a stray G would group a pile for everyone
+		if (isTyping(event.target)) return;
 		// hover-target routing: a hovered deck takes the key, otherwise it
 		// falls through to the hovered-card behavior
 		const hoveredDeck = get(dragStore).isDeckHovered;
@@ -53,6 +57,7 @@
 	}
 
 	function handleKeyUp(event: KeyboardEvent) {
+		if (isTyping(event.target)) return;
 		if (event.code === 'Space') cameraTransforms.togglePreviewHud(false);
 	}
 

--- a/src/routes/play/Pane.svelte
+++ b/src/routes/play/Pane.svelte
@@ -8,7 +8,6 @@
 		Text,
 		AutoValue,
 		Folder,
-		Element,
 		FpsGraph,
 		Textarea
 	} from 'svelte-tweakpane-ui';
@@ -77,6 +76,11 @@
 			? Object.fromEntries(scenarioNames.map((n) => [n, n]))
 			: { '(none — build one at /setup)': '' }
 	);
+	// An empty table's most useful control is the one that fills it, so Scenarios
+	// opens itself until there are decks and then gets out of the way. `expanded`
+	// is a plain reactive prop on Folder, so this needs no manual toggling.
+	const isTableEmpty = $derived(Object.keys($gameStore?.decks ?? {}).length === 0);
+
 	// unclaimed placeholder seats present in the synced state
 	const openSeats = $derived(
 		Object.keys($gameStore?.players ?? {})
@@ -131,7 +135,6 @@
 	x={0}
 	localStoreId="table-settings"
 >
-	<FpsGraph />
 	<Folder title="Connection" expanded={false}>
 		<Text label="My ID" value={localStorage.getItem('myPlayerId') ?? ''} disabled />
 		<Text label="Server:" bind:value={$connectionStore.serverUrl} />
@@ -150,7 +153,7 @@
 			value={`Share copies an invite link — whoever opens it is seated at the first open seat and gets its decks.`}
 		/>
 	</Folder>
-	<Folder title="Scenarios" expanded={false}>
+	<Folder title="Scenarios" expanded={isTableEmpty}>
 		<List label="Preset" bind:value={selectedScenario} options={scenarioOptions} />
 		<Button title="Seed lobby with preset" on:click={seedLobby} />
 		<Button
@@ -175,7 +178,7 @@
 		<AutoValue label="Scale" bind:value={scale} />
 		<Wheel label="Rotation" bind:value={rot} format={(v) => `${(Math.abs(v) % 360).toFixed(0)}°`} />
 	</Folder>
-	<Folder title="Keybinds">
+	<Folder title="Keybinds" expanded={false}>
 		<Button
 			on:click={() => gameActions?.setSeat()}
 			label="Seat: {$gameStore?.players?.[gameActions?.getMe()?.id ?? 0]?.seat}"
@@ -191,6 +194,10 @@
 		<Text label="Drop without snapping" value="hold Alt" disabled />
 		<Text label="Cancel drag" value="Esc" disabled />
 		<Text label="Nudge card higher" value="Arrow Up" disabled />
-		<Text label="Nudge card lower" value="Arrow Up" disabled />
+		<Text label="Nudge card lower" value="Arrow Down" disabled />
+	</Folder>
+	<!-- instrumentation, not settings: out of the player's way until asked for -->
+	<Folder title="Debug" expanded={false}>
+		<FpsGraph />
 	</Folder>
 </Pane>

--- a/src/routes/play/PaneDecks.svelte
+++ b/src/routes/play/PaneDecks.svelte
@@ -54,12 +54,10 @@
 	width={300}
 	localStoreId="table-decks-v2"
 >
+	<!-- the "spawn a deck to get started" hint lives on the page, not here: a
+	     tweakpane <Element> mounts its DOM in the pane's *container*, so the
+	     title bar drew straight through it (#113) -->
 	{#if myDecks.length === 0}
-		<Element>
-			<div class="flex w-full justify-center font-sans text-xs text-white uppercase opacity-30">
-				<span class="animate-pulse"> Spawn a deck to get started </span>
-			</div>
-		</Element>
 		<Button title="Spawn {STANDARD_52.name}" on:click={() => spawnPack(STANDARD_52)} />
 	{/if}
 	<!-- bringing your own content onto a LIVE table: spawning goes through the

--- a/src/routes/play/__tests__/Pane.test.ts
+++ b/src/routes/play/__tests__/Pane.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The /play settings pane used to open on Keybinds — 13 read-only key names —
+ * with an FpsGraph as its first row, hiding every action behind a collapsed
+ * folder (#113). What a player sees on first paint is the assertion here.
+ *
+ * Drives the real tweakpane controls in jsdom, like PaneDecks.test.ts.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import Pane from '../Pane.svelte';
+import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { gameActions } from '$lib/store/game/actions';
+import type { GameDTO } from '$lib/store/game/types';
+
+// the pane reads the lobby out of the URL and can navigate; neither module
+// boots outside a real SvelteKit client runtime
+vi.mock('$app/state', () => ({
+	page: { url: new URL('http://localhost/play?lobby=testlobby'), state: {} }
+}));
+vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+
+// the draggable Pane observes its own size; jsdom has no ResizeObserver
+class NoopObserver {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+}
+vi.stubGlobal('ResizeObserver', NoopObserver);
+// the Overlays rotation Wheel is a camerakit blade, which waits on one
+vi.stubGlobal('IntersectionObserver', NoopObserver);
+
+/** tweakpane renders asynchronously; let its microtasks flush */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 20));
+
+/** the tweakpane folder blade whose title bar reads `title` */
+const folder = (container: HTMLElement, title: string) =>
+	[...container.querySelectorAll('.tp-fldv')].find(
+		(f) => f.querySelector('.tp-fldv_t')?.textContent?.trim() === title
+	);
+
+const isExpanded = (el: Element | undefined) => el?.classList.contains('tp-fldv-expanded');
+
+const deckOf = (id: string, n: number) => ({
+	id,
+	cards: Array.from({ length: n }, (_, i) => ({ id: `${id}-${i}`, faceImageUrl: 'f.png' }))
+});
+
+describe('/play settings pane on first paint', () => {
+	beforeEach(() => {
+		cleanup();
+		localStorage.clear();
+		gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {} });
+		localStorage.setItem('myPlayerId', 'player9');
+		gameActions.addPlayer('player9');
+	});
+
+	it('opens Scenarios and leaves the reference folders shut', async () => {
+		const { container } = render(Pane);
+		await settle();
+
+		// the actionable folder on an empty table
+		expect(isExpanded(folder(container, 'Scenarios'))).toBe(true);
+		// pure reference / instrumentation stays out of the way
+		expect(isExpanded(folder(container, 'Keybinds'))).toBe(false);
+		expect(isExpanded(folder(container, 'Debug'))).toBe(false);
+		expect(isExpanded(folder(container, 'Connection'))).toBe(false);
+		expect(isExpanded(folder(container, 'Overlays'))).toBe(false);
+	});
+
+	it('collapses Scenarios once the table has decks', async () => {
+		const { container } = render(Pane);
+		await settle();
+		expect(isExpanded(folder(container, 'Scenarios'))).toBe(true);
+
+		gameStore.updateState({
+			decks: { 'deck:player9:main': deckOf('deck:player9:main', 52) }
+		} as Partial<GameDTO>);
+		await settle();
+
+		expect(isExpanded(folder(container, 'Scenarios'))).toBe(false);
+		// the pane survived the update — a blade change can silently tear the
+		// whole thing down (see BulkSheet.svelte)
+		expect(folder(container, 'Keybinds')).toBeDefined();
+	});
+
+	it('keeps the fps graph inside Debug, not at the top of the pane', async () => {
+		const { container } = render(Pane);
+		await settle();
+
+		const graph = container.querySelector('.tp-fpsv');
+		expect(graph).not.toBeNull();
+		expect(folder(container, 'Debug')?.contains(graph!)).toBe(true);
+	});
+
+	it('labels the downward nudge Arrow Down', async () => {
+		const { container } = render(Pane);
+		await settle();
+
+		const rows = [...container.querySelectorAll('.tp-lblv')];
+		const row = rows.find((r) =>
+			r.querySelector('.tp-lblv_l')?.textContent?.includes('Nudge card lower')
+		);
+		expect(row?.querySelector('input')?.value).toBe('Arrow Down');
+	});
+});

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -10,11 +10,14 @@
 	import { ungroupHoveredDeck } from '$lib/hotkeys/ungroup';
 	import { shuffleHoveredDeck } from '$lib/hotkeys/shuffle';
 	import { cycleHoveredPieceState } from '$lib/hotkeys/piece-state';
+	import { isTyping } from '$lib/hotkeys/is-typing';
 	import { disconnect } from '$lib/websocket/connection';
 	import PieceStateMenu from '$lib/PieceStateMenu.svelte';
 	import SetupPane from './SetupPane.svelte';
 
 	function handleKeyDown(event: KeyboardEvent) {
+		// a key typed into a pane field is text, not a table command
+		if (isTyping(event.target)) return;
 		// hover-target routing: a hovered deck takes the key, otherwise it
 		// falls through to the hovered-card behavior (mirrors /play)
 		const hoveredDeck = get(dragStore).isDeckHovered;
@@ -43,6 +46,7 @@
 	}
 
 	function handleKeyUp(event: KeyboardEvent) {
+		if (isTyping(event.target)) return;
 		if (event.code === 'Space') cameraTransforms.togglePreviewHud(false);
 	}
 

--- a/src/routes/setup/SetupPane.svelte
+++ b/src/routes/setup/SetupPane.svelte
@@ -34,6 +34,7 @@
 		importScenarioFromText,
 		type SeatIndex
 	} from '$lib/scenario/scenario';
+	import { setSelectedDeck } from '$lib/store/deckSelection';
 	import { snapPointIds } from '$lib/store/game/actions/snap';
 	import { snapEditor, setSnapDefaults, setSnapPlacing } from '$lib/store/snapEditor';
 	import { SNAP_RADIUS_DEFAULT } from '$lib/utils/constants-snap';
@@ -41,6 +42,7 @@
 	import FileDropZone from '$lib/files/FileDropZone.svelte';
 	import { openDroppedFile } from '$lib/files/drop';
 	import { purgeUndefinedValues } from '$lib/utils/transforms/data';
+	import { tick } from 'svelte';
 	import { DEG2RAD } from 'three/src/math/MathUtils.js';
 	import type { GameDTO } from '$lib/store/game/types';
 	import toast from 'svelte-french-toast';
@@ -150,11 +152,62 @@
 		toast(`Seat ${activeSeat}: spawned ${STANDARD_52.name}`);
 	}
 
+	// ── second-click guard for the two irreversible buttons ───────────────────
+	// `Clear table` sits directly under `Delete selected`, and neither could be
+	// undone (#114). A browser `confirm()` is out — it steals focus from a
+	// draggable pane — and so is swapping the button for a confirm pair: an
+	// `{#if}` that REPLACES a blade tears the whole pane down (see the note in
+	// create/BulkSheet.svelte). So the button arms itself instead: the first
+	// click renames it to the question and ADDS a Cancel beside it (adding
+	// blades is safe), and only the second click goes through.
+
+	/** an armed button someone walked away from goes back to being safe */
+	const CONFIRM_TIMEOUT_MS = 5000;
+
+	let armed: 'clear' | 'delete' | null = $state(null);
+	let armedTimer: ReturnType<typeof setTimeout> | undefined;
+
+	function arm(which: 'clear' | 'delete') {
+		clearTimeout(armedTimer);
+		armed = which;
+		armedTimer = setTimeout(() => (armed = null), CONFIRM_TIMEOUT_MS);
+	}
+
+	function disarm() {
+		clearTimeout(armedTimer);
+		armed = null;
+	}
+
+	$effect(() => disarm);
+
+	/**
+	 * Nothing to lose: an empty table clears without asking. Overlays are judged
+	 * by their `imageUrl` rather than their presence — the pane's own effect
+	 * keeps an `overlays.table` record alive for the Position/Scale/Rotation
+	 * controls whether or not a map was ever picked, so a bare one isn't content.
+	 */
+	const tableIsEmpty = $derived.by(() => {
+		const s = $gameStore;
+		for (const collection of ['cards', 'decks', 'pieces', 'snapPoints'] as const) {
+			if (Object.values(s?.[collection] ?? {}).some(Boolean)) return false;
+		}
+		if (Object.values(s?.overlays ?? {}).some((o) => o?.imageUrl)) return false;
+		return !Object.keys(s?.players ?? {}).some(isSeatPlaceholder);
+	});
+
 	function handleDelete() {
 		if (!selectedScenario) return;
+		if (armed !== 'delete') return arm('delete');
+		disarm();
 		deleteScenario(selectedScenario);
 		refreshScenarios();
 		selectedScenario = scenarioNames[0] ?? '';
+	}
+
+	function handleClearTable() {
+		if (!tableIsEmpty && armed !== 'clear') return arm('clear');
+		disarm();
+		clearTable();
 	}
 
 	function handleExport() {
@@ -209,6 +262,99 @@
 	function setDeckField(deckId: string, patch: Record<string, unknown>) {
 		gameStore.updateState({ decks: { [deckId]: patch } });
 	}
+
+	// ── one selection, two controls ───────────────────────────────────────────
+	// `activeSeat` (what every Seats button acts on) and the Decks tab strip used
+	// to be unrelated state 80px apart: the strip could read `seat1 main` while
+	// the buttons all said "for seat 0" (#114). They are tied together here —
+	// click a tab and the seat follows it, change the seat and the strip jumps to
+	// that seat's first deck.
+	//
+	// The strip's own cursor is an INDEX, which shifts whenever a deck is spawned
+	// or deleted, so the deck ID is what's canonical: `deckTabIndex` is only the
+	// transport to and from tweakpane, re-derived from the id whenever `deckIds`
+	// moves. `synced` remembers what this component last agreed to, which is how
+	// the effect below tells WHICH of the three inputs actually changed — two
+	// plain effects would fight, and a seat with no decks would have its own
+	// selection undone by the tab strip.
+
+	/** owner seat of `deck:<owner>:<slot>`; undefined for a real player's deck */
+	function deckSeat(deckId: string | undefined): SeatIndex | undefined {
+		const owner = deckId?.split(':')[1];
+		return owner && isSeatPlaceholder(owner) ? (Number(owner.slice(4)) as SeatIndex) : undefined;
+	}
+
+	function firstDeckForSeat(ids: string[], seat: SeatIndex): string | undefined {
+		return ids.find((id) => deckSeat(id) === seat);
+	}
+
+	let selectedDeck: string | null = $state(null);
+	let deckTabIndex = $state(0);
+	let synced = { seat: 0 as number, index: 0, ids: '' };
+
+	/** Move the strip's cursor, recording it so the effect below knows it's ours. */
+	function setTabIndex(index: number, ids: string[]) {
+		deckTabIndex = index;
+		synced = { seat: activeSeat, index, ids: ids.join('\n') };
+	}
+
+	/** Point both controls at one deck. The single writer for either cursor. */
+	function pointAt(deckId: string | null, ids: string[]) {
+		selectedDeck = deckId;
+		const seat = deckSeat(deckId ?? undefined);
+		if (seat !== undefined) activeSeat = seat;
+		setTabIndex(deckId ? Math.max(0, ids.indexOf(deckId)) : 0, ids);
+	}
+
+	/**
+	 * tweakpane builds a tab page from the child component's `onMount`, one flush
+	 * AFTER `deckIds` grows — so an index written in the same flush addresses a
+	 * page that doesn't exist yet, and `TabGroup` only re-applies `selectedIndex`
+	 * when the NUMBER changes, so it never retries. Park the cursor out of range
+	 * (`pages.at()` misses, which is a no-op rather than a selection) and put it
+	 * back once the pages are there. Without this the outline on the table and
+	 * the tab strip disagree the first time a deck spawns for the far seat.
+	 */
+	function reassertTab(ids: string[]) {
+		const want = deckTabIndex;
+		const parked = ids.length;
+		setTabIndex(parked, ids);
+		tick().then(() => {
+			if (deckTabIndex === parked) setTabIndex(want, ids);
+		});
+	}
+
+	$effect(() => {
+		const ids = deckIds;
+		const idsKey = ids.join('\n');
+		const index = deckTabIndex;
+		const seat = activeSeat;
+
+		if (idsKey !== synced.ids) {
+			// decks spawned or went away. A deck just spawned FOR the seat being
+			// edited is what you want to position next, so it wins; otherwise hold
+			// whatever was selected, and only then fall back to the seat's first.
+			const before = synced.ids ? synced.ids.split('\n') : [];
+			const added = ids.find((id) => !before.includes(id) && deckSeat(id) === seat);
+			const keep = selectedDeck && ids.includes(selectedDeck) ? selectedDeck : null;
+			pointAt(added ?? keep ?? firstDeckForSeat(ids, seat) ?? ids[0] ?? null, ids);
+			if (ids.length) reassertTab(ids);
+		} else if (index !== synced.index) {
+			// a tab was clicked — the seat follows it
+			pointAt(ids[index] ?? null, ids);
+		} else if (seat !== synced.seat) {
+			// the seat was changed — the strip follows it, when that seat has a deck
+			const id = firstDeckForSeat(ids, seat);
+			if (id) pointAt(id, ids);
+			else synced.seat = seat;
+		}
+	});
+
+	// publish to the scene, and stop highlighting when the editor goes away
+	$effect(() => {
+		setSelectedDeck(selectedDeck);
+		return () => setSelectedDeck(null);
+	});
 
 	// Snap points — authored placement guides. The scene has the direct
 	// manipulation (click to place while armed, drag a marker to move,
@@ -291,7 +437,7 @@
 	</Folder>
 	{#if deckIds.length > 0}
 		<Folder title="Decks" expanded={true}>
-			<TabGroup>
+			<TabGroup bind:selectedIndex={deckTabIndex}>
 				{#each deckIds as deckId (deckId)}
 					{@const deck = $gameStore?.decks?.[deckId]}
 					{@const position = deck?.position ?? [0, 0.4, 0]}
@@ -411,7 +557,13 @@
 		<Button title="Load selected" on:click={handleLoad} />
 		<Button title="Export selected (.tbps.json)" on:click={handleExport} />
 		<Button title="Open a scenario (.tbps.json)" on:click={() => scenarioFileInput?.click()} />
-		<Button title="Delete selected" on:click={handleDelete} />
+		<Button
+			title={armed === 'delete' ? `Really delete "${selectedScenario}"?` : 'Delete selected'}
+			on:click={handleDelete}
+		/>
+		{#if armed === 'delete'}
+			<Button title="Keep it" on:click={disarm} />
+		{/if}
 		<Element>
 			<input
 				bind:this={scenarioFileInput}
@@ -422,7 +574,13 @@
 			/>
 		</Element>
 	</Folder>
-	<Button title="Clear table" on:click={clearTable} />
+	<Button
+		title={armed === 'clear' ? 'Really clear the whole table?' : 'Clear table'}
+		on:click={handleClearTable}
+	/>
+	{#if armed === 'clear'}
+		<Button title="Leave it alone" on:click={disarm} />
+	{/if}
 	<Textarea
 		disabled
 		rows={6}

--- a/src/routes/setup/__tests__/SetupPane.snap.test.ts
+++ b/src/routes/setup/__tests__/SetupPane.snap.test.ts
@@ -113,7 +113,12 @@ describe('SetupPane — snap points', () => {
 		await fireEvent.click(button(container, 'Add at table centre')!);
 		await settle();
 
+		// non-empty table: the first click only arms the button (#114)
 		await fireEvent.click(button(container, 'Clear table')!);
+		await settle();
+		expect(snapPoints()).not.toEqual({});
+
+		await fireEvent.click(button(container, 'Really clear the whole table?')!);
 		await settle();
 
 		expect(snapPoints()).toEqual({});

--- a/src/routes/setup/__tests__/SetupPane.test.ts
+++ b/src/routes/setup/__tests__/SetupPane.test.ts
@@ -4,13 +4,19 @@
  * blade that tears down takes the WHOLE pane with it — see BulkSheet.svelte's
  * note), and "spawn for the seat I'm editing" wires the seat through, so the
  * same pack can be laid out for both sides without re-picking a file (#93).
+ *
+ * Plus the two #114 fixes: seat selection and the Decks tab strip are one
+ * selection expressed two ways, and the irreversible buttons need a second
+ * click.
  */
 import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, fireEvent, render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import SetupPane from '../SetupPane.svelte';
 import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { selectedDeckId } from '$lib/store/deckSelection';
 import { saveLibraryPack } from '$lib/packs/library';
+import { saveScenario, listScenarios } from '$lib/scenario/scenario';
 import type { GamePackDef } from '$lib/packs/types';
 
 // jsdom has neither observer; the draggable Pane needs one and tweakpane's
@@ -87,5 +93,199 @@ describe('SetupPane', () => {
 		// the placeholder that will own it is seated first, or the scenario would
 		// save a deck belonging to nobody
 		expect(get(gameStore).players?.seat1?.seat).toBe(1);
+	});
+});
+
+/** two decks on the table, one per seat — the state #114 was reported against */
+function twoSeatsWithDecks() {
+	gameStore.set({
+		players: {
+			seat0: { id: 'seat0', seat: 0, joinTimestamp: 0, tray: {}, metadata: {} },
+			seat1: { id: 'seat1', seat: 1, joinTimestamp: 0, tray: {}, metadata: {} }
+		},
+		cards: {},
+		decks: {
+			'deck:seat0:main': { id: 'deck:seat0:main', cards: [], position: [8.5, 0.4, 4.5] },
+			'deck:seat1:main': { id: 'deck:seat1:main', cards: [], position: [8.5, 0.4, -4.7] }
+		},
+		pieces: {},
+		overlays: {}
+	} as unknown as Parameters<typeof gameStore.set>[0]);
+}
+
+/** tweakpane renders tab titles into their own buttons */
+const tab = (container: HTMLElement, title: string) =>
+	[...container.querySelectorAll('button')].find((b) => b.textContent?.trim() === title);
+
+/** …and marks the active one `tp-tbiv-sel` — tweakpane's own idea of selected */
+const selectedTabTitle = (container: HTMLElement) =>
+	container.querySelector('.tp-tbiv-sel')?.textContent?.trim();
+
+describe('SetupPane — seat and deck tab are one selection (#114)', () => {
+	beforeEach(() => {
+		cleanup();
+		localStorage.clear();
+		gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {}, overlays: {} });
+		selectedDeckId.set(null);
+	});
+
+	it('follows the seat when a deck tab is clicked', async () => {
+		twoSeatsWithDecks();
+		const { container } = render(SetupPane);
+		await settle();
+
+		// the strip opens on the seat being edited
+		expect(get(selectedDeckId)).toBe('deck:seat0:main');
+		expect(button(container, 'View table from seat 0')).toBeDefined();
+
+		await fireEvent.click(tab(container, 'seat1 main')!);
+		await settle();
+
+		expect(get(selectedDeckId)).toBe('deck:seat1:main');
+		// every "for seat N" button now agrees with the tab
+		expect(button(container, 'View table from seat 1')).toBeDefined();
+		expect(button(container, 'Spawn selected for seat 1')).toBeDefined();
+	});
+
+	it('moves the tab strip when the seat is changed', async () => {
+		twoSeatsWithDecks();
+		const { container } = render(SetupPane);
+		await settle();
+
+		const seats = listWith(container, 'Seat 1 (far)');
+		seats.selectedIndex = 1;
+		seats.dispatchEvent(new Event('change', { bubbles: true }));
+		await settle();
+
+		expect(get(selectedDeckId)).toBe('deck:seat1:main');
+		expect(selectedTabTitle(container)).toBe('seat1 main');
+		// and the pane is still standing
+		expect(button(container, 'Clear table')).toBeDefined();
+	});
+
+	it('keeps pointing at the same deck when another one spawns', async () => {
+		twoSeatsWithDecks();
+		const { container } = render(SetupPane);
+		await settle();
+
+		await fireEvent.click(tab(container, 'seat1 main')!);
+		await settle();
+
+		gameStore.updateState({
+			decks: { 'deck:seat0:discard': { id: 'deck:seat0:discard', cards: [] } }
+		} as unknown as Parameters<typeof gameStore.updateState>[0]);
+		await settle();
+
+		// the index shifted under the strip; the SELECTION did not
+		expect(get(selectedDeckId)).toBe('deck:seat1:main');
+		expect(button(container, 'View table from seat 1')).toBeDefined();
+	});
+
+	it('stays on the seat a deck was just spawned for, strip included', async () => {
+		saveLibraryPack(PACK);
+		const { container } = render(SetupPane);
+		await settle();
+
+		await fireEvent.click(button(container, 'Spawn selected for seat 0')!);
+		await settle();
+
+		const seats = listWith(container, 'Seat 1 (far)');
+		seats.selectedIndex = 1;
+		seats.dispatchEvent(new Event('change', { bubbles: true }));
+		await settle();
+		await fireEvent.click(button(container, 'Spawn selected for seat 1')!);
+		await settle();
+
+		// the seat you spawned for stays put — it used to snap back to seat 0
+		expect(button(container, 'View table from seat 1')).toBeDefined();
+		expect(get(selectedDeckId)).toBe('deck:seat1:main');
+		// and tweakpane's own cursor agrees with the outline on the table: the
+		// selected page is the only one whose controls are visible
+		expect(selectedTabTitle(container)).toBe('seat1 main');
+	});
+
+	it('stops highlighting once the editor is gone', async () => {
+		twoSeatsWithDecks();
+		const { unmount } = render(SetupPane);
+		await settle();
+		expect(get(selectedDeckId)).toBe('deck:seat0:main');
+
+		unmount();
+		await settle();
+
+		expect(get(selectedDeckId)).toBeNull();
+	});
+});
+
+describe('SetupPane — the irreversible buttons ask twice (#114)', () => {
+	beforeEach(() => {
+		cleanup();
+		localStorage.clear();
+		gameStore.set({ players: {}, cards: {}, decks: {}, pieces: {}, overlays: {} });
+		selectedDeckId.set(null);
+	});
+
+	it('arms Clear table before wiping a non-empty table', async () => {
+		twoSeatsWithDecks();
+		const { container } = render(SetupPane);
+		await settle();
+
+		await fireEvent.click(button(container, 'Clear table')!);
+		await settle();
+
+		// nothing gone yet, and there is a way back
+		expect(Object.values(get(gameStore).decks ?? {}).filter(Boolean)).toHaveLength(2);
+		expect(button(container, 'Leave it alone')).toBeDefined();
+
+		await fireEvent.click(button(container, 'Really clear the whole table?')!);
+		await settle();
+
+		expect(Object.values(get(gameStore).decks ?? {}).filter(Boolean)).toHaveLength(0);
+		// disarmed again, and the pane survived both blades coming and going
+		expect(button(container, 'Leave it alone')).toBeUndefined();
+		expect(button(container, 'Clear table')).toBeDefined();
+		expect(button(container, 'Save scenario')).toBeDefined();
+	});
+
+	it('cancels an armed Clear table', async () => {
+		twoSeatsWithDecks();
+		const { container } = render(SetupPane);
+		await settle();
+
+		await fireEvent.click(button(container, 'Clear table')!);
+		await settle();
+		await fireEvent.click(button(container, 'Leave it alone')!);
+		await settle();
+
+		expect(Object.values(get(gameStore).decks ?? {}).filter(Boolean)).toHaveLength(2);
+		expect(button(container, 'Clear table')).toBeDefined();
+	});
+
+	it('does not bother asking when the table is already empty', async () => {
+		const { container } = render(SetupPane);
+		await settle();
+
+		await fireEvent.click(button(container, 'Clear table')!);
+		await settle();
+
+		expect(button(container, 'Really clear the whole table?')).toBeUndefined();
+	});
+
+	it('arms Delete selected before dropping a saved scenario', async () => {
+		twoSeatsWithDecks();
+		saveScenario('keeper');
+		const { container } = render(SetupPane);
+		await settle();
+
+		await fireEvent.click(button(container, 'Delete selected')!);
+		await settle();
+		expect(listScenarios().map((s) => s.name)).toEqual(['keeper']);
+
+		await fireEvent.click(button(container, 'Really delete "keeper"?')!);
+		await settle();
+
+		expect(listScenarios()).toEqual([]);
+		expect(button(container, 'Delete selected')).toBeDefined();
+		expect(button(container, 'Clear table')).toBeDefined();
 	});
 });


### PR DESCRIPTION
Integration PR for the pane-UX epic. Four tickets, already reviewed and merged into this
branch individually; this lands them on `main` together.

| Ticket | PR | What |
|---|---|---|
| tableplace-112 | #117 | Hotkeys no longer fire while you're typing in a pane field — `isTyping()` lifted out of /create into `src/lib/hotkeys/is-typing.ts` and applied on /setup and /play |
| tableplace-113 | #118 | /play settings opens on what's actionable instead of the keybind reference |
| tableplace-108 | #121 | /create becomes one inline tabbed pane (Pack / Cards / Board / File) opened on a real step 1, replacing four draggable panes |
| tableplace-114 | #124 | /setup — one selection shared by seat and deck tabs, a visible table referent, and a confirm on Clear table |

**18 files, +1452/−443.**

## Why a single integration PR

The four tickets overlap heavily on the same pane components, so they were serialized onto
one branch rather than merged in parallel — the merge-train pattern this workspace uses for
overlapping work. Each was reviewed on its own PR against this branch with `test` and
`render` green.

## Note for review

The branch was cut before `tableplace-116` (#122) landed on main, so it is being updated
from main before merge — the CI run that matters is the one **after** that update, since a
green result from before it was a claim about a base that no longer exists.

Neither main-only commit is expected to collide: #122 touched the websocket default host,
`e2e/servers.ts` and docs; #106 added `src/lib/compose/` and `scripts/seed-lobby.ts`.
Neither overlaps the pane components.

## Verification expected before merge

- `test` and `render` both green **on the updated branch** — the `render` job is the one
  that matters here, since this is entirely interactive UI and unit tests were not evidence
  for that class of change in tableplace-102.
- /create, /setup and /play each load and are interactive.
