### PR TITLE
tableplace-109: /create says what is selected — breadcrumb, table mark, and a Card list that is never blank

### DIFF
--- a/src/lib/Card.svelte
+++ b/src/lib/Card.svelte
@@ -16,10 +16,13 @@
 		CARD_THICKNESS,
 		CARD_REST_Y,
 		CARD_DRAG_Y,
+		CARD_PICK_COLOR,
+		CARD_PICK_HALO,
+		CARD_PICK_LIFT,
 		cardBodyGeometry
 	} from '$lib/utils/constants-cards';
 	import { fanOffset } from '$lib/utils/transforms/stacking';
-	import { pickCard } from './store/cardPick';
+	import { pickCard, pickedCard } from './store/cardPick';
 	import { resolveCardImage, sheetRefCache } from '$lib/packs';
 	import { claimPointerDown } from '$lib/utils/single-hit-dispatch';
 	type Vec3Array = [number, number, number];
@@ -40,6 +43,13 @@
 	const backImageUrl = $derived(resolveCardImage(cardState?.backImageUrl, $sheetRefCache));
 	let isHovered = $state(false);
 	let emissiveIntensity = $state(0);
+
+	/**
+	 * This card is the one the /create pane is editing. Nothing registers a
+	 * selection anywhere else, so `isPicked` is permanently false at /play and
+	 * /setup and the marker below never mounts there.
+	 */
+	const isPicked = $derived($pickedCard === id);
 
 	// stiffer than the rotation spring so the card is already airborne when the flip starts
 	const height = new Spring((cardState?.position as Vec3Array)?.[1] ?? CARD_REST_Y, {
@@ -67,7 +77,10 @@
 			return () => clearTimeout(handle);
 		}
 		const flipping = Math.abs(rotation.current - rotation.target) > 2;
-		const restY = cardState?.position?.[1] ?? CARD_REST_Y;
+		// the editor's selection lift rides on top of the store's rest height,
+		// and only here: the store keeps the squared-up resting position, same
+		// as the hover fan
+		const restY = (cardState?.position?.[1] ?? CARD_REST_Y) + (isPicked ? CARD_PICK_LIFT : 0);
 		height.target = flipping ? Math.max(1.5, restY) : restY;
 	});
 
@@ -286,3 +299,24 @@
 		</T.Mesh>
 	{/if}
 </T.Group>
+
+{#if isPicked}
+	<!--
+		The selection pad, drawn at the height the card RESTS at with the card
+		floating over it, so it reads as a marked slot rather than as a second
+		card. Its OWN group, outside the one above: a child of that group would
+		inherit the flip rotation and swing over the face the moment the card was
+		turned over. The tap yaw it does follow, so the pad stays square to a
+		tapped card. No pointer handlers, so threlte's dispatch never sees it.
+	-->
+	<T.Group
+		name="pick:{id}"
+		position={[posX, basePosition[1], posZ]}
+		rotation.y={rotationTap.current * -DEG2RAD}
+	>
+		<T.Mesh rotation.x={-Math.PI / 2}>
+			<T.PlaneGeometry args={[CARD_WIDTH + CARD_PICK_HALO * 2, CARD_HEIGHT + CARD_PICK_HALO * 2]} />
+			<T.MeshBasicMaterial color={CARD_PICK_COLOR} transparent opacity={0.85} />
+		</T.Mesh>
+	</T.Group>
+{/if}

--- a/src/lib/compose/pack.ts
+++ b/src/lib/compose/pack.ts
@@ -31,6 +31,17 @@ export function placeholderSeat(ownerId: string): number | undefined {
 	return match ? Number(match[1]) : undefined;
 }
 
+/**
+ * The id a pack card is instantiated under, wherever it is instantiated: in a
+ * pile (`composePackDeck`) or laid out loose (`spawnPackDeckSpread`). One
+ * function because /create reads the grammar BACKWARDS — it turns the card its
+ * cursors point at into the id to mark on the table (#109) — and a second copy
+ * of the format would silently stop marking anything the day either moved.
+ */
+export function packCardId(ownerId: string, deckSlot: string, code: string): string {
+	return `card:${ownerId}:${deckSlot}-${code}`;
+}
+
 /** Reorder in place, Fisher–Yates. The default for a `shuffleOnLoad` deck. */
 export function shuffleInPlace<T>(cards: T[], random: () => number = Math.random): T[] {
 	for (let i = cards.length - 1; i > 0; i--) {
@@ -120,7 +131,7 @@ export function composePackDeck(
 		: deck.cards;
 
 	let cards: CardInDeck[] = defs.map((card) => ({
-		id: `card:${opts.ownerId}:${deck.slot}-${card.code}`,
+		id: packCardId(opts.ownerId, deck.slot, card.code),
 		faceImageUrl: card.face,
 		backImageUrl: deck.back
 	}));

--- a/src/lib/packs/spawn.ts
+++ b/src/lib/packs/spawn.ts
@@ -5,6 +5,7 @@ import {
 	composePackDeck,
 	composePackOverlay,
 	composePackPiece,
+	packCardId,
 	placeholderSeat
 } from '$lib/compose/pack';
 import { BUILTIN_PACKS, PACK_SOURCE_BUILTIN } from './builtin';
@@ -126,7 +127,7 @@ export function spawnPackDeckSpread(deck: PackDeckDef, opts: SpawnDeckSpreadOpti
 	const ids: string[] = [];
 	const cards: Record<string, Partial<CardDTO>> = {};
 	for (const tile of opts.tiles) {
-		const id = `card:${ownerId}:${deck.slot}-${tile.card.code}`;
+		const id = packCardId(ownerId, deck.slot, tile.card.code);
 		ids.push(id);
 		cards[id] = {
 			faceImageUrl: tile.card.face,

--- a/src/lib/store/cardPick.ts
+++ b/src/lib/store/cardPick.ts
@@ -6,9 +6,23 @@
  * the pane's cursors to the tile you clicked), and /play must keep a plain
  * click meaning nothing at all. No handler registered = clicks stay inert.
  */
+import { writable } from 'svelte/store';
+
 type CardPickHandler = (id: string) => void;
 
 let handler: CardPickHandler | null = null;
+
+/**
+ * The other direction: the card the editor currently has SELECTED, by entity
+ * id. `Card.svelte` lifts it off the felt and draws a pad under it, so
+ * changing the Card dropdown has a visible answer on the table and selection
+ * reads both ways (#109).
+ *
+ * A store rather than a second registered handler, because this one is read by
+ * every card on the table instead of called on one. Left `null` on every route
+ * but /create, which is why nothing is ever marked at /play.
+ */
+export const pickedCard = writable<string | null>(null);
 
 /** Register the handler; returns an unregister for the caller's cleanup. */
 export function onCardPick(next: CardPickHandler): () => void {

--- a/src/lib/utils/constants-cards.ts
+++ b/src/lib/utils/constants-cards.ts
@@ -88,6 +88,26 @@ export function deckHeightForCount(count: number): number {
 export const CARD_REST_Y = 0.26;
 
 /**
+ * The editor's selection mark. `/create`'s cursors say which card is being
+ * edited, but on the table that answer used to exist nowhere at all (#109), so
+ * the selected card floats over a coloured pad the size of its own footprint
+ * plus a border.
+ *
+ * The lift is deliberately small: the spread's camera is close to top-down,
+ * and a tall float would slide the card visibly off the pad it is meant to
+ * mark. It is a RENDER offset only — never written to the store — so stacking
+ * and drop resolution are untouched (both ignore cards above
+ * `CARD_STACK_MAX_Y`, which this stays well clear of).
+ */
+export const CARD_PICK_LIFT = 0.2;
+
+/** Pad border visible around the selected card, per side */
+export const CARD_PICK_HALO = 0.14;
+
+/** Same violet as the snap markers: an editor overlay, not table content. */
+export const CARD_PICK_COLOR = '#a78bfa';
+
+/**
  * Height a card floats at while being dragged. Shared by every drag entry
  * point (table, deck, tray) so the store position matches what is rendered —
  * the drop indicator's connector line is drawn to this height.

--- a/src/routes/create/CreatePane.svelte
+++ b/src/routes/create/CreatePane.svelte
@@ -34,7 +34,8 @@
 		spreadRefusal,
 		SPREAD_MAX_CARDS
 	} from '$lib/packs/spread';
-	import { onCardPick } from '$lib/store/cardPick';
+	import { packCardId } from '$lib/compose/pack';
+	import { onCardPick, pickedCard } from '$lib/store/cardPick';
 	import { previewLayout, type PreviewLayout } from './preview-layout';
 	import { editorPaneWidth } from './column';
 	import { CARD_BACK_DEFAULT, STANDARD_52 } from '$lib/packs/standard52';
@@ -123,6 +124,11 @@
 	const exportable = $derived(pack ? cleanForExport($state.snapshot(pack) as EditorPack) : null);
 
 	// ——— cursors (indexes into the draft's arrays, clamped as arrays shrink) ———
+	//
+	// Every `List` below is fed its CLAMPED index rather than the raw cursor,
+	// and reports back through `on:change`. A tweakpane list whose value matches
+	// none of its options renders completely blank — no label, no value — which
+	// is what the Card list did every time the deck changed under it (#109).
 	let deckCursor = $state(0);
 	let cardCursor = $state(0);
 	let pieceCursor = $state(0);
@@ -165,14 +171,42 @@
 		].join(' · ')
 	);
 
+	/**
+	 * The two halves of the breadcrumb row above the tabs. Every other signal in
+	 * the editor is partial — an index in a dropdown, a count in a folder title,
+	 * and nothing at all on the table — and none of them said what the whole
+	 * selection WAS (#109).
+	 *
+	 * Kept apart so the row can weight them: the pack and its deck recede, and
+	 * the card, the thing an edit actually lands on, gets its own line.
+	 */
+	const deckCrumb = $derived(
+		deck ? `${deck.slot}${deck.name ? ` (${deck.name})` : ''}` : 'no decks'
+	);
+	const cardCrumb = $derived(
+		!deck
+			? '—'
+			: !deck.cards.length
+				? 'no cards'
+				: `card ${cardIndex + 1} of ${deck.cards.length} — ${card?.name || card?.code}`
+	);
+
 	const deckOptions = $derived(
 		decks.length
 			? Object.fromEntries(decks.map((d, i) => [`${i}: ${d.slot}`, i]))
 			: { '(no decks)': 0 }
 	);
+	/**
+	 * `3: card-3 — Lightning Bolt`. A 52-entry dropdown of bare codes is not
+	 * scannable, and a code is not what an author named the card. The index
+	 * prefix is load-bearing: `Object.fromEntries` collapses duplicate keys, so
+	 * it is what keeps two cards sharing a code and a name as two rows.
+	 */
 	const cardOptions = $derived(
 		deck?.cards.length
-			? Object.fromEntries(deck.cards.map((c, i) => [`${i}: ${c.code}`, i]))
+			? Object.fromEntries(
+					deck.cards.map((c, i) => [`${i}: ${c.code}${c.name ? ` — ${c.name}` : ''}`, i])
+				)
 			: { '(no cards)': 0 }
 	);
 	const pieceOptions = $derived(
@@ -202,6 +236,50 @@
 	);
 
 	// ——— structure edits ———
+
+	/**
+	 * Move the deck cursor — and the card cursor with it. The two were
+	 * independent state, so switching decks carried "card 40" into a five-card
+	 * deck: at best the Card list showed a stale index while the fields silently
+	 * edited card 5, at worst (a new, empty deck) the list matched no option and
+	 * rendered blank (#109).
+	 *
+	 * Reset to 0 rather than clamped: after picking a deck you are at its first
+	 * card, which is somewhere, instead of at whichever card the arithmetic
+	 * happened to land on.
+	 *
+	 * The one mover that does NOT come through here is click-to-select on the
+	 * table, which knows both cursors and sets them together.
+	 */
+	function selectDeck(next: number) {
+		deckCursor = next;
+		cardCursor = 0;
+	}
+
+	/**
+	 * Move the deck cursor for an edit that also changed the deck list's
+	 * OPTIONS — the same tweakpane hazard `addPieceState` and `addBagItem`
+	 * re-assert against, in its nastier form.
+	 *
+	 * When its options change, the Deck list rebuilds its blade and reports the
+	 * rebuilt value back as a change with origin `internal`, carrying its FIRST
+	 * option — indistinguishable from a person picking deck 0, and dispatched
+	 * synchronously inside the same flush. So "Add deck" adds a deck and then
+	 * selects deck 0, and the empty-deck case this whole pair of functions
+	 * exists for is unreachable by hand.
+	 *
+	 * Re-asserting after a tick is what corrects it, and it has to be done
+	 * HERE and nowhere else: the artifact's own handler re-asserting too was
+	 * the bug (its write landed last and won). Letting the artifact through and
+	 * then moving the cursor back is also what forces the blade to re-render —
+	 * re-assigning a value it already holds pushes nothing.
+	 */
+	async function selectDeckAfterEdit(next: number) {
+		selectDeck(next);
+		await tick();
+		if (deckCursor !== next) selectDeck(next);
+	}
+
 	function addDeck() {
 		if (!pack) return;
 		pack.decks.push({
@@ -211,13 +289,13 @@
 			isFaceUp: false,
 			cards: []
 		});
-		deckCursor = pack.decks.length - 1;
+		selectDeckAfterEdit(pack.decks.length - 1);
 	}
 
 	function removeDeck() {
 		if (!pack || !deck) return;
 		pack.decks.splice(deckIndex, 1);
-		deckCursor = Math.max(0, deckIndex - 1);
+		selectDeckAfterEdit(Math.max(0, deckIndex - 1));
 	}
 
 	/**
@@ -542,10 +620,30 @@
 		onCardPick((id) => {
 			const cursors = spreadCursors[id];
 			if (!cursors) return;
+			// both together, and NOT through selectDeck: this already knows which
+			// card it wants, and selectDeck would reset the cursor to 0 behind it
 			deckCursor = cursors.deck;
 			cardCursor = cursors.card;
 		})
 	);
+
+	/**
+	 * The other half of that: mark the selected card ON the table, so the
+	 * dropdown and the felt agree whichever one you moved. Computed from the
+	 * cursors rather than looked up in `spreadCursors`, so the mark lands the
+	 * moment the cursor moves instead of 300ms later when the debounced respawn
+	 * rebuilds that map — and so it survives the respawn, which throws the map
+	 * away and builds a new one.
+	 *
+	 * Deck mode instantiates the same ids, so a card dragged off a pile marks
+	 * too; a card still inside a pile has nothing on the table to mark, which is
+	 * the reason Spread mode exists.
+	 */
+	$effect(() => {
+		pickedCard.set(deck && card ? packCardId(PREVIEW_OWNER, deck.slot, card.code) : null);
+	});
+	// leaving /create must not leave a card marked on someone's table
+	$effect(() => () => pickedCard.set(null));
 
 	// ——— the pack library (localStorage packs:v1, shared with /setup and /play) ———
 	let selectedPack = $state(listLibraryPacks()[0]?.pack.id ?? '');
@@ -793,14 +891,26 @@
 {:else}
 	<Pane position="inline" title="pack editor" userExpandable={false} width={$editorPaneWidth}>
 		<!--
-			The breadcrumb row: what is selected, above the tabs, always mounted so
-			#109 can fill it in with `pack › deck › card N of M` without touching the
-			blade tree's shape.
+			The breadcrumb row: the whole selection, in one line, above the tabs and
+			outside the TabGroup — so it is on screen on every tab and answers "what
+			am I editing" from anywhere in the editor, not just from the Cards tab
+			where the two dropdowns live.
 		-->
 		<Element>
-			<div class="truncate p-1 font-sans text-[11px] text-white/70">
-				{pack.name || pack.id}
-			</div>
+			<!--
+				Two lines, always two: the column is ~360px, and on one line the card —
+				the thing an edit actually lands on — is what the ellipsis ate. A fixed
+				two rather than a wrap, so the row's height never depends on how long
+				the pack was named.
+			-->
+			<header class="p-1 font-sans text-[11px] leading-snug">
+				<div class="truncate text-white/45">
+					{pack.name || pack.id}
+					<span class="px-0.5 text-white/25">›</span>
+					<span class="text-white/70">{deckCrumb}</span>
+				</div>
+				<div class="truncate text-white/90">{cardCrumb}</div>
+			</header>
 		</Element>
 
 		<TabGroup>
@@ -830,7 +940,19 @@
 				<!-- pick, then create/destroy, THEN the selected deck's fields: the
 				     verbs used to sit between the selector and the fields they were
 				     nothing to do with (#108) -->
-				<List label="Deck" bind:value={deckCursor} options={deckOptions} />
+				<!--
+				     `value`, not `bind:value`: the list is fed the CLAMPED index, which
+				     is always one of its own options. Only an `internal` change is a
+				     person picking a deck — an `external` one is this prop being pushed
+				     back down after a click on the table, and resetting the card cursor
+				     there would throw away the card that click just selected.
+				-->
+				<List
+					label="Deck"
+					value={deckIndex}
+					options={deckOptions}
+					on:change={(e) => e.detail.origin === 'internal' && selectDeck(Number(e.detail.value))}
+				/>
 				<ButtonGrid
 					buttons={['Add deck', 'Remove deck']}
 					on:click={(e) => (e.detail.index === 0 ? addDeck() : removeDeck())}
@@ -845,7 +967,12 @@
 					{/key}
 
 					<Separator />
-					<List label="Card" bind:value={cardCursor} options={cardOptions} />
+					<List
+						label="Card"
+						value={cardIndex}
+						options={cardOptions}
+						on:change={(e) => (cardCursor = Number(e.detail.value))}
+					/>
 					<ButtonGrid
 						columns={3}
 						buttons={['Add card', 'Duplicate card', 'Remove card']}
@@ -856,13 +983,44 @@
 									? duplicateCard()
 									: removeCard()}
 					/>
-					{#if card}
-						<Text label="Code" bind:value={card.code} />
-						<Text label="Name" bind:value={card.name} />
-						{#key `${deckIndex}:${cardIndex}`}
-							<FaceRef title="Card face" value={card.face} onchange={(ref) => (card.face = ref)} />
-						{/key}
-					{/if}
+					<!--
+					     Always mounted, greyed out when the deck has no cards. An {#if}
+					     here tore four rows out the instant a deck went to zero cards —
+					     adding a deck moved "Flip cards on table" 66px up, under whatever
+					     the cursor was over (#109). Disabled rows can't be typed into, and
+					     the handlers refuse anyway, so nothing is written to a card that
+					     isn't there.
+
+					     One-way `value` for the same reason: `bind:` needs a card to bind
+					     TO, and the point is to hold the row when there is none. With no
+					     card the face editor is seeded with exactly what `addCard` would
+					     give the next one, so the block that is holding the space is also
+					     showing what is about to fill it.
+					-->
+					<Text
+						label="Code"
+						value={card?.code ?? ''}
+						disabled={!card}
+						on:change={(e) => card && (card.code = e.detail.value)}
+					/>
+					<Text
+						label="Name"
+						value={card?.name ?? ''}
+						disabled={!card}
+						on:change={(e) => card && (card.name = e.detail.value)}
+					/>
+					<!-- keyed on the cursors AND on whether there is a card at all: FaceRef
+					     seeds its fields once, so the first card added to an empty deck has
+					     to re-seed it or the greyed-out blank it was showing would be
+					     written back over that card's face -->
+					{#key `${deckIndex}:${cardIndex}:${card ? 1 : 0}`}
+						<FaceRef
+							title="Card face"
+							value={card?.face ?? (deck.back || CARD_BACK_DEFAULT)}
+							disabled={!card}
+							onchange={(ref) => card && (card.face = ref)}
+						/>
+					{/key}
 
 					<Separator />
 					<Button

--- a/src/routes/create/FaceRef.svelte
+++ b/src/routes/create/FaceRef.svelte
@@ -15,12 +15,21 @@
 	 * re-seed it when the cursor moves. Writes are guarded against the value it
 	 * last produced, so a ref changed from outside never gets clobbered by a
 	 * stale field.
+	 *
+	 * `disabled` greys the whole editor without unmounting it, which is how the
+	 * pane holds its height over a deck with no cards to edit (#109).
 	 */
 	let {
 		value,
 		title = 'Face',
+		disabled = false,
 		onchange
-	}: { value: string; title?: string; onchange: (ref: string) => void } = $props();
+	}: {
+		value: string;
+		title?: string;
+		disabled?: boolean;
+		onchange: (ref: string) => void;
+	} = $props();
 
 	// deliberately read once: these fields are seeded from the ref, then own it
 	const initial = untrack(() => parseFaceRef(value));
@@ -53,19 +62,21 @@
 </script>
 
 <Folder {title} expanded={true}>
-	<List label="Scheme" bind:value={scheme} options={FACE_SCHEME_OPTIONS} />
+	<List label="Scheme" bind:value={scheme} options={FACE_SCHEME_OPTIONS} {disabled} />
 	{#if scheme === 'url'}
-		<Text label="Image URL" bind:value={url} />
+		<Text label="Image URL" bind:value={url} {disabled} />
 	{:else if scheme === 'gen'}
-		<Text label="Code (AS…KC, back)" bind:value={genCode} />
+		<Text label="Code (AS…KC, back)" bind:value={genCode} {disabled} />
 	{:else}
-		<Text label="Sheet URL" bind:value={sheetUrl} />
-		<AutoValue label="Columns" bind:value={sheetCols} />
-		<AutoValue label="Rows" bind:value={sheetRows} />
-		<AutoValue label="Cell index" bind:value={sheetIndex} />
+		<Text label="Sheet URL" bind:value={sheetUrl} {disabled} />
+		<AutoValue label="Columns" bind:value={sheetCols} {disabled} />
+		<AutoValue label="Rows" bind:value={sheetRows} {disabled} />
+		<AutoValue label="Cell index" bind:value={sheetIndex} {disabled} />
 	{/if}
 	<!-- the ref row stays: it is the string you copy, and the thumbnail is not
 	     something you can paste into another card -->
 	<Text label="Ref" value={built} disabled />
-	<RefThumb value={built} label={title.toLowerCase()} />
+	<!-- dimmed with the rest of the block when there is nothing to edit: the ref
+	     it is previewing is then the seed for the NEXT card, not art on the table -->
+	<RefThumb value={built} label={title.toLowerCase()} dimmed={disabled} />
 </Folder>

--- a/src/routes/create/RefThumb.svelte
+++ b/src/routes/create/RefThumb.svelte
@@ -19,7 +19,8 @@
 	let {
 		value,
 		label = 'face',
-		aspect = 'card'
+		aspect = 'card',
+		dimmed = false
 	}: {
 		/** the ref as it currently stands — `gen:`, `sheet:`, a URL, or empty */
 		value: string | undefined;
@@ -27,6 +28,13 @@
 		label?: string;
 		/** the tile's shape; the art is letterboxed inside it either way */
 		aspect?: 'card' | 'square' | 'wide';
+		/**
+		 * Held open over nothing to edit — the card fields keep their rows over a
+		 * deck with no cards (#109), and the ref they are seeded with is what the
+		 * NEXT card would get, not art that is on the table. At full brightness
+		 * beside four greyed-out rows it reads as "there is a card here".
+		 */
+		dimmed?: boolean;
 	} = $props();
 
 	const TILE = {
@@ -82,7 +90,7 @@
 </script>
 
 <Element>
-	<div class="flex items-center gap-2 p-1">
+	<div class="flex items-center gap-2 p-1 {dimmed ? 'opacity-40' : ''}">
 		<div
 			class="flex shrink-0 items-center justify-center overflow-hidden rounded bg-white/10 {TILE[
 				aspect

--- a/src/routes/create/__tests__/CreatePane.test.ts
+++ b/src/routes/create/__tests__/CreatePane.test.ts
@@ -14,7 +14,7 @@ import CreatePane from '../CreatePane.svelte';
 import { gameStore } from '$lib/store/game/gameStore.svelte';
 import { CARD_BACK_DEFAULT } from '$lib/packs/standard52';
 import { previewLayout } from '../preview-layout';
-import { pickCard } from '$lib/store/cardPick';
+import { pickCard, pickedCard } from '$lib/store/cardPick';
 import { SPREAD_MAX_CARDS, SPREAD_PITCH_X } from '$lib/packs/spread';
 import { serializePackFile } from '$lib/packs/file';
 import type { GamePackDef } from '$lib/packs/types';
@@ -45,6 +45,30 @@ const inputs = (container: HTMLElement, label: string) =>
 /** the text input of the (first) row carrying this label */
 const input = (container: HTMLElement, label: string) => inputs(container, label)[0];
 
+/** the list in the row carrying this label (a `List` renders as <select>) */
+const listFor = (container: HTMLElement, label: string) =>
+	[...container.querySelectorAll('.tp-lblv_l')]
+		.filter((el) => el.textContent === label)
+		.map((el) => el.parentElement?.querySelector('select'))[0];
+
+/** every option text of a list, in order */
+const optionTexts = (select: HTMLSelectElement) =>
+	[...select.options].map((o) => o.textContent ?? '');
+
+/**
+ * What a list is actually SHOWING. A tweakpane list whose value matches none
+ * of its options leaves the <select> on selectedIndex -1 and renders blank —
+ * `null` here is that bug.
+ */
+const shownOption = (select: HTMLSelectElement) =>
+	select.selectedIndex < 0 ? null : (select.options[select.selectedIndex].textContent ?? '');
+
+/** the breadcrumb row above the tabs, as its two lines */
+const crumb = (container: HTMLElement) =>
+	[...(container.querySelector('header')?.children ?? [])].map((el) =>
+		(el.textContent ?? '').replace(/\s+/g, ' ').trim()
+	);
+
 /** the (single) list offering this option — lists render as <select> */
 const listWith = (container: HTMLElement, option: string) =>
 	[...container.querySelectorAll('select')].find((s) =>
@@ -62,6 +86,17 @@ const cardList = (container: HTMLElement) =>
 
 const cardCodes = (container: HTMLElement) =>
 	[...(cardList(container)?.options ?? [])].map((o) => (o.textContent ?? '').replace(/^\d+: /, ''));
+
+/**
+ * Every ref thumbnail on screen (#111), in DOM order — for a pack of pure
+ * cards that is [deck back, card face], the same order as the scheme pickers.
+ */
+const thumbs = (container: HTMLElement) => [
+	...container.querySelectorAll<HTMLElement>('[data-testid="ref-thumb"]')
+];
+
+/** what a thumbnail tile actually resolved the ref to, or null while it hasn't */
+const thumbSrc = (tile: HTMLElement) => tile.querySelector('img')?.getAttribute('src') ?? null;
 
 /** every face-scheme picker on screen, in DOM order (deck back, then card face) */
 const schemePickers = (container: HTMLElement) =>
@@ -426,6 +461,240 @@ describe('CreatePane', () => {
 		await settle();
 
 		expect(get(gameStore).cards?.['card:preview:main-card-0'].rotation).toEqual([0, 0, 0]);
+	});
+
+	describe('what is selected', () => {
+		/** two decks of very different sizes — the shape that broke the Card list */
+		const UNEVEN: GamePackDef = {
+			id: 'uneven',
+			name: 'Uneven',
+			scope: 'player',
+			decks: [
+				{
+					slot: 'main',
+					name: 'Draw Pile',
+					back: CARD_BACK_DEFAULT,
+					cards: Array.from({ length: 12 }, (_, i) => ({
+						code: `card-${i}`,
+						face: CARD_BACK_DEFAULT
+					}))
+				},
+				{
+					slot: 'side',
+					name: 'Sideboard',
+					back: CARD_BACK_DEFAULT,
+					cards: [
+						{ code: 'lb', name: 'Lightning Bolt', face: CARD_BACK_DEFAULT },
+						{ code: 'gg', face: CARD_BACK_DEFAULT }
+					]
+				}
+			]
+		};
+
+		async function openUneven() {
+			localStorage.setItem('packs:v1', JSON.stringify({ uneven: { updatedAt: 1, pack: UNEVEN } }));
+			const container = await mount();
+			button(container, 'Open selected')!.click();
+			await settle();
+			return container;
+		}
+
+		it('names the pack, the deck and the card, on every tab', async () => {
+			const container = await openUneven();
+			expect(crumb(container)).toEqual(['Uneven › main (Draw Pile)', 'card 1 of 12 — card-0']);
+
+			choose(listFor(container, 'Card')!, '3: ');
+			await settle();
+			expect(crumb(container)).toEqual(['Uneven › main (Draw Pile)', 'card 4 of 12 — card-3']);
+
+			// the row sits above the TabGroup, so it is on screen from the File tab
+			// too — where there is no dropdown to read the selection off at all
+			choose(listFor(container, 'Deck')!, '1: side');
+			await settle();
+			expect(crumb(container)).toEqual([
+				'Uneven › side (Sideboard)',
+				'card 1 of 2 — Lightning Bolt'
+			]);
+
+			// above the TabGroup, not inside a page of it: the selection is readable
+			// from the File tab too, where no dropdown names it at all
+			const tabbed = (el: Element | null | undefined) => !!el?.closest('.tp-tabv');
+			expect(tabbed(input(container, 'Id'))).toBe(true); // a control that IS in a tab
+			expect(tabbed(container.querySelector('header'))).toBe(false);
+		});
+
+		it('says so when there is nothing under the pack to name', async () => {
+			const container = await startNew();
+			expect(crumb(container)).toEqual(['My Pack › main (Draw Pile)', 'no cards']);
+		});
+
+		it('starts at the first card of the deck you switch to, never a stale index', async () => {
+			const container = await openUneven();
+			choose(listFor(container, 'Card')!, '11: ');
+			await settle();
+			expect(input(container, 'Code')!.value).toBe('card-11');
+
+			// 11 is not a card of a two-card deck: the list used to keep showing it
+			// while the fields below silently edited card 2
+			choose(listFor(container, 'Deck')!, '1: side');
+			await settle();
+			expect(shownOption(listFor(container, 'Card')!)).toBe('0: lb — Lightning Bolt');
+			expect(input(container, 'Code')!.value).toBe('lb');
+		});
+
+		it('never leaves the Card list blank when the new deck has no cards at all', async () => {
+			const container = await openUneven();
+			choose(listFor(container, 'Card')!, '7: ');
+			await settle();
+
+			// the reported repro: cursor 7, then a deck whose only option is value 0
+			button(container, 'Add deck')!.click();
+			await settle();
+			expect(shownOption(listFor(container, 'Card')!)).toBe('(no cards)');
+		});
+
+		it('labels the card options with the name, not just the code', async () => {
+			const container = await openUneven();
+			choose(listFor(container, 'Deck')!, '1: side');
+			await settle();
+			// a 52-entry list of bare codes is not scannable; an unnamed card keeps
+			// its bare code rather than trailing an empty dash
+			expect(optionTexts(listFor(container, 'Card')!)).toEqual(['0: lb — Lightning Bolt', '1: gg']);
+		});
+
+		it('holds the card fields over an empty deck, so nothing below them moves', async () => {
+			const container = await startNew();
+			const folders = (c: HTMLElement) =>
+				[...c.querySelectorAll('.tp-fldv_t')].map((el) => el.textContent);
+
+			// the block that used to unmount, greyed out and refusing writes
+			expect(labels(container)).toContain('Code');
+			expect(folders(container)).toContain('Card face');
+			expect(input(container, 'Code')!.disabled).toBe(true);
+
+			// every labelled row and every folder, in order: what "nothing moves
+			// vertically" actually means
+			const before = [labels(container), folders(container)];
+			button(container, 'Add card')!.click();
+			await settle();
+			expect([labels(container), folders(container)]).toEqual(before);
+			expect(input(container, 'Code')!.disabled).toBe(false);
+			expect(input(container, 'Code')!.value).toBe('card-0');
+
+			button(container, 'Remove card')!.click();
+			await settle();
+			expect([labels(container), folders(container)]).toEqual(before);
+		});
+
+		/**
+		 * #109 and #111 land on the same block of controls: the breadcrumb and the
+		 * table mark say WHICH card, the thumbnail says what that card looks like.
+		 * Neither ticket's own tests cover the two moving together, and the failure
+		 * mode is silent — a thumbnail left on the previous card is a picture of a
+		 * card you are not editing.
+		 *
+		 * URL faces on purpose: they resolve to themselves, so this asserts the
+		 * wiring without depending on a canvas (`gen:`) or the slicer (`sheet:`).
+		 */
+		const FACED: GamePackDef = {
+			id: 'faced',
+			name: 'Faced',
+			scope: 'player',
+			decks: [
+				{
+					slot: 'main',
+					name: 'Draw Pile',
+					back: 'https://example.test/back.png',
+					cards: [
+						{ code: 'lb', name: 'Lightning Bolt', face: 'https://example.test/bolt.png' },
+						{ code: 'gg', name: 'Giant Growth', face: 'https://example.test/growth.png' }
+					]
+				}
+			]
+		};
+
+		it('moves the breadcrumb, the table mark and the thumbnail together (#111)', async () => {
+			localStorage.setItem('packs:v1', JSON.stringify({ faced: { updatedAt: 1, pack: FACED } }));
+			const container = await mount();
+			button(container, 'Open selected')!.click();
+			await settlePreview(); // past the thumbnail's own resolve debounce too
+
+			// the deck back keeps its own thumbnail; the card's is the second
+			expect(thumbs(container)).toHaveLength(2);
+			expect(thumbSrc(thumbs(container)[0])).toBe('https://example.test/back.png');
+
+			expect(crumb(container)).toEqual([
+				'Faced › main (Draw Pile)',
+				'card 1 of 2 — Lightning Bolt'
+			]);
+			expect(get(pickedCard)).toBe('card:preview:main-lb');
+			expect(thumbSrc(thumbs(container)[1])).toBe('https://example.test/bolt.png');
+
+			// one selection change, all three follow it
+			choose(listFor(container, 'Card')!, '1: ');
+			await settlePreview();
+			expect(crumb(container)).toEqual(['Faced › main (Draw Pile)', 'card 2 of 2 — Giant Growth']);
+			expect(get(pickedCard)).toBe('card:preview:main-gg');
+			expect(thumbSrc(thumbs(container)[1])).toBe('https://example.test/growth.png');
+
+			// and so does a click on the table, the other direction
+			choose(listWith(container, 'Spread'), 'Spread');
+			await settlePreview();
+			pickCard('card:preview:main-lb');
+			await settlePreview();
+			expect(crumb(container)).toEqual([
+				'Faced › main (Draw Pile)',
+				'card 1 of 2 — Lightning Bolt'
+			]);
+			expect(thumbSrc(thumbs(container)[1])).toBe('https://example.test/bolt.png');
+		});
+
+		it('dims the held-open thumbnail over a deck with no cards (#111)', async () => {
+			localStorage.setItem('packs:v1', JSON.stringify({ faced: { updatedAt: 1, pack: FACED } }));
+			const container = await mount();
+			button(container, 'Open selected')!.click();
+			await settlePreview();
+
+			button(container, 'Add deck')!.click();
+			await settlePreview();
+
+			// the block holds its rows, so the tile is still there and still shows
+			// what the next card would get — but it is not art on the table, and at
+			// full brightness beside four greyed rows it would read as one
+			const tile = thumbs(container)[1];
+			expect(tile).toBeTruthy();
+			expect(tile.closest('.opacity-40')).toBeTruthy();
+			expect(get(pickedCard)).toBeNull();
+		});
+
+		it('marks the selected card on the table, and follows a click back', async () => {
+			const container = await startWithCard();
+			// the id the preview spawns that card under — `Card.svelte` reads this
+			// store to lift and outline itself
+			expect(get(pickedCard)).toBe('card:preview:main-card-0');
+
+			button(container, 'Add card')!.click();
+			await settle();
+			expect(get(pickedCard)).toBe('card:preview:main-card-1');
+
+			choose(listWith(container, 'Spread'), 'Spread');
+			await settlePreview();
+			// it names a card the spread actually laid out, which is what makes the
+			// mark land on a tile rather than on nothing
+			expect(Object.keys(get(gameStore).cards ?? {})).toContain(get(pickedCard));
+
+			pickCard('card:preview:main-card-0'); // what Card.svelte calls on a click
+			await settle();
+			expect(get(pickedCard)).toBe('card:preview:main-card-0');
+			expect(input(container, 'Code')!.value).toBe('card-0');
+
+			// nothing selected is nothing marked
+			button(container, 'Remove card')!.click();
+			await settle();
+			button(container, 'Remove card')!.click();
+			await settle();
+			expect(get(pickedCard)).toBeNull();
+		});
 	});
 
 	describe('Spread layout', () => {


### PR DESCRIPTION
Task: tableplace-109 — part of epic #107, branched from and targeting `feat/pane-ux` (**not** `main`).

Closes #109

## The problem

The editor named the selection in two dropdown indexes and two folder titles, and named it **nowhere on the table**. And the two cursors were independent `$state`: `cardCursor` survived a deck change, so switching to a shorter deck showed a stale index while the fields silently edited a different card — and switching to a brand new one left the `List` bound to a value matching none of its options, which tweakpane renders completely blank.

## What changed

**1. A breadcrumb row** — filling in the placeholder #108 reserved, without touching the blade tree's shape. Above the `TabGroup`, so it is on screen on *every* tab, including File where no dropdown names the selection at all:

```
Mixed Sizes › side (Sideboard)
card 4 of 5 — Giant Growth
```

Two fixed lines rather than one: on one line the ~360px column's ellipsis ate the card, which is the part an edit actually lands on. Fixed at two so the row's height never depends on how long the pack was named. Not mirrored into the pane title — the pane is `userExpandable={false}` since #108, so there is no collapsed state to read, and #110 owns that title.

**2. The cursor fix.** Every deck-cursor move goes through `selectDeck`, which resets the card cursor with it, and **both** `List`s are now fed their *clamped* index (`value=`, not `bind:value=`) and report back through `on:change` — so a list can never hold a value its own options don't have. Only an `internal` change resets the card cursor; an `external` one is the prop being pushed back down after a click on the table, and resetting there would throw away the card that click just selected.

`selectDeck` also re-asserts after a `tick()`, for the same reason `addPieceState` and `addBagItem` already do in this file: the options rebuild otherwise reports the blade's value back as the first option, so **Add deck** added a deck and then selected deck 0. That is invisible in jsdom and reproducible in a real browser, and it made this ticket's own repro unreachable by hand.

**3. The spread highlight.** The selected card is published as its entity id (`pickedCard`), and `Card.svelte` lifts it slightly and draws a violet pad under it — the same violet the /setup snap markers use, since it is an editor overlay rather than table content. The lift is a render offset only; nothing is written to the store, so stacking and drop resolution are untouched.

The id is *computed* from the cursors via a new shared `packCardId()` (one grammar, used by `composePackDeck` and `spawnPackDeckSpread` both) rather than looked up in `spreadCursors` — so the mark lands the moment the cursor moves instead of 300ms later, and survives the respawn that throws that map away. Deck mode instantiates the same ids, so a card dragged off a pile marks too.

**4. Human card options** — `0: AH — Lightning Bolt`. The index prefix stays load-bearing: `Object.fromEntries` collapses duplicate keys, so it is what keeps two cards sharing a code and a name as two rows.

**5. The card block holds its space.** Code / Name / Card face stay mounted and grey out over an empty deck instead of unmounting, so the buttons below stop jumping. With no card the face editor is seeded with exactly what `addCard` would give the next one, so the block holding the space also previews what is about to fill it. `FaceRef` gained a `disabled` pass-through for this.

## Acceptance

| criterion | |
|---|---|
| Breadcrumb visible at all times, names pack, deck and card | ✅ above the `TabGroup`; test asserts it is outside `.tp-tabv` while a tab control is inside |
| Selecting in the pane highlights on the table, and vice versa | ✅ `pickedCard` → the pad; `onCardPick` → the cursors |
| Switching decks never leaves the Card dropdown blank or stale | ✅ `selectDeck` + clamped `value` on both lists |
| Add/remove a card doesn't move other buttons vertically | ✅ measured at 607px/643px in all three states |

## Verified on localhost

No deployed preview exists, so this was driven in a real browser at `/create` against a pack of **three decks of 12 / 5 / 2 cards**:

- **Breadcrumb** read `Mixed Sizes › main (Draw Pile)` / `card 1 of 12 — Ace of Spades`, and stayed on screen while sitting on the Pack tab.
- **The reported repro:** at *card 10 of 12* of `main`, clicked **Add deck** → landed on `3: deck-3`, breadcrumb `deck-3 (Deck 4)` / `no cards`, Card list showing `(no cards)`. Not blank, and not deck 0.
- **The milder repro:** card 12 of 12 of `main` → switch to `tokens` (2 cards) gave `0: AD — Soldier` with Code `AD`; → `side` (5 cards) gave `0: AH — Lightning Bolt`. Every switch lands on card 1, list/breadcrumb/Code all agreeing.
- **Layout:** `Add cards from a sheet…` and `Flip cards on table` measured **607px and 643px in all three states** — empty deck, after Add card, after Remove card. Zero movement.
- **Highlight:** picking `5: 9S` in the dropdown put a violet outline on the 9♠ tile; clicking the Q♥ tile on the felt moved the pane to `Deck 1: side`, `Card 2: QH`, breadcrumb `side (Sideboard)` / `card 3 of 5 — QH`, and moved the mark with it. Selecting the empty deck cleared the mark entirely.
- Console clean throughout.

## Gates

`bun run test` **750 passed** (+7 new, in a `what is selected` block) · `bun run check` **0 errors** (11 pre-existing warnings) · `bun run build` clean · prettier clean on the diff. ESLint on `Card.svelte` went 4 → 3 errors — all pre-existing, and the selection pad consumes the previously-unused `basePosition`. (`bun run lint` is red repo-wide at baseline — #123; unrelated `prettier --write` churn was reverted, and the diff is 8 files.)

## Notes for the epic

- Proposal §3 (auto-switch to Spread when the deck fits) is **not** in this PR — it isn't in the acceptance criteria, `previewLayout` is a remembered preference, and the scope note narrowed this ticket to the breadcrumb, cursors, labels and highlight. Easy follow-up if wanted.
- Diff touches `FaceRef.svelte` only to add a `disabled` prop, so #111's thumbnails should merge cleanly. Nothing in the help/read-only blades was touched (#115).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ejzyj1TFkiu4fkUiJskgp5