### PR TITLE
pane UX epic, part 2 — /create thumbnails, selection breadcrumb, prose help (tableplace-109, -111, -115)

### DIFF
--- a/src/lib/Card.svelte
+++ b/src/lib/Card.svelte
@@ -16,10 +16,13 @@
 		CARD_THICKNESS,
 		CARD_REST_Y,
 		CARD_DRAG_Y,
+		CARD_PICK_COLOR,
+		CARD_PICK_HALO,
+		CARD_PICK_LIFT,
 		cardBodyGeometry
 	} from '$lib/utils/constants-cards';
 	import { fanOffset } from '$lib/utils/transforms/stacking';
-	import { pickCard } from './store/cardPick';
+	import { pickCard, pickedCard } from './store/cardPick';
 	import { resolveCardImage, sheetRefCache } from '$lib/packs';
 	import { claimPointerDown } from '$lib/utils/single-hit-dispatch';
 	type Vec3Array = [number, number, number];
@@ -40,6 +43,13 @@
 	const backImageUrl = $derived(resolveCardImage(cardState?.backImageUrl, $sheetRefCache));
 	let isHovered = $state(false);
 	let emissiveIntensity = $state(0);
+
+	/**
+	 * This card is the one the /create pane is editing. Nothing registers a
+	 * selection anywhere else, so `isPicked` is permanently false at /play and
+	 * /setup and the marker below never mounts there.
+	 */
+	const isPicked = $derived($pickedCard === id);
 
 	// stiffer than the rotation spring so the card is already airborne when the flip starts
 	const height = new Spring((cardState?.position as Vec3Array)?.[1] ?? CARD_REST_Y, {
@@ -67,7 +77,10 @@
 			return () => clearTimeout(handle);
 		}
 		const flipping = Math.abs(rotation.current - rotation.target) > 2;
-		const restY = cardState?.position?.[1] ?? CARD_REST_Y;
+		// the editor's selection lift rides on top of the store's rest height,
+		// and only here: the store keeps the squared-up resting position, same
+		// as the hover fan
+		const restY = (cardState?.position?.[1] ?? CARD_REST_Y) + (isPicked ? CARD_PICK_LIFT : 0);
 		height.target = flipping ? Math.max(1.5, restY) : restY;
 	});
 
@@ -286,3 +299,24 @@
 		</T.Mesh>
 	{/if}
 </T.Group>
+
+{#if isPicked}
+	<!--
+		The selection pad, drawn at the height the card RESTS at with the card
+		floating over it, so it reads as a marked slot rather than as a second
+		card. Its OWN group, outside the one above: a child of that group would
+		inherit the flip rotation and swing over the face the moment the card was
+		turned over. The tap yaw it does follow, so the pad stays square to a
+		tapped card. No pointer handlers, so threlte's dispatch never sees it.
+	-->
+	<T.Group
+		name="pick:{id}"
+		position={[posX, basePosition[1], posZ]}
+		rotation.y={rotationTap.current * -DEG2RAD}
+	>
+		<T.Mesh rotation.x={-Math.PI / 2}>
+			<T.PlaneGeometry args={[CARD_WIDTH + CARD_PICK_HALO * 2, CARD_HEIGHT + CARD_PICK_HALO * 2]} />
+			<T.MeshBasicMaterial color={CARD_PICK_COLOR} transparent opacity={0.85} />
+		</T.Mesh>
+	</T.Group>
+{/if}

--- a/src/lib/compose/pack.ts
+++ b/src/lib/compose/pack.ts
@@ -31,6 +31,17 @@ export function placeholderSeat(ownerId: string): number | undefined {
 	return match ? Number(match[1]) : undefined;
 }
 
+/**
+ * The id a pack card is instantiated under, wherever it is instantiated: in a
+ * pile (`composePackDeck`) or laid out loose (`spawnPackDeckSpread`). One
+ * function because /create reads the grammar BACKWARDS — it turns the card its
+ * cursors point at into the id to mark on the table (#109) — and a second copy
+ * of the format would silently stop marking anything the day either moved.
+ */
+export function packCardId(ownerId: string, deckSlot: string, code: string): string {
+	return `card:${ownerId}:${deckSlot}-${code}`;
+}
+
 /** Reorder in place, Fisher–Yates. The default for a `shuffleOnLoad` deck. */
 export function shuffleInPlace<T>(cards: T[], random: () => number = Math.random): T[] {
 	for (let i = cards.length - 1; i > 0; i--) {
@@ -120,7 +131,7 @@ export function composePackDeck(
 		: deck.cards;
 
 	let cards: CardInDeck[] = defs.map((card) => ({
-		id: `card:${opts.ownerId}:${deck.slot}-${card.code}`,
+		id: packCardId(opts.ownerId, deck.slot, card.code),
 		faceImageUrl: card.face,
 		backImageUrl: deck.back
 	}));

--- a/src/lib/packs/spawn.ts
+++ b/src/lib/packs/spawn.ts
@@ -5,6 +5,7 @@ import {
 	composePackDeck,
 	composePackOverlay,
 	composePackPiece,
+	packCardId,
 	placeholderSeat
 } from '$lib/compose/pack';
 import { BUILTIN_PACKS, PACK_SOURCE_BUILTIN } from './builtin';
@@ -126,7 +127,7 @@ export function spawnPackDeckSpread(deck: PackDeckDef, opts: SpawnDeckSpreadOpti
 	const ids: string[] = [];
 	const cards: Record<string, Partial<CardDTO>> = {};
 	for (const tile of opts.tiles) {
-		const id = `card:${ownerId}:${deck.slot}-${tile.card.code}`;
+		const id = packCardId(ownerId, deck.slot, tile.card.code);
 		ids.push(id);
 		cards[id] = {
 			faceImageUrl: tile.card.face,

--- a/src/lib/store/cardPick.ts
+++ b/src/lib/store/cardPick.ts
@@ -6,9 +6,23 @@
  * the pane's cursors to the tile you clicked), and /play must keep a plain
  * click meaning nothing at all. No handler registered = clicks stay inert.
  */
+import { writable } from 'svelte/store';
+
 type CardPickHandler = (id: string) => void;
 
 let handler: CardPickHandler | null = null;
+
+/**
+ * The other direction: the card the editor currently has SELECTED, by entity
+ * id. `Card.svelte` lifts it off the felt and draws a pad under it, so
+ * changing the Card dropdown has a visible answer on the table and selection
+ * reads both ways (#109).
+ *
+ * A store rather than a second registered handler, because this one is read by
+ * every card on the table instead of called on one. Left `null` on every route
+ * but /create, which is why nothing is ever marked at /play.
+ */
+export const pickedCard = writable<string | null>(null);
 
 /** Register the handler; returns an unregister for the caller's cleanup. */
 export function onCardPick(next: CardPickHandler): () => void {

--- a/src/lib/tweakpane/PaneProse.svelte
+++ b/src/lib/tweakpane/PaneProse.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+	import { getContext, type Snippet } from 'svelte';
+	import type { Writable } from 'svelte/store';
+
+	/**
+	 * Real HTML inside a tweakpane pane — the help/prose blade #115 needs.
+	 *
+	 * `svelte-tweakpane-ui`'s own `<Element>` is meant for exactly this and is
+	 * what /create uses (`BulkSheet.svelte`, `CreatePane.svelte`), but it only
+	 * works in a `position="inline"` pane. In a `position="draggable"` one its
+	 * contents never make it into the pane at all: `<Element>` moves its slot
+	 * into the blade from a Svelte 4 `$:` statement that, in a draggable pane,
+	 * never re-runs once the blade ref lands — the markup is left stranded in the
+	 * pane's container, which is the "the title bar drew straight through it"
+	 * symptom #113 hit in `PaneDecks.svelte`. Verified on localhost before this
+	 * component existed: 0 of 5 `<Element>`s on /play had been moved into the
+	 * pane, against 1 of 1 on /create.
+	 *
+	 * So this does the same job through the same tweakpane contract, but drives
+	 * the move from an `$effect`, which re-runs whenever the blade is recreated.
+	 *
+	 * Same swap hazard as everything else here (`BulkSheet.svelte:135-140`): keep
+	 * one of these mounted and drive its contents by expression rather than
+	 * wrapping it in an `{#if}` that replaces a blade.
+	 */
+
+	type Blade = { element: HTMLElement; dispose: () => void };
+	type BladeContainer = { addBlade: (options: Record<string, unknown>) => Blade };
+
+	let { children }: { children: Snippet } = $props();
+
+	// the container (Pane or Folder) that mounts us — the same context
+	// svelte-tweakpane-ui hands to its own blades
+	const parentStore = getContext<Writable<BladeContainer | undefined>>('parentStore');
+
+	// a zero-size marker left in Svelte's DOM: its position among its siblings is
+	// where this blade belongs in the pane
+	let marker = $state<HTMLDivElement>();
+	let source = $state<HTMLDivElement>();
+
+	/** siblings before the marker, minus the ones that aren't blades themselves */
+	function bladeIndex(el: HTMLElement): number {
+		let index = 0;
+		for (let s = el.previousElementSibling; s !== null; s = s.previousElementSibling) {
+			if (!s.classList.contains('skip-element-index')) index++;
+		}
+		return index;
+	}
+
+	// An explicit subscription rather than `$effect(() => $parentStore)`: a
+	// `<Folder>` hands its children an empty store and only fills it in once its
+	// own blade exists, and that late write is exactly the update the auto-
+	// subscription missed — the bug this component is here to avoid.
+	$effect(() => {
+		if (!marker || !source) return;
+		const anchor = marker;
+		const content = source;
+		let blade: Blade | undefined;
+
+		const unsubscribe = parentStore.subscribe((container) => {
+			blade?.dispose();
+			blade = undefined;
+			if (!container) return;
+			blade = container.addBlade({ index: bladeIndex(anchor), view: 'separator' });
+			blade.element.replaceChildren(content);
+		});
+
+		return () => {
+			unsubscribe();
+			blade?.dispose();
+		};
+	});
+</script>
+
+<div bind:this={marker} style="display: none;"></div>
+<!--
+	`skip-element-index` keeps this out of the blade count while it is still
+	sitting in Svelte's DOM, so the blades after it don't land one row too low.
+-->
+<div bind:this={source} class="skip-element-index tp-prose">
+	{@render children()}
+</div>
+
+<style>
+	/* line the prose up with the blades above it, which are inset by the
+	   container's horizontal padding */
+	.tp-prose {
+		padding-right: var(--cnt-hp);
+		padding-left: var(--cnt-hp);
+	}
+</style>

--- a/src/lib/utils/constants-cards.ts
+++ b/src/lib/utils/constants-cards.ts
@@ -88,6 +88,26 @@ export function deckHeightForCount(count: number): number {
 export const CARD_REST_Y = 0.26;
 
 /**
+ * The editor's selection mark. `/create`'s cursors say which card is being
+ * edited, but on the table that answer used to exist nowhere at all (#109), so
+ * the selected card floats over a coloured pad the size of its own footprint
+ * plus a border.
+ *
+ * The lift is deliberately small: the spread's camera is close to top-down,
+ * and a tall float would slide the card visibly off the pad it is meant to
+ * mark. It is a RENDER offset only — never written to the store — so stacking
+ * and drop resolution are untouched (both ignore cards above
+ * `CARD_STACK_MAX_Y`, which this stays well clear of).
+ */
+export const CARD_PICK_LIFT = 0.2;
+
+/** Pad border visible around the selected card, per side */
+export const CARD_PICK_HALO = 0.14;
+
+/** Same violet as the snap markers: an editor overlay, not table content. */
+export const CARD_PICK_COLOR = '#a78bfa';
+
+/**
  * Height a card floats at while being dragged. Shared by every drag entry
  * point (table, deck, tray) so the store position matches what is rendered —
  * the drop indicator's connector line is drawn to this height.

--- a/src/routes/create/CreatePane.svelte
+++ b/src/routes/create/CreatePane.svelte
@@ -34,7 +34,8 @@
 		spreadRefusal,
 		SPREAD_MAX_CARDS
 	} from '$lib/packs/spread';
-	import { onCardPick } from '$lib/store/cardPick';
+	import { packCardId } from '$lib/compose/pack';
+	import { onCardPick, pickedCard } from '$lib/store/cardPick';
 	import { previewLayout, type PreviewLayout } from './preview-layout';
 	import { editorPaneWidth } from './column';
 	import { CARD_BACK_DEFAULT, STANDARD_52 } from '$lib/packs/standard52';
@@ -123,6 +124,11 @@
 	const exportable = $derived(pack ? cleanForExport($state.snapshot(pack) as EditorPack) : null);
 
 	// ——— cursors (indexes into the draft's arrays, clamped as arrays shrink) ———
+	//
+	// Every `List` below is fed its CLAMPED index rather than the raw cursor,
+	// and reports back through `on:change`. A tweakpane list whose value matches
+	// none of its options renders completely blank — no label, no value — which
+	// is what the Card list did every time the deck changed under it (#109).
 	let deckCursor = $state(0);
 	let cardCursor = $state(0);
 	let pieceCursor = $state(0);
@@ -165,14 +171,42 @@
 		].join(' · ')
 	);
 
+	/**
+	 * The two halves of the breadcrumb row above the tabs. Every other signal in
+	 * the editor is partial — an index in a dropdown, a count in a folder title,
+	 * and nothing at all on the table — and none of them said what the whole
+	 * selection WAS (#109).
+	 *
+	 * Kept apart so the row can weight them: the pack and its deck recede, and
+	 * the card, the thing an edit actually lands on, gets its own line.
+	 */
+	const deckCrumb = $derived(
+		deck ? `${deck.slot}${deck.name ? ` (${deck.name})` : ''}` : 'no decks'
+	);
+	const cardCrumb = $derived(
+		!deck
+			? '—'
+			: !deck.cards.length
+				? 'no cards'
+				: `card ${cardIndex + 1} of ${deck.cards.length} — ${card?.name || card?.code}`
+	);
+
 	const deckOptions = $derived(
 		decks.length
 			? Object.fromEntries(decks.map((d, i) => [`${i}: ${d.slot}`, i]))
 			: { '(no decks)': 0 }
 	);
+	/**
+	 * `3: card-3 — Lightning Bolt`. A 52-entry dropdown of bare codes is not
+	 * scannable, and a code is not what an author named the card. The index
+	 * prefix is load-bearing: `Object.fromEntries` collapses duplicate keys, so
+	 * it is what keeps two cards sharing a code and a name as two rows.
+	 */
 	const cardOptions = $derived(
 		deck?.cards.length
-			? Object.fromEntries(deck.cards.map((c, i) => [`${i}: ${c.code}`, i]))
+			? Object.fromEntries(
+					deck.cards.map((c, i) => [`${i}: ${c.code}${c.name ? ` — ${c.name}` : ''}`, i])
+				)
 			: { '(no cards)': 0 }
 	);
 	const pieceOptions = $derived(
@@ -202,6 +236,50 @@
 	);
 
 	// ——— structure edits ———
+
+	/**
+	 * Move the deck cursor — and the card cursor with it. The two were
+	 * independent state, so switching decks carried "card 40" into a five-card
+	 * deck: at best the Card list showed a stale index while the fields silently
+	 * edited card 5, at worst (a new, empty deck) the list matched no option and
+	 * rendered blank (#109).
+	 *
+	 * Reset to 0 rather than clamped: after picking a deck you are at its first
+	 * card, which is somewhere, instead of at whichever card the arithmetic
+	 * happened to land on.
+	 *
+	 * The one mover that does NOT come through here is click-to-select on the
+	 * table, which knows both cursors and sets them together.
+	 */
+	function selectDeck(next: number) {
+		deckCursor = next;
+		cardCursor = 0;
+	}
+
+	/**
+	 * Move the deck cursor for an edit that also changed the deck list's
+	 * OPTIONS — the same tweakpane hazard `addPieceState` and `addBagItem`
+	 * re-assert against, in its nastier form.
+	 *
+	 * When its options change, the Deck list rebuilds its blade and reports the
+	 * rebuilt value back as a change with origin `internal`, carrying its FIRST
+	 * option — indistinguishable from a person picking deck 0, and dispatched
+	 * synchronously inside the same flush. So "Add deck" adds a deck and then
+	 * selects deck 0, and the empty-deck case this whole pair of functions
+	 * exists for is unreachable by hand.
+	 *
+	 * Re-asserting after a tick is what corrects it, and it has to be done
+	 * HERE and nowhere else: the artifact's own handler re-asserting too was
+	 * the bug (its write landed last and won). Letting the artifact through and
+	 * then moving the cursor back is also what forces the blade to re-render —
+	 * re-assigning a value it already holds pushes nothing.
+	 */
+	async function selectDeckAfterEdit(next: number) {
+		selectDeck(next);
+		await tick();
+		if (deckCursor !== next) selectDeck(next);
+	}
+
 	function addDeck() {
 		if (!pack) return;
 		pack.decks.push({
@@ -211,13 +289,13 @@
 			isFaceUp: false,
 			cards: []
 		});
-		deckCursor = pack.decks.length - 1;
+		selectDeckAfterEdit(pack.decks.length - 1);
 	}
 
 	function removeDeck() {
 		if (!pack || !deck) return;
 		pack.decks.splice(deckIndex, 1);
-		deckCursor = Math.max(0, deckIndex - 1);
+		selectDeckAfterEdit(Math.max(0, deckIndex - 1));
 	}
 
 	/**
@@ -542,10 +620,30 @@
 		onCardPick((id) => {
 			const cursors = spreadCursors[id];
 			if (!cursors) return;
+			// both together, and NOT through selectDeck: this already knows which
+			// card it wants, and selectDeck would reset the cursor to 0 behind it
 			deckCursor = cursors.deck;
 			cardCursor = cursors.card;
 		})
 	);
+
+	/**
+	 * The other half of that: mark the selected card ON the table, so the
+	 * dropdown and the felt agree whichever one you moved. Computed from the
+	 * cursors rather than looked up in `spreadCursors`, so the mark lands the
+	 * moment the cursor moves instead of 300ms later when the debounced respawn
+	 * rebuilds that map — and so it survives the respawn, which throws the map
+	 * away and builds a new one.
+	 *
+	 * Deck mode instantiates the same ids, so a card dragged off a pile marks
+	 * too; a card still inside a pile has nothing on the table to mark, which is
+	 * the reason Spread mode exists.
+	 */
+	$effect(() => {
+		pickedCard.set(deck && card ? packCardId(PREVIEW_OWNER, deck.slot, card.code) : null);
+	});
+	// leaving /create must not leave a card marked on someone's table
+	$effect(() => () => pickedCard.set(null));
 
 	// ——— the pack library (localStorage packs:v1, shared with /setup and /play) ———
 	let selectedPack = $state(listLibraryPacks()[0]?.pack.id ?? '');
@@ -793,14 +891,26 @@
 {:else}
 	<Pane position="inline" title="pack editor" userExpandable={false} width={$editorPaneWidth}>
 		<!--
-			The breadcrumb row: what is selected, above the tabs, always mounted so
-			#109 can fill it in with `pack › deck › card N of M` without touching the
-			blade tree's shape.
+			The breadcrumb row: the whole selection, in one line, above the tabs and
+			outside the TabGroup — so it is on screen on every tab and answers "what
+			am I editing" from anywhere in the editor, not just from the Cards tab
+			where the two dropdowns live.
 		-->
 		<Element>
-			<div class="truncate p-1 font-sans text-[11px] text-white/70">
-				{pack.name || pack.id}
-			</div>
+			<!--
+				Two lines, always two: the column is ~360px, and on one line the card —
+				the thing an edit actually lands on — is what the ellipsis ate. A fixed
+				two rather than a wrap, so the row's height never depends on how long
+				the pack was named.
+			-->
+			<header class="p-1 font-sans text-[11px] leading-snug">
+				<div class="truncate text-white/45">
+					{pack.name || pack.id}
+					<span class="px-0.5 text-white/25">›</span>
+					<span class="text-white/70">{deckCrumb}</span>
+				</div>
+				<div class="truncate text-white/90">{cardCrumb}</div>
+			</header>
 		</Element>
 
 		<TabGroup>
@@ -830,7 +940,19 @@
 				<!-- pick, then create/destroy, THEN the selected deck's fields: the
 				     verbs used to sit between the selector and the fields they were
 				     nothing to do with (#108) -->
-				<List label="Deck" bind:value={deckCursor} options={deckOptions} />
+				<!--
+				     `value`, not `bind:value`: the list is fed the CLAMPED index, which
+				     is always one of its own options. Only an `internal` change is a
+				     person picking a deck — an `external` one is this prop being pushed
+				     back down after a click on the table, and resetting the card cursor
+				     there would throw away the card that click just selected.
+				-->
+				<List
+					label="Deck"
+					value={deckIndex}
+					options={deckOptions}
+					on:change={(e) => e.detail.origin === 'internal' && selectDeck(Number(e.detail.value))}
+				/>
 				<ButtonGrid
 					buttons={['Add deck', 'Remove deck']}
 					on:click={(e) => (e.detail.index === 0 ? addDeck() : removeDeck())}
@@ -845,7 +967,12 @@
 					{/key}
 
 					<Separator />
-					<List label="Card" bind:value={cardCursor} options={cardOptions} />
+					<List
+						label="Card"
+						value={cardIndex}
+						options={cardOptions}
+						on:change={(e) => (cardCursor = Number(e.detail.value))}
+					/>
 					<ButtonGrid
 						columns={3}
 						buttons={['Add card', 'Duplicate card', 'Remove card']}
@@ -856,13 +983,44 @@
 									? duplicateCard()
 									: removeCard()}
 					/>
-					{#if card}
-						<Text label="Code" bind:value={card.code} />
-						<Text label="Name" bind:value={card.name} />
-						{#key `${deckIndex}:${cardIndex}`}
-							<FaceRef title="Card face" value={card.face} onchange={(ref) => (card.face = ref)} />
-						{/key}
-					{/if}
+					<!--
+					     Always mounted, greyed out when the deck has no cards. An {#if}
+					     here tore four rows out the instant a deck went to zero cards —
+					     adding a deck moved "Flip cards on table" 66px up, under whatever
+					     the cursor was over (#109). Disabled rows can't be typed into, and
+					     the handlers refuse anyway, so nothing is written to a card that
+					     isn't there.
+
+					     One-way `value` for the same reason: `bind:` needs a card to bind
+					     TO, and the point is to hold the row when there is none. With no
+					     card the face editor is seeded with exactly what `addCard` would
+					     give the next one, so the block that is holding the space is also
+					     showing what is about to fill it.
+					-->
+					<Text
+						label="Code"
+						value={card?.code ?? ''}
+						disabled={!card}
+						on:change={(e) => card && (card.code = e.detail.value)}
+					/>
+					<Text
+						label="Name"
+						value={card?.name ?? ''}
+						disabled={!card}
+						on:change={(e) => card && (card.name = e.detail.value)}
+					/>
+					<!-- keyed on the cursors AND on whether there is a card at all: FaceRef
+					     seeds its fields once, so the first card added to an empty deck has
+					     to re-seed it or the greyed-out blank it was showing would be
+					     written back over that card's face -->
+					{#key `${deckIndex}:${cardIndex}:${card ? 1 : 0}`}
+						<FaceRef
+							title="Card face"
+							value={card?.face ?? (deck.back || CARD_BACK_DEFAULT)}
+							disabled={!card}
+							onchange={(ref) => card && (card.face = ref)}
+						/>
+					{/key}
 
 					<Separator />
 					<Button

--- a/src/routes/create/CreatePane.svelte
+++ b/src/routes/create/CreatePane.svelte
@@ -70,6 +70,7 @@
 		type EditorPack
 	} from './normalize';
 	import FaceRef from './FaceRef.svelte';
+	import RefThumb from './RefThumb.svelte';
 	import BulkSheet from './BulkSheet.svelte';
 	import { allocateCode } from './bulk-sheet';
 	import type { PackCardDef } from '$lib/packs/types';
@@ -899,6 +900,7 @@
 						<Color label="Color" bind:value={piece.color} />
 						{#if piece.kind === 'token' || piece.kind === 'bag'}
 							<Text label="Image URL" bind:value={piece.imageUrl} />
+							<RefThumb value={piece.imageUrl} label="piece image" aspect="square" />
 						{/if}
 						<!--
 							States: the TTS `States` analog — one piece, several faces, cycled in
@@ -999,6 +1001,7 @@
 						<Separator />
 						<List label="Overlay" bind:value={overlayCursor} options={overlayOptions} />
 						<Text label="Image URL" bind:value={overlay.imageUrl} />
+						<RefThumb value={overlay.imageUrl} label="overlay image" aspect="wide" />
 						<AutoValue label="Ratio (w/h)" bind:value={overlay.ratio} />
 						<AutoValue label="Scale" bind:value={overlay.scale} />
 						<Button title="Remove overlay" on:click={removeOverlay} />

--- a/src/routes/create/FaceRef.svelte
+++ b/src/routes/create/FaceRef.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
-	import { AutoValue, Folder, List, Text } from 'svelte-tweakpane-ui';
+	import { AutoValue, Folder, List, Monitor, Text } from 'svelte-tweakpane-ui';
 	import { buildFaceRef, parseFaceRef, FACE_SCHEME_OPTIONS, type FaceDraft } from './face-ref';
 	import RefThumb from './RefThumb.svelte';
 
@@ -73,9 +73,16 @@
 		<AutoValue label="Rows" bind:value={sheetRows} {disabled} />
 		<AutoValue label="Cell index" bind:value={sheetIndex} {disabled} />
 	{/if}
-	<!-- the ref row stays: it is the string you copy, and the thumbnail is not
-	     something you can paste into another card -->
-	<Text label="Ref" value={built} disabled />
+	<!--
+		The ref row stays: it is the string you copy, and the thumbnail is not
+		something you can paste into another card. A `Monitor` rather than a
+		permanently-disabled `Text` (#115) — it is derived from the fields above
+		and can never be typed into, and a greyed-out input reads as "you are not
+		allowed to edit this" rather than "this is the output". It still takes
+		`disabled`, so it dims with the rest of the block when there is nothing to
+		edit (#109) instead of looking the same either way.
+	-->
+	<Monitor label="Ref" value={built} {disabled} />
 	<!-- dimmed with the rest of the block when there is nothing to edit: the ref
 	     it is previewing is then the seed for the NEXT card, not art on the table -->
 	<RefThumb value={built} label={title.toLowerCase()} dimmed={disabled} />

--- a/src/routes/create/FaceRef.svelte
+++ b/src/routes/create/FaceRef.svelte
@@ -2,6 +2,7 @@
 	import { untrack } from 'svelte';
 	import { AutoValue, Folder, List, Text } from 'svelte-tweakpane-ui';
 	import { buildFaceRef, parseFaceRef, FACE_SCHEME_OPTIONS, type FaceDraft } from './face-ref';
+	import RefThumb from './RefThumb.svelte';
 
 	/**
 	 * Inline face authoring for whatever the pane is editing right now — a
@@ -63,5 +64,8 @@
 		<AutoValue label="Rows" bind:value={sheetRows} />
 		<AutoValue label="Cell index" bind:value={sheetIndex} />
 	{/if}
+	<!-- the ref row stays: it is the string you copy, and the thumbnail is not
+	     something you can paste into another card -->
 	<Text label="Ref" value={built} disabled />
+	<RefThumb value={built} label={title.toLowerCase()} />
 </Folder>

--- a/src/routes/create/FaceRef.svelte
+++ b/src/routes/create/FaceRef.svelte
@@ -15,12 +15,21 @@
 	 * re-seed it when the cursor moves. Writes are guarded against the value it
 	 * last produced, so a ref changed from outside never gets clobbered by a
 	 * stale field.
+	 *
+	 * `disabled` greys the whole editor without unmounting it, which is how the
+	 * pane holds its height over a deck with no cards to edit (#109).
 	 */
 	let {
 		value,
 		title = 'Face',
+		disabled = false,
 		onchange
-	}: { value: string; title?: string; onchange: (ref: string) => void } = $props();
+	}: {
+		value: string;
+		title?: string;
+		disabled?: boolean;
+		onchange: (ref: string) => void;
+	} = $props();
 
 	// deliberately read once: these fields are seeded from the ref, then own it
 	const initial = untrack(() => parseFaceRef(value));
@@ -53,19 +62,21 @@
 </script>
 
 <Folder {title} expanded={true}>
-	<List label="Scheme" bind:value={scheme} options={FACE_SCHEME_OPTIONS} />
+	<List label="Scheme" bind:value={scheme} options={FACE_SCHEME_OPTIONS} {disabled} />
 	{#if scheme === 'url'}
-		<Text label="Image URL" bind:value={url} />
+		<Text label="Image URL" bind:value={url} {disabled} />
 	{:else if scheme === 'gen'}
-		<Text label="Code (AS…KC, back)" bind:value={genCode} />
+		<Text label="Code (AS…KC, back)" bind:value={genCode} {disabled} />
 	{:else}
-		<Text label="Sheet URL" bind:value={sheetUrl} />
-		<AutoValue label="Columns" bind:value={sheetCols} />
-		<AutoValue label="Rows" bind:value={sheetRows} />
-		<AutoValue label="Cell index" bind:value={sheetIndex} />
+		<Text label="Sheet URL" bind:value={sheetUrl} {disabled} />
+		<AutoValue label="Columns" bind:value={sheetCols} {disabled} />
+		<AutoValue label="Rows" bind:value={sheetRows} {disabled} />
+		<AutoValue label="Cell index" bind:value={sheetIndex} {disabled} />
 	{/if}
 	<!-- the ref row stays: it is the string you copy, and the thumbnail is not
 	     something you can paste into another card -->
 	<Text label="Ref" value={built} disabled />
-	<RefThumb value={built} label={title.toLowerCase()} />
+	<!-- dimmed with the rest of the block when there is nothing to edit: the ref
+	     it is previewing is then the seed for the NEXT card, not art on the table -->
+	<RefThumb value={built} label={title.toLowerCase()} dimmed={disabled} />
 </Folder>

--- a/src/routes/create/RefThumb.svelte
+++ b/src/routes/create/RefThumb.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+	import { Element } from 'svelte-tweakpane-ui';
+	import { resolveRefPreview, PREVIEW_DEBOUNCE_MS, type RefPreview } from './ref-preview';
+
+	/**
+	 * The resolved image, next to the ref that sets it.
+	 *
+	 * Authoring a face used to mean typing a string and then going to look at a
+	 * 3D table to find out whether you got it right — in Deck mode, by dragging a
+	 * card off a pile and flipping it, knowing the next keystroke respawns the
+	 * preview and undoes all of that (#111). This is the same answer the bulk
+	 * sheet already gives per cell, given to the single-ref controls.
+	 *
+	 * ONE `Element` blade, always mounted, its contents driven by expressions:
+	 * an `{#if}` that swaps one blade for another tears the pane down, because
+	 * tweakpane owns that DOM (see BulkSheet.svelte). Everything below is plain
+	 * DOM inside the one element, where Svelte is free to do as it likes.
+	 */
+	let {
+		value,
+		label = 'face',
+		aspect = 'card'
+	}: {
+		/** the ref as it currently stands — `gen:`, `sheet:`, a URL, or empty */
+		value: string | undefined;
+		/** what is missing when it's empty, e.g. "card face", "overlay image" */
+		label?: string;
+		/** the tile's shape; the art is letterboxed inside it either way */
+		aspect?: 'card' | 'square' | 'wide';
+	} = $props();
+
+	const TILE = {
+		card: 'aspect-[3/4] w-16',
+		square: 'aspect-square w-16',
+		wide: 'aspect-[4/3] w-24'
+	} as const;
+
+	let preview = $state<RefPreview>({ kind: 'empty' });
+	/** set by the <img>'s own error: a resolvable ref whose art is a dead link */
+	let broken = $state(false);
+
+	$effect(() => {
+		const ref = (value ?? '').trim();
+		broken = false;
+		if (!ref) {
+			preview = { kind: 'empty' };
+			return;
+		}
+		preview = { kind: 'pending' };
+		// a ref is typed a character at a time and every prefix of a sheet URL is
+		// a fetch, so the ref has to sit still before it is worth resolving
+		let live = true;
+		const timer = setTimeout(async () => {
+			const next = await resolveRefPreview(ref);
+			if (live) preview = next;
+		}, PREVIEW_DEBOUNCE_MS);
+		return () => {
+			live = false;
+			clearTimeout(timer);
+		};
+	});
+
+	const src = $derived(preview.kind === 'image' ? preview.src : '');
+	const failed = $derived(preview.kind === 'unresolvable' || broken);
+	/**
+	 * What the tile is showing, and the one thing a test needs to assert on.
+	 * NOT called `state`: svelte2tsx reads `$state` as a subscription to a store
+	 * named `state`, so a variable by that name breaks every rune in the file.
+	 */
+	const status = $derived(failed ? 'failed' : src ? 'image' : preview.kind);
+
+	const caption = $derived(
+		status === 'failed' ? 'no preview' : status === 'pending' ? 'slicing…' : 'none'
+	);
+	const note = $derived(
+		status === 'failed'
+			? 'Dead link, or the host blocks reads. The ref is still valid — the table falls back the same way.'
+			: status === 'empty'
+				? `No ${label} set — nothing renders on the table.`
+				: ''
+	);
+</script>
+
+<Element>
+	<div class="flex items-center gap-2 p-1">
+		<div
+			class="flex shrink-0 items-center justify-center overflow-hidden rounded bg-white/10 {TILE[
+				aspect
+			]}"
+			data-testid="ref-thumb"
+			data-state={status}
+		>
+			{#if src && !broken}
+				<!-- the ref's own URL, loaded as an image and nothing more: a host
+				     that blocks canvas reads still displays fine here, and a dead
+				     one lands in `onerror` rather than as a broken-image icon -->
+				<img
+					{src}
+					alt=""
+					class="max-h-full max-w-full object-contain"
+					onerror={() => (broken = true)}
+				/>
+			{:else}
+				<span class="px-1 text-center font-sans text-[9px] leading-tight text-white/50">
+					{caption}
+				</span>
+			{/if}
+		</div>
+		{#if note}
+			<div class="min-w-0 flex-1 font-sans text-[10px] leading-snug text-white/45">{note}</div>
+		{/if}
+	</div>
+</Element>

--- a/src/routes/create/RefThumb.svelte
+++ b/src/routes/create/RefThumb.svelte
@@ -19,7 +19,8 @@
 	let {
 		value,
 		label = 'face',
-		aspect = 'card'
+		aspect = 'card',
+		dimmed = false
 	}: {
 		/** the ref as it currently stands — `gen:`, `sheet:`, a URL, or empty */
 		value: string | undefined;
@@ -27,6 +28,13 @@
 		label?: string;
 		/** the tile's shape; the art is letterboxed inside it either way */
 		aspect?: 'card' | 'square' | 'wide';
+		/**
+		 * Held open over nothing to edit — the card fields keep their rows over a
+		 * deck with no cards (#109), and the ref they are seeded with is what the
+		 * NEXT card would get, not art that is on the table. At full brightness
+		 * beside four greyed-out rows it reads as "there is a card here".
+		 */
+		dimmed?: boolean;
 	} = $props();
 
 	const TILE = {
@@ -82,7 +90,7 @@
 </script>
 
 <Element>
-	<div class="flex items-center gap-2 p-1">
+	<div class="flex items-center gap-2 p-1 {dimmed ? 'opacity-40' : ''}">
 		<div
 			class="flex shrink-0 items-center justify-center overflow-hidden rounded bg-white/10 {TILE[
 				aspect

--- a/src/routes/create/__tests__/CreatePane.test.ts
+++ b/src/routes/create/__tests__/CreatePane.test.ts
@@ -14,7 +14,7 @@ import CreatePane from '../CreatePane.svelte';
 import { gameStore } from '$lib/store/game/gameStore.svelte';
 import { CARD_BACK_DEFAULT } from '$lib/packs/standard52';
 import { previewLayout } from '../preview-layout';
-import { pickCard } from '$lib/store/cardPick';
+import { pickCard, pickedCard } from '$lib/store/cardPick';
 import { SPREAD_MAX_CARDS, SPREAD_PITCH_X } from '$lib/packs/spread';
 import { serializePackFile } from '$lib/packs/file';
 import type { GamePackDef } from '$lib/packs/types';
@@ -45,6 +45,30 @@ const inputs = (container: HTMLElement, label: string) =>
 /** the text input of the (first) row carrying this label */
 const input = (container: HTMLElement, label: string) => inputs(container, label)[0];
 
+/** the list in the row carrying this label (a `List` renders as <select>) */
+const listFor = (container: HTMLElement, label: string) =>
+	[...container.querySelectorAll('.tp-lblv_l')]
+		.filter((el) => el.textContent === label)
+		.map((el) => el.parentElement?.querySelector('select'))[0];
+
+/** every option text of a list, in order */
+const optionTexts = (select: HTMLSelectElement) =>
+	[...select.options].map((o) => o.textContent ?? '');
+
+/**
+ * What a list is actually SHOWING. A tweakpane list whose value matches none
+ * of its options leaves the <select> on selectedIndex -1 and renders blank —
+ * `null` here is that bug.
+ */
+const shownOption = (select: HTMLSelectElement) =>
+	select.selectedIndex < 0 ? null : (select.options[select.selectedIndex].textContent ?? '');
+
+/** the breadcrumb row above the tabs, as its two lines */
+const crumb = (container: HTMLElement) =>
+	[...(container.querySelector('header')?.children ?? [])].map((el) =>
+		(el.textContent ?? '').replace(/\s+/g, ' ').trim()
+	);
+
 /** the (single) list offering this option — lists render as <select> */
 const listWith = (container: HTMLElement, option: string) =>
 	[...container.querySelectorAll('select')].find((s) =>
@@ -62,6 +86,17 @@ const cardList = (container: HTMLElement) =>
 
 const cardCodes = (container: HTMLElement) =>
 	[...(cardList(container)?.options ?? [])].map((o) => (o.textContent ?? '').replace(/^\d+: /, ''));
+
+/**
+ * Every ref thumbnail on screen (#111), in DOM order — for a pack of pure
+ * cards that is [deck back, card face], the same order as the scheme pickers.
+ */
+const thumbs = (container: HTMLElement) => [
+	...container.querySelectorAll<HTMLElement>('[data-testid="ref-thumb"]')
+];
+
+/** what a thumbnail tile actually resolved the ref to, or null while it hasn't */
+const thumbSrc = (tile: HTMLElement) => tile.querySelector('img')?.getAttribute('src') ?? null;
 
 /** every face-scheme picker on screen, in DOM order (deck back, then card face) */
 const schemePickers = (container: HTMLElement) =>
@@ -426,6 +461,240 @@ describe('CreatePane', () => {
 		await settle();
 
 		expect(get(gameStore).cards?.['card:preview:main-card-0'].rotation).toEqual([0, 0, 0]);
+	});
+
+	describe('what is selected', () => {
+		/** two decks of very different sizes — the shape that broke the Card list */
+		const UNEVEN: GamePackDef = {
+			id: 'uneven',
+			name: 'Uneven',
+			scope: 'player',
+			decks: [
+				{
+					slot: 'main',
+					name: 'Draw Pile',
+					back: CARD_BACK_DEFAULT,
+					cards: Array.from({ length: 12 }, (_, i) => ({
+						code: `card-${i}`,
+						face: CARD_BACK_DEFAULT
+					}))
+				},
+				{
+					slot: 'side',
+					name: 'Sideboard',
+					back: CARD_BACK_DEFAULT,
+					cards: [
+						{ code: 'lb', name: 'Lightning Bolt', face: CARD_BACK_DEFAULT },
+						{ code: 'gg', face: CARD_BACK_DEFAULT }
+					]
+				}
+			]
+		};
+
+		async function openUneven() {
+			localStorage.setItem('packs:v1', JSON.stringify({ uneven: { updatedAt: 1, pack: UNEVEN } }));
+			const container = await mount();
+			button(container, 'Open selected')!.click();
+			await settle();
+			return container;
+		}
+
+		it('names the pack, the deck and the card, on every tab', async () => {
+			const container = await openUneven();
+			expect(crumb(container)).toEqual(['Uneven › main (Draw Pile)', 'card 1 of 12 — card-0']);
+
+			choose(listFor(container, 'Card')!, '3: ');
+			await settle();
+			expect(crumb(container)).toEqual(['Uneven › main (Draw Pile)', 'card 4 of 12 — card-3']);
+
+			// the row sits above the TabGroup, so it is on screen from the File tab
+			// too — where there is no dropdown to read the selection off at all
+			choose(listFor(container, 'Deck')!, '1: side');
+			await settle();
+			expect(crumb(container)).toEqual([
+				'Uneven › side (Sideboard)',
+				'card 1 of 2 — Lightning Bolt'
+			]);
+
+			// above the TabGroup, not inside a page of it: the selection is readable
+			// from the File tab too, where no dropdown names it at all
+			const tabbed = (el: Element | null | undefined) => !!el?.closest('.tp-tabv');
+			expect(tabbed(input(container, 'Id'))).toBe(true); // a control that IS in a tab
+			expect(tabbed(container.querySelector('header'))).toBe(false);
+		});
+
+		it('says so when there is nothing under the pack to name', async () => {
+			const container = await startNew();
+			expect(crumb(container)).toEqual(['My Pack › main (Draw Pile)', 'no cards']);
+		});
+
+		it('starts at the first card of the deck you switch to, never a stale index', async () => {
+			const container = await openUneven();
+			choose(listFor(container, 'Card')!, '11: ');
+			await settle();
+			expect(input(container, 'Code')!.value).toBe('card-11');
+
+			// 11 is not a card of a two-card deck: the list used to keep showing it
+			// while the fields below silently edited card 2
+			choose(listFor(container, 'Deck')!, '1: side');
+			await settle();
+			expect(shownOption(listFor(container, 'Card')!)).toBe('0: lb — Lightning Bolt');
+			expect(input(container, 'Code')!.value).toBe('lb');
+		});
+
+		it('never leaves the Card list blank when the new deck has no cards at all', async () => {
+			const container = await openUneven();
+			choose(listFor(container, 'Card')!, '7: ');
+			await settle();
+
+			// the reported repro: cursor 7, then a deck whose only option is value 0
+			button(container, 'Add deck')!.click();
+			await settle();
+			expect(shownOption(listFor(container, 'Card')!)).toBe('(no cards)');
+		});
+
+		it('labels the card options with the name, not just the code', async () => {
+			const container = await openUneven();
+			choose(listFor(container, 'Deck')!, '1: side');
+			await settle();
+			// a 52-entry list of bare codes is not scannable; an unnamed card keeps
+			// its bare code rather than trailing an empty dash
+			expect(optionTexts(listFor(container, 'Card')!)).toEqual(['0: lb — Lightning Bolt', '1: gg']);
+		});
+
+		it('holds the card fields over an empty deck, so nothing below them moves', async () => {
+			const container = await startNew();
+			const folders = (c: HTMLElement) =>
+				[...c.querySelectorAll('.tp-fldv_t')].map((el) => el.textContent);
+
+			// the block that used to unmount, greyed out and refusing writes
+			expect(labels(container)).toContain('Code');
+			expect(folders(container)).toContain('Card face');
+			expect(input(container, 'Code')!.disabled).toBe(true);
+
+			// every labelled row and every folder, in order: what "nothing moves
+			// vertically" actually means
+			const before = [labels(container), folders(container)];
+			button(container, 'Add card')!.click();
+			await settle();
+			expect([labels(container), folders(container)]).toEqual(before);
+			expect(input(container, 'Code')!.disabled).toBe(false);
+			expect(input(container, 'Code')!.value).toBe('card-0');
+
+			button(container, 'Remove card')!.click();
+			await settle();
+			expect([labels(container), folders(container)]).toEqual(before);
+		});
+
+		/**
+		 * #109 and #111 land on the same block of controls: the breadcrumb and the
+		 * table mark say WHICH card, the thumbnail says what that card looks like.
+		 * Neither ticket's own tests cover the two moving together, and the failure
+		 * mode is silent — a thumbnail left on the previous card is a picture of a
+		 * card you are not editing.
+		 *
+		 * URL faces on purpose: they resolve to themselves, so this asserts the
+		 * wiring without depending on a canvas (`gen:`) or the slicer (`sheet:`).
+		 */
+		const FACED: GamePackDef = {
+			id: 'faced',
+			name: 'Faced',
+			scope: 'player',
+			decks: [
+				{
+					slot: 'main',
+					name: 'Draw Pile',
+					back: 'https://example.test/back.png',
+					cards: [
+						{ code: 'lb', name: 'Lightning Bolt', face: 'https://example.test/bolt.png' },
+						{ code: 'gg', name: 'Giant Growth', face: 'https://example.test/growth.png' }
+					]
+				}
+			]
+		};
+
+		it('moves the breadcrumb, the table mark and the thumbnail together (#111)', async () => {
+			localStorage.setItem('packs:v1', JSON.stringify({ faced: { updatedAt: 1, pack: FACED } }));
+			const container = await mount();
+			button(container, 'Open selected')!.click();
+			await settlePreview(); // past the thumbnail's own resolve debounce too
+
+			// the deck back keeps its own thumbnail; the card's is the second
+			expect(thumbs(container)).toHaveLength(2);
+			expect(thumbSrc(thumbs(container)[0])).toBe('https://example.test/back.png');
+
+			expect(crumb(container)).toEqual([
+				'Faced › main (Draw Pile)',
+				'card 1 of 2 — Lightning Bolt'
+			]);
+			expect(get(pickedCard)).toBe('card:preview:main-lb');
+			expect(thumbSrc(thumbs(container)[1])).toBe('https://example.test/bolt.png');
+
+			// one selection change, all three follow it
+			choose(listFor(container, 'Card')!, '1: ');
+			await settlePreview();
+			expect(crumb(container)).toEqual(['Faced › main (Draw Pile)', 'card 2 of 2 — Giant Growth']);
+			expect(get(pickedCard)).toBe('card:preview:main-gg');
+			expect(thumbSrc(thumbs(container)[1])).toBe('https://example.test/growth.png');
+
+			// and so does a click on the table, the other direction
+			choose(listWith(container, 'Spread'), 'Spread');
+			await settlePreview();
+			pickCard('card:preview:main-lb');
+			await settlePreview();
+			expect(crumb(container)).toEqual([
+				'Faced › main (Draw Pile)',
+				'card 1 of 2 — Lightning Bolt'
+			]);
+			expect(thumbSrc(thumbs(container)[1])).toBe('https://example.test/bolt.png');
+		});
+
+		it('dims the held-open thumbnail over a deck with no cards (#111)', async () => {
+			localStorage.setItem('packs:v1', JSON.stringify({ faced: { updatedAt: 1, pack: FACED } }));
+			const container = await mount();
+			button(container, 'Open selected')!.click();
+			await settlePreview();
+
+			button(container, 'Add deck')!.click();
+			await settlePreview();
+
+			// the block holds its rows, so the tile is still there and still shows
+			// what the next card would get — but it is not art on the table, and at
+			// full brightness beside four greyed rows it would read as one
+			const tile = thumbs(container)[1];
+			expect(tile).toBeTruthy();
+			expect(tile.closest('.opacity-40')).toBeTruthy();
+			expect(get(pickedCard)).toBeNull();
+		});
+
+		it('marks the selected card on the table, and follows a click back', async () => {
+			const container = await startWithCard();
+			// the id the preview spawns that card under — `Card.svelte` reads this
+			// store to lift and outline itself
+			expect(get(pickedCard)).toBe('card:preview:main-card-0');
+
+			button(container, 'Add card')!.click();
+			await settle();
+			expect(get(pickedCard)).toBe('card:preview:main-card-1');
+
+			choose(listWith(container, 'Spread'), 'Spread');
+			await settlePreview();
+			// it names a card the spread actually laid out, which is what makes the
+			// mark land on a tile rather than on nothing
+			expect(Object.keys(get(gameStore).cards ?? {})).toContain(get(pickedCard));
+
+			pickCard('card:preview:main-card-0'); // what Card.svelte calls on a click
+			await settle();
+			expect(get(pickedCard)).toBe('card:preview:main-card-0');
+			expect(input(container, 'Code')!.value).toBe('card-0');
+
+			// nothing selected is nothing marked
+			button(container, 'Remove card')!.click();
+			await settle();
+			button(container, 'Remove card')!.click();
+			await settle();
+			expect(get(pickedCard)).toBeNull();
+		});
 	});
 
 	describe('Spread layout', () => {

--- a/src/routes/create/__tests__/RefThumb.test.ts
+++ b/src/routes/create/__tests__/RefThumb.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The thumbnail blade itself: what a creator sees for a ref that works, a ref
+ * that doesn't, and a ref they haven't typed yet. `data-state` is the tile's
+ * own account of which of those it is showing.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+import RefThumb from '../RefThumb.svelte';
+import { makeSheetRef } from '$lib/packs/resolve.svelte';
+
+vi.mock('$lib/tts/slice', () => ({
+	sliceCell: vi.fn(async ({ url, index }: { url: string; index: number }) =>
+		url.includes('dead') ? null : `data:image/png;base64,cell${index}`
+	)
+}));
+
+// the Pane observes its own size; jsdom has no ResizeObserver
+globalThis.ResizeObserver ??= class {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+} as unknown as typeof ResizeObserver;
+
+/** past the resolve debounce, plus tweakpane's own async render */
+const settle = (ms = 350) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const tile = (container: HTMLElement) =>
+	container.querySelector<HTMLElement>('[data-testid="ref-thumb"]')!;
+
+describe('RefThumb', () => {
+	it('says what is missing when no ref is set', async () => {
+		const { container } = render(RefThumb, { props: { value: '', label: 'card face' } });
+		await settle();
+		expect(tile(container).dataset.state).toBe('empty');
+		expect(container.textContent).toContain('No card face set');
+	});
+
+	it('shows a URL ref as an image the browser loads itself', async () => {
+		const { container } = render(RefThumb, { props: { value: 'https://example.test/card.png' } });
+		await settle();
+		expect(tile(container).dataset.state).toBe('image');
+		expect(tile(container).querySelector('img')?.getAttribute('src')).toBe(
+			'https://example.test/card.png'
+		);
+	});
+
+	it('falls back to a labelled tile when that image is a dead link', async () => {
+		const { container } = render(RefThumb, { props: { value: 'https://dead.test/gone.png' } });
+		await settle();
+		const img = tile(container).querySelector('img')!;
+		// the load failure a dead link produces, which is the only signal a plain
+		// <img> gives: without this it would sit there as a broken-image icon
+		img.dispatchEvent(new Event('error'));
+		await settle(20);
+		expect(tile(container).dataset.state).toBe('failed');
+		expect(tile(container).querySelector('img')).toBeNull();
+		expect(container.textContent).toContain('no preview');
+	});
+
+	it('slices a sheet: ref to its cell', async () => {
+		const ref = makeSheetRef({ url: 'https://example.test/s.png', cols: 10, rows: 7, index: 2 });
+		const { container } = render(RefThumb, { props: { value: ref } });
+		await settle();
+		expect(tile(container).dataset.state).toBe('image');
+		expect(tile(container).querySelector('img')?.getAttribute('src')).toBe(
+			'data:image/png;base64,cell2'
+		);
+	});
+
+	it('shows "no preview" for a sheet the host will not let it read', async () => {
+		const ref = makeSheetRef({ url: 'https://dead.test/s.png', cols: 2, rows: 2, index: 0 });
+		const { container } = render(RefThumb, { props: { value: ref } });
+		await settle();
+		expect(tile(container).dataset.state).toBe('failed');
+		expect(container.textContent).toContain('the table falls back the same way');
+	});
+
+	it('re-resolves when the ref changes, and drops a stale failure', async () => {
+		const { container, rerender } = render(RefThumb, {
+			props: { value: 'https://dead.test/gone.png' }
+		});
+		await settle();
+		tile(container).querySelector('img')!.dispatchEvent(new Event('error'));
+		await settle(20);
+		expect(tile(container).dataset.state).toBe('failed');
+
+		await rerender({ value: 'https://example.test/other.png' });
+		await settle();
+		expect(tile(container).dataset.state).toBe('image');
+	});
+});

--- a/src/routes/create/__tests__/ref-preview.test.ts
+++ b/src/routes/create/__tests__/ref-preview.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Turning a ref into something an `<img>` can take. The interesting half is
+ * the failures: a preview that lies about a dead sheet is worse than no
+ * preview, so an unslicable cell and an unparseable ref both have to come back
+ * as `unresolvable` rather than as some other card's art.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { resolveRefPreview } from '../ref-preview';
+import { makeSheetRef } from '$lib/packs/resolve.svelte';
+
+/** the CORS-tainted sheet resolves null, exactly as the real slicer does */
+vi.mock('$lib/tts/slice', () => ({
+	sliceCell: vi.fn(async ({ url, index }: { url: string; index: number }) =>
+		url.includes('dead') ? null : `data:image/png;base64,cell${index}`
+	)
+}));
+
+// jsdom has no 2d context, so the real generator can't draw — the drawing
+// itself is resolve.svelte's business, this is about what comes back
+vi.mock('$lib/packs/resolve.svelte', async () => {
+	const actual = await vi.importActual<typeof import('$lib/packs/resolve.svelte')>(
+		'$lib/packs/resolve.svelte'
+	);
+	return {
+		...actual,
+		resolveCardImage: (ref: string) => (ref === 'gen:std52/AS' ? 'data:image/png;base64,ace' : ref)
+	};
+});
+
+describe('resolveRefPreview', () => {
+	it('has nothing to show for an empty ref', async () => {
+		expect(await resolveRefPreview('')).toEqual({ kind: 'empty' });
+		expect(await resolveRefPreview('   ')).toEqual({ kind: 'empty' });
+		expect(await resolveRefPreview(undefined)).toEqual({ kind: 'empty' });
+	});
+
+	it('draws a gen: ref through the resolver', async () => {
+		expect(await resolveRefPreview('gen:std52/AS')).toEqual({
+			kind: 'image',
+			src: 'data:image/png;base64,ace'
+		});
+	});
+
+	it('calls a gen: ref it cannot draw unresolvable, never the ref string', async () => {
+		// the generator passes the ref back when there is nothing to draw with;
+		// handing that to an <img> is a request for `/gen:std52/AS`
+		expect(await resolveRefPreview('gen:nonesuch/AS')).toEqual({ kind: 'unresolvable' });
+	});
+
+	it('slices a sheet: ref to the cell it points at', async () => {
+		const ref = makeSheetRef({
+			url: 'https://example.test/sheet.png',
+			cols: 10,
+			rows: 7,
+			index: 4
+		});
+		expect(await resolveRefPreview(ref)).toEqual({
+			kind: 'image',
+			src: 'data:image/png;base64,cell4'
+		});
+	});
+
+	it('is unresolvable for a sheet that cannot be read, not the table fallback', async () => {
+		const ref = makeSheetRef({ url: 'https://dead.test/sheet.png', cols: 2, rows: 2, index: 0 });
+		expect(await resolveRefPreview(ref)).toEqual({ kind: 'unresolvable' });
+	});
+
+	it('is unresolvable for a sheet ref that is not JSON, or has no url', async () => {
+		expect(await resolveRefPreview('sheet:not json at all')).toEqual({ kind: 'unresolvable' });
+		expect(await resolveRefPreview('sheet:{"cols":2,"rows":2,"index":0}')).toEqual({
+			kind: 'unresolvable'
+		});
+	});
+
+	it('passes a URL through for the <img> to load, as the table does', async () => {
+		expect(await resolveRefPreview('https://example.test/card.png')).toEqual({
+			kind: 'image',
+			src: 'https://example.test/card.png'
+		});
+		// a broken one is still an image request: only the load can tell, and
+		// the thumbnail's own onerror is what turns it into "no preview"
+		expect(await resolveRefPreview('https://dead.test/gone.png')).toEqual({
+			kind: 'image',
+			src: 'https://dead.test/gone.png'
+		});
+	});
+
+	it('clamps a nonsense grid rather than dividing by zero', async () => {
+		const { sliceCell } = await import('$lib/tts/slice');
+		await resolveRefPreview('sheet:{"url":"https://example.test/s.png","cols":0,"rows":-3}');
+		expect(sliceCell).toHaveBeenCalledWith(expect.objectContaining({ cols: 1, rows: 1, index: 0 }));
+	});
+});

--- a/src/routes/create/ref-preview.ts
+++ b/src/routes/create/ref-preview.ts
@@ -1,0 +1,88 @@
+/**
+ * What the pane can SHOW for a ref it is editing.
+ *
+ * A face ref is one opaque string (`https://…`, `gen:std52/AS`, `sheet:{…}`),
+ * and until now the only feedback the editor gave for one was the string
+ * itself. This turns a ref into something an `<img>` can take, through the
+ * same art path the table uses: `resolveCardImage` for `gen:`, the sheet
+ * slicer for `sheet:`, and the URL itself for everything else — which is
+ * exactly what the table hands to its material.
+ *
+ * Two deliberate departures from `resolveCardImage` for `sheet:` refs, which
+ * is why they go to `sliceCell` directly (as BulkSheet's grid does):
+ *
+ * - a dead or CORS-blocked sheet resolves there to a NAMED PROXY CARD. That is
+ *   the right answer for the table, and the wrong one for a preview whose
+ *   whole job is to say whether the art is there — a drawn proxy would read as
+ *   "your ref works".
+ * - a pending slice resolves to `''`, which is indistinguishable from failure.
+ *   Here they must look different: one is a spinner, the other is an answer.
+ */
+
+import { resolveCardImage } from '$lib/packs/resolve.svelte';
+import { sliceCell } from '$lib/tts/slice';
+
+export type RefPreview =
+	/** nothing typed yet — not a failure, just no art to show */
+	| { kind: 'empty' }
+	/** a sheet cell is being fetched and cut */
+	| { kind: 'pending' }
+	/** hand this to an `<img>`; it may still fail to LOAD (dead link) */
+	| { kind: 'image'; src: string }
+	/** the ref cannot produce an image at all */
+	| { kind: 'unresolvable' };
+
+/**
+ * How long the ref sits still before it is resolved. Refs are typed a
+ * character at a time, and every prefix of a sheet URL is a fetch.
+ */
+export const PREVIEW_DEBOUNCE_MS = 250;
+
+function grid(value: unknown): number {
+	const n = Math.round(Number(value));
+	return Number.isFinite(n) && n > 0 ? n : 1;
+}
+
+/** the four fields the slicer needs, or null if this isn't a usable sheet ref */
+function parseSheetCell(ref: string) {
+	try {
+		const payload = JSON.parse(ref.slice('sheet:'.length));
+		const url = typeof payload?.url === 'string' ? payload.url.trim() : '';
+		if (!url) return null;
+		const index = Math.round(Number(payload?.index));
+		return {
+			url,
+			cols: grid(payload?.cols),
+			rows: grid(payload?.rows),
+			index: Number.isFinite(index) && index > 0 ? index : 0
+		};
+	} catch {
+		// a hand-written `sheet:` ref that isn't JSON — still a valid string to
+		// keep in the pack (parseFaceRef preserves it), just not a previewable one
+		return null;
+	}
+}
+
+/** Resolve a ref to something the thumbnail can render. */
+export async function resolveRefPreview(ref: string | undefined | null): Promise<RefPreview> {
+	const value = (ref ?? '').trim();
+	if (!value) return { kind: 'empty' };
+
+	if (value.startsWith('gen:')) {
+		const src = resolveCardImage(value);
+		// the generator hands the ref straight back when it can't draw (an
+		// unknown generator, or no 2d context) — that string is not an image
+		return src && src !== value ? { kind: 'image', src } : { kind: 'unresolvable' };
+	}
+
+	if (value.startsWith('sheet:')) {
+		const cell = parseSheetCell(value);
+		if (!cell) return { kind: 'unresolvable' };
+		const src = await sliceCell(cell);
+		return src ? { kind: 'image', src } : { kind: 'unresolvable' };
+	}
+
+	// every other ref is a URL the table loads as-is, so the preview loads it
+	// as-is too — no proxy, no canvas, and no CORS requirement for display
+	return { kind: 'image', src: value };
+}

--- a/src/routes/play/Pane.svelte
+++ b/src/routes/play/Pane.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { gameStore } from '$lib/store/game/gameStore.svelte';
+	import PaneProse from '$lib/tweakpane/PaneProse.svelte';
 	import {
 		Button,
 		Pane,
@@ -9,7 +10,7 @@
 		AutoValue,
 		Folder,
 		FpsGraph,
-		Textarea
+		Monitor
 	} from 'svelte-tweakpane-ui';
 	import { DEG2RAD } from 'three/src/math/MathUtils.js';
 	import { purgeUndefinedValues } from '$lib/utils/transforms/data';
@@ -124,6 +125,24 @@
 				: `Copied invite — joiner auto-claims seat ${inviteSeat}`
 		);
 	}
+
+	// The reference card, as data rather than as eleven disabled `Text` blades
+	// (#115). Ordered as you meet them: look, then act on one card, then on a
+	// pile, then the drag modifiers.
+	const KEYBINDS: [action: string, key: string][] = [
+		['Reset camera', 'C'],
+		['Preview hovered', 'spacebar'],
+		['Tap card', 'T'],
+		['Reverse Tap card', 'R'],
+		['Flip card', 'F'],
+		['Group stack into deck', 'G'],
+		[`Ungroup deck (max ${UNGROUP_MAX_CARDS} cards)`, 'Shift + G'],
+		['Drop without snapping', 'hold Alt'],
+		['Cancel drag', 'Esc'],
+		['Nudge card higher', 'Arrow Up'],
+		// #113 fixed this label — it is Arrow Down, not the Shift chord it used to claim
+		['Nudge card lower', 'Arrow Down']
+	];
 </script>
 
 <Pane
@@ -136,7 +155,8 @@
 	localStoreId="table-settings"
 >
 	<Folder title="Connection" expanded={false}>
-		<Text label="My ID" value={localStorage.getItem('myPlayerId') ?? ''} disabled />
+		<!-- read-only value, so a `Monitor` rather than an input that refuses you (#115) -->
+		<Monitor label="My ID" value={localStorage.getItem('myPlayerId') ?? ''} />
 		<Text label="Server:" bind:value={$connectionStore.serverUrl} />
 		<Text label="Lobby:" bind:value={lobbyId} />
 		<Button
@@ -148,10 +168,12 @@
 				goto(`/play?${lobbyUrl}`, { invalidateAll: true });
 			}}
 		/>
-		<Textarea
-			disabled
-			value={`Share copies an invite link — whoever opens it is seated at the first open seat and gets its decks.`}
-		/>
+		<PaneProse>
+			<div class="p-1 font-sans text-[11px] leading-snug text-white/50">
+				Share copies an invite link — whoever opens it is seated at the first open seat and gets its
+				decks.
+			</div>
+		</PaneProse>
 	</Folder>
 	<Folder title="Scenarios" expanded={isTableEmpty}>
 		<List label="Preset" bind:value={selectedScenario} options={scenarioOptions} />
@@ -164,11 +186,17 @@
 			<Button title="Claim seat {seat}" on:click={() => handleClaimSeat(seat)} />
 		{/each}
 		<Button title="Copy opponent invite" on:click={copyInvite} />
-		<Textarea
-			disabled
-			rows={3}
-			value={`Build presets at /setup. Seeding replaces the table for the whole lobby; each player then claims a seat to take over its decks.`}
-		/>
+		<!--
+			Always mounted, after the `{#each}` above: a blade computes its index from
+			its own DOM position when it is created, so seats appearing and vanishing
+			insert around this rather than displacing it.
+		-->
+		<PaneProse>
+			<div class="p-1 font-sans text-[11px] leading-snug text-white/50">
+				Build presets at /setup. Seeding replaces the table for the whole lobby; each player then
+				claims a seat to take over its decks.
+			</div>
+		</PaneProse>
 	</Folder>
 	<HUDPieces ownerId={gameActions.getMyId() ?? undefined} />
 	<Folder title="Overlays" expanded={false}>
@@ -184,17 +212,22 @@
 			label="Seat: {$gameStore?.players?.[gameActions?.getMe()?.id ?? 0]?.seat}"
 			title="Next Seat"
 		/>
-		<Text label="Reset camera" value="C" disabled />
-		<Text label="Preview hovered" value="spacebar" disabled />
-		<Text label="Tap card" value="T" disabled />
-		<Text label="Reverse Tap card" value="R" disabled />
-		<Text label="Flip card" value="F" disabled />
-		<Text label="Group stack into deck" value="G" disabled />
-		<Text label="Ungroup deck (max {UNGROUP_MAX_CARDS} cards)" value="Shift + G" disabled />
-		<Text label="Drop without snapping" value="hold Alt" disabled />
-		<Text label="Cancel drag" value="Esc" disabled />
-		<Text label="Nudge card higher" value="Arrow Up" disabled />
-		<Text label="Nudge card lower" value="Arrow Down" disabled />
+		<!--
+			One prose blade where eleven disabled `Text` blades used to be (#115): a
+			keybind is something you read, not a field you were locked out of, and
+			the list now costs one row of the pane's height instead of eleven. The
+			folder stays closed by default — #113.
+		-->
+		<PaneProse>
+			<dl
+				class="grid grid-cols-[1fr_auto] items-baseline gap-x-3 gap-y-0.5 p-1 font-sans text-[11px] leading-snug"
+			>
+				{#each KEYBINDS as [action, key] (action)}
+					<dt class="text-white/50">{action}</dt>
+					<dd class="justify-self-end font-mono text-white/80">{key}</dd>
+				{/each}
+			</dl>
+		</PaneProse>
 	</Folder>
 	<!-- instrumentation, not settings: out of the player's way until asked for -->
 	<Folder title="Debug" expanded={false}>

--- a/src/routes/play/__tests__/Pane.test.ts
+++ b/src/routes/play/__tests__/Pane.test.ts
@@ -96,10 +96,28 @@ describe('/play settings pane on first paint', () => {
 		const { container } = render(Pane);
 		await settle();
 
-		const rows = [...container.querySelectorAll('.tp-lblv')];
-		const row = rows.find((r) =>
-			r.querySelector('.tp-lblv_l')?.textContent?.includes('Nudge card lower')
+		// #115 moved the keybinds out of eleven disabled `Text` blades and into
+		// one `Element` list, so the copy #113 fixed is now a <dt>/<dd> pair
+		const term = [...container.querySelectorAll('dt')].find(
+			(t) => t.textContent?.trim() === 'Nudge card lower'
 		);
-		expect(row?.querySelector('input')?.value).toBe('Arrow Down');
+		expect(term?.nextElementSibling?.textContent?.trim()).toBe('Arrow Down');
+	});
+
+	it('renders help and keybinds as prose, not as disabled form controls', async () => {
+		const { container } = render(Pane);
+		await settle();
+
+		// the whole point of #115: nothing read-only may look like a field you
+		// are locked out of. Every keybind lives in the list...
+		expect(container.querySelectorAll('dt').length).toBe(11);
+		// ...and no blade in the pane is rendered disabled
+		expect(container.querySelectorAll('.tp-lblv-disabled').length).toBe(0);
+		expect([...container.querySelectorAll('input')].filter((i) => i.disabled).length).toBe(0);
+		expect(container.querySelector('textarea')).toBeNull();
+
+		// the share/seed explanations survived the move out of the Textareas
+		expect(container.textContent).toContain('whoever opens it is seated at the first open seat');
+		expect(container.textContent).toContain('Build presets at /setup');
 	});
 });

--- a/src/routes/setup/SetupPane.svelte
+++ b/src/routes/setup/SetupPane.svelte
@@ -6,7 +6,6 @@
 		Folder,
 		List,
 		Text,
-		Textarea,
 		Point,
 		Wheel,
 		AutoValue,
@@ -39,6 +38,7 @@
 	import { snapEditor, setSnapDefaults, setSnapPlacing } from '$lib/store/snapEditor';
 	import { SNAP_RADIUS_DEFAULT } from '$lib/utils/constants-snap';
 	import HUDPieces from '$lib/HUDPieces.svelte';
+	import PaneProse from '$lib/tweakpane/PaneProse.svelte';
 	import FileDropZone from '$lib/files/FileDropZone.svelte';
 	import { openDroppedFile } from '$lib/files/drop';
 	import { purgeUndefinedValues } from '$lib/utils/transforms/data';
@@ -581,11 +581,55 @@
 	{#if armed === 'clear'}
 		<Button title="Leave it alone" on:click={disarm} />
 	{/if}
-	<Textarea
-		disabled
-		rows={6}
-		value={`Everything here is local — no lobby is touched. Open a pack (or drop a .tbpp.json on the table) and it joins your pack library, ready to spawn for any seat without picking the file again. Place the map, arrange, then Save. Pack decks save as a pack reference plus their card order, so a stacked deck reloads exactly; tick "shuffle on load" for a draw pile. Snap points: arm "place on click" and click the felt, drag a ring to move it, right-click it to delete. They ride along in the scenario and pull dropped cards/tokens onto themselves in /play (hold Alt on release to ignore them); the rings only show here. Your library lives in this browser only — share a pack by exporting its .tbpp.json. Seed a lobby from /play → Settings → Scenarios. Note: cards in YOUR hand tray are not saved; keep starting cards on the table.`}
-	/>
+
+	<!--
+		Prose, not a disabled `Textarea` (#115): six rows of dense explanation in a
+		scroll box reads as a broken field, can't wrap to the pane and can't be
+		selected. One always-mounted blade inside a folder that is closed by
+		default — the pane is already the tallest thing on the route, and this is
+		reference you read once. See the swap hazard in `BulkSheet.svelte:135-140`:
+		adding a folder is fine, replacing a blade is not.
+	-->
+	<Folder title="How this works" expanded={false}>
+		<PaneProse>
+			<!--
+				Bounded and scrolled inside itself (`max-h-64`, as `BulkSheet` bounds
+				its grid): this folder is the last thing in the tallest pane on the
+				route and a draggable tweakpane doesn't scroll, so an unbounded block
+				would put its own tail under the bottom of the viewport — the exact
+				failure #115 is about. Prose that scrolls is still prose; it wraps to
+				the pane and can be selected.
+			-->
+			<div
+				class="flex max-h-64 flex-col gap-2 overflow-y-auto p-1 font-sans text-[11px] leading-snug text-white/50"
+			>
+				<p>
+					Everything here is local — no lobby is touched. Open a pack (or drop a
+					<code class="font-mono text-white/65">.tbpp.json</code> on the table) and it joins your pack
+					library, ready to spawn for any seat without picking the file again. Place the map, arrange,
+					then Save.
+				</p>
+				<p>
+					Pack decks save as a pack reference plus their card order, so a stacked deck reloads
+					exactly; tick <em class="text-white/65 not-italic">shuffle on load</em> for a draw pile.
+				</p>
+				<p>
+					<span class="text-white/65">Snap points:</span> arm
+					<em class="text-white/65 not-italic">place on click</em> and click the felt, drag a ring to
+					move it, right-click it to delete. They ride along in the scenario and pull dropped cards/tokens
+					onto themselves in /play (hold Alt on release to ignore them); the rings only show here.
+				</p>
+				<p>
+					Your library lives in this browser only — share a pack by exporting its
+					<code class="font-mono text-white/65">.tbpp.json</code>. Seed a lobby from /play →
+					Settings → Scenarios.
+				</p>
+				<p class="text-white/65">
+					Note: cards in your hand tray are not saved — keep starting cards on the table.
+				</p>
+			</div>
+		</PaneProse>
+	</Folder>
 </Pane>
 
 <FileDropZone onfile={handleDroppedFile} />

--- a/src/routes/setup/__tests__/SetupPane.test.ts
+++ b/src/routes/setup/__tests__/SetupPane.test.ts
@@ -94,6 +94,18 @@ describe('SetupPane', () => {
 		// save a deck belonging to nobody
 		expect(get(gameStore).players?.seat1?.seat).toBe(1);
 	});
+
+	it('explains itself in prose, not in a disabled Textarea', async () => {
+		const { container } = render(SetupPane);
+		await settle();
+
+		// #115: the six-row disabled scroll box is gone, and its copy survived the
+		// move into real markup behind the "How this works" folder
+		expect(container.querySelector('textarea')).toBeNull();
+		expect([...container.querySelectorAll('input')].filter((i) => i.disabled)).toHaveLength(0);
+		expect(container.textContent).toContain('Everything here is local');
+		expect(container.textContent).toContain('cards in your hand tray are not saved');
+	});
 });
 
 /** two decks on the table, one per seat — the state #114 was reported against */


### PR DESCRIPTION
Second integration PR for the pane-UX epic. #127 carried the first four tickets to main;
these are the three that landed on `feat/pane-ux` afterwards, each reviewed and merged
individually with `test` and `render` green.

| Ticket | PR | What |
|---|---|---|
| tableplace-111 | #126 | /create shows the resolved image — thumbnails for card face, deck back, piece and overlay, with a labelled "no preview" tile for dead links and unreadable sheets |
| tableplace-109 | #128 | /create says what is selected — breadcrumb, table mark, and a Card list that is never blank |
| tableplace-115 | #125 | Help text is prose, not disabled form controls — across /create, /setup and /play |

**17 files, +1189/−66.**

## Serialized, not merged in parallel

All three touch the same pane components, so they went through a rebase train rather than
landing side by side: #126 first (purely additive), then #128 rebased onto it, then #125 onto
that. Each rebase was verified against the branch contents rather than against
`mergeStateStatus` — #128 in particular reported `CLEAN` at one point while not actually
carrying #126's work, which a status check alone would have missed.

The train earned its keep: #128 modifies #126's `RefThumb.svelte` so the breadcrumb, table
mark and thumbnail move **together** on selection, which is a composed behavior neither PR
would have produced alone.

## Two decisions inside this diff worth not undoing

- **`ref-preview.ts` sends `sheet:` refs to `sliceCell` directly**, not through
  `resolveCardImage`. The resolver substitutes a proxy card for a dead sheet and returns `''`
  while pending — correct for the *table*, where degrading gracefully is right, and wrong for
  an authoring *preview*, which would then claim a broken ref works. `gen:` refs and plain
  URLs still go through the resolver.
- **`PaneProse.svelte` is a new component, not a patch to `Element.svelte`.**
  `svelte-tweakpane-ui`'s `<Element>` silently fails to mount content in a
  `position="draggable"` pane (`<Folder>` hands children an empty store and fills it later;
  Element's Svelte-4 reactive statement misses the write — measured 0/5 on /play vs 1/1 on
  /create). Patching the vendored component would put every pane in the blast radius; the
  additive fix leaves existing `Element` uses untouched, and that held through two rebases.

## Note for review

The branch is updated from main before merge, so the checks that matter are the ones run
**after** that update — main moved when #127 landed.

`render` is the gate to trust here. This is entirely interactive UI, and unit tests are not
evidence for that class in this repo: tableplace-102 had 704 passing tests against a
completely unusable app.
