### PR TITLE
tableplace-api-12: link the provisioning doc from llms.txt

### DIFF
--- a/scripts/llms.template.md
+++ b/scripts/llms.template.md
@@ -9,6 +9,14 @@ Canonical URLs:
 - this document — `https://table.place/llms.txt`
 - pack schema — `{{PACK_SCHEMA_URL}}`
 - scenario schema — `{{SCENARIO_SCHEMA_URL}}`
+- **provisioning a lobby from a pack** — `https://api.table.place/llms.txt`
+
+This document ends where a valid file does. Turning one into a table your players can open is
+a different service with its own document: `POST https://api.table.place/v1/lobbies` takes packs
+plus a layout id and returns one URL per seat, with no account and nothing to host but your card
+images. Its `llms.txt` is likewise self-contained and generated from that service's own routes,
+caps and error catalogue. Read it there rather than guessing from here — this document does not
+describe the API, and the API does not accept scenarios.
 
 ## 1. The two formats
 

--- a/scripts/llms.template.md
+++ b/scripts/llms.template.md
@@ -16,7 +16,9 @@ a different service with its own document: `POST https://api.table.place/v1/lobb
 plus a layout id and returns one URL per seat, with no account and nothing to host but your card
 images. Its `llms.txt` is likewise self-contained and generated from that service's own routes,
 caps and error catalogue. Read it there rather than guessing from here — this document does not
-describe the API, and the API does not accept scenarios.
+describe the API, and the API does not accept scenarios. Note also that it places decks and
+overlays and nothing else: a pack's `pieces` never reach a table provisioned that way, so the
+piece and bag sections below do not apply if that is your route to a table.
 
 ## 1. The two formats
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -9,6 +9,14 @@ Canonical URLs:
 - this document — `https://table.place/llms.txt`
 - pack schema — `https://table.place/pack.schema.json`
 - scenario schema — `https://table.place/scenario.schema.json`
+- **provisioning a lobby from a pack** — `https://api.table.place/llms.txt`
+
+This document ends where a valid file does. Turning one into a table your players can open is
+a different service with its own document: `POST https://api.table.place/v1/lobbies` takes packs
+plus a layout id and returns one URL per seat, with no account and nothing to host but your card
+images. Its `llms.txt` is likewise self-contained and generated from that service's own routes,
+caps and error catalogue. Read it there rather than guessing from here — this document does not
+describe the API, and the API does not accept scenarios.
 
 ## 1. The two formats
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -16,7 +16,9 @@ a different service with its own document: `POST https://api.table.place/v1/lobb
 plus a layout id and returns one URL per seat, with no account and nothing to host but your card
 images. Its `llms.txt` is likewise self-contained and generated from that service's own routes,
 caps and error catalogue. Read it there rather than guessing from here — this document does not
-describe the API, and the API does not accept scenarios.
+describe the API, and the API does not accept scenarios. Note also that it places decks and
+overlays and nothing else: a pack's `pieces` never reach a table provisioned that way, so the
+piece and bag sections below do not apply if that is your route to a table.
 
 ## 1. The two formats
 


### PR DESCRIPTION
An agent that starts at `https://table.place/llms.txt` can author a valid `.tbpp.json` unaided
and then has nowhere to go. Nothing in this document mentions `api.table.place`, `/v1/lobbies`
or provisioning, and that service's repository is private — so the handoff ends one step short
of a table.

This adds the link, in the canonical URL list at the top and in a short paragraph beneath it:

- `https://api.table.place/llms.txt` — the request envelope, layout discovery, every cap, the
  full error catalogue, the 201 and its seat URLs, and the two limitations the API will never
  report at runtime (card faces are fetched by the **player's browser**, so an unreachable face
  provisions a valid lobby of blank white cards with a 201; and a pack's `pieces` are never
  placed).

It is generated from that service's own routes, caps and error catalogue, with a CI staleness
check — the same discipline as `bun run schemas` / `schemas:check` here.

**No new numbered section**, deliberately: the section numbers in this document are referenced
by the API document (its face-ref and scenario sections point at § 5 and § 7 here), so
renumbering would break links in both directions.

`static/llms.txt` is edited to match rather than regenerated wholesale, so the diff is the eight
added lines and not a churn of `x-generated-at` / `x-tableplace-source-sha` stamps across all
three artifacts. `bun run schemas:check` passes (it strips those volatile lines), and a full
`bun run schemas` produces exactly this content.

**Merge order:** the target URL is served by tableplace-api#12 and 404s until that deploys.

Task: tableplace-api-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvPP6NL72QYp5ZJ532brHk