### PR TITLE
tableplace-139: llms.txt §6.1 omits 'die' from pack piece kinds

### DIFF
--- a/scripts/llms-txt.ts
+++ b/scripts/llms-txt.ts
@@ -39,7 +39,14 @@ import {
 	BAG_HEIGHT
 } from '../src/lib/utils/constants-pieces';
 import { SNAP_RADIUS_DEFAULT } from '../src/lib/utils/constants-snap';
-import { TBPP_VERSION, PACK_SCHEMA_URL } from '../src/lib/packs/file';
+import {
+	TBPP_VERSION,
+	PACK_SCHEMA_URL,
+	PIECE_KINDS,
+	BAG_ITEM_KINDS,
+	BAG_DRAW_MODES,
+	CARD_ORIENTATIONS
+} from '../src/lib/packs/file';
 import { TBPS_VERSION, TBPS_SUPPORTED, SCENARIO_SCHEMA_URL } from '../src/lib/scenario/file';
 import { PACK_SPEC_VERSION, SCENARIO_SPEC_VERSION } from '../src/lib/formats/spec-version';
 
@@ -93,6 +100,21 @@ const fence = (body: string) => '```json\n' + body.trimEnd() + '\n```';
 const jsonBlock = (value: unknown) => fence(JSON.stringify(value, null, '\t'));
 
 /**
+ * Render a closed set of string literals as prose — `` `"a"`, `"b"` or `"c"` ``
+ * — built from the same runtime array the parser validates `kind`/`drawMode`/
+ * etc. against, so a value added there can't ship without appearing here too.
+ * `notes` adds an optional parenthetical per value, e.g. marking a default.
+ */
+function enumProse(values: readonly string[], notes: Partial<Record<string, string>> = {}): string {
+	const parts = values.map((v) => {
+		const note = notes[v];
+		return note ? `\`"${v}"\` (${note})` : `\`"${v}"\``;
+	});
+	if (parts.length < 2) return parts.join('');
+	return `${parts.slice(0, -1).join(', ')} or ${parts[parts.length - 1]}`;
+}
+
+/**
  * Substitute `{{KEY}}` placeholders. Throws on an unknown or unfilled
  * placeholder so a typo fails the build rather than shipping a literal
  * `{{TYPO}}` into the published contract.
@@ -122,6 +144,14 @@ export function renderLlmsTxt(packSchemaJson: string, scenarioSchemaJson: string
 		PACK_SPEC_VERSION,
 		SCENARIO_SPEC_VERSION,
 		PACK_SCHEMA_URL,
-		SCENARIO_SCHEMA_URL
+		SCENARIO_SCHEMA_URL,
+		PIECE_KINDS: enumProse(PIECE_KINDS),
+		CARD_ORIENTATIONS: enumProse(CARD_ORIENTATIONS, { portrait: 'default' }),
+		BAG_PIECE_ITEM_KINDS: enumProse(BAG_ITEM_KINDS.filter((k) => k !== 'card')),
+		BAG_DRAW_MODES: enumProse(BAG_DRAW_MODES, {
+			random: 'the default: a blind draw',
+			lifo: 'last in, first out — a stack',
+			fifo: 'a queue'
+		})
 	});
 }

--- a/scripts/llms.template.md
+++ b/scripts/llms.template.md
@@ -147,8 +147,8 @@ Resolution is asynchronous and failure is non-fatal: an unreachable sheet falls 
 - **`name`** — human-readable title.
 - **`scope`** — `"table"` or `"player"`. `table` is the shared game loaded once per lobby by the host (board, communal decks). `player` is what one participant brings and is spawned per seat — a deck-builder export is a player pack. When in doubt for a card game, use `player`.
 - **`decks[]`** — `slot` (stable id within the pack), `name`, `back` (a face ref), optional `isFaceUp`, and `cards[]`.
-  - **`cards[]`** — `code` (stable id within the deck), optional `name`, `face` (a face ref), and optional `orientation` — `"portrait"` (default) or `"landscape"`. A landscape card rests turned 90° everywhere it renders (board, hand, preview) while its art stays portrait in the image; use it for cards that are played sideways (the analog of Tabletop Simulator's `SidewaysCard`).
-- **`pieces[]`** _(optional)_ — `kind` (`"token"`, `"pawn"`, `"counter"` or `"bag"`), `name`, optional `color` (hex string, used when there is no image), optional `imageUrl` (a face ref), optional `states` and `state` (§6.2), optional `radius`, optional `maxValue` (counters), optional `snap` (default `true`; `false` opts the piece out of snap points and grids — it drops as if Alt were held), and `position` as `[x, z]`. A bag adds the three fields in §6.3.
+  - **`cards[]`** — `code` (stable id within the deck), optional `name`, `face` (a face ref), and optional `orientation` — {{CARD_ORIENTATIONS}}. A landscape card rests turned 90° everywhere it renders (board, hand, preview) while its art stays portrait in the image; use it for cards that are played sideways (the analog of Tabletop Simulator's `SidewaysCard`).
+- **`pieces[]`** _(optional)_ — `kind` ({{PIECE_KINDS}}), `name`, optional `color` (hex string, used when there is no image), optional `imageUrl` (a face ref), optional `states` and `state` (§6.2), optional `radius`, optional `maxValue` (counters), optional `snap` (default `true`; `false` opts the piece out of snap points and grids — it drops as if Alt were held), and `position` as `[x, z]`. A bag adds the three fields in §6.3.
 - **`overlays[]`** _(optional)_ — board/map images: `imageUrl` (a face ref), `ratio` (image width ÷ height), `scale` (world size along the long axis).
 - **`source`** _(optional)_ — provenance stamp written by converters; the only value is `"tts"`. Omit it in hand-authored packs.
 
@@ -200,8 +200,8 @@ A piece of `kind: "bag"` is a container: a pouch holding a pool nobody can look 
 }
 ```
 
-- **`contents`** — what the bag holds, in insertion order. Each entry is either a **piece item** — `kind` `"token"`, `"pawn"` or `"counter"`, plus `name` and the optional `color` / `imageUrl` / `radius` / `maxValue`; there is no `position`, because the draw decides where it lands — or a **card item**: `kind: "card"` plus `code`, optional `name`, `face` (a face ref, §5), optional `back` and optional `orientation` (§6.1).
-- **`drawMode`** — `"random"` (the default: a blind draw), `"lifo"` (last in, first out — a stack) or `"fifo"` (a queue).
+- **`contents`** — what the bag holds, in insertion order. Each entry is either a **piece item** — `kind` {{BAG_PIECE_ITEM_KINDS}}, plus `name` and the optional `color` / `imageUrl` / `radius` / `maxValue`; there is no `position`, because the draw decides where it lands — or a **card item**: `kind: "card"` plus `code`, optional `name`, `face` (a face ref, §5), optional `back` and optional `orientation` (§6.1).
+- **`drawMode`** — {{BAG_DRAW_MODES}}.
 - **`infinite`** — `true` makes each draw **clone** the item rather than remove it, so the bag never empties. Its badge reads `∞`.
 - `code` must be **unique within the bag**, like a deck's card codes: the drawn card's table id is built from it.
 - **Bags cannot contain bags.** Containers do not nest in this format; do not emit a `"bag"` item inside `contents`, it will be rejected.

--- a/src/lib/packs/file.ts
+++ b/src/lib/packs/file.ts
@@ -79,7 +79,8 @@ function arr(v: unknown, path: string): unknown[] {
 	return v;
 }
 
-const CARD_ORIENTATIONS = ['portrait', 'landscape'] as const;
+/** Exported so llms-txt.ts can render this list in prose instead of hand-writing it. */
+export const CARD_ORIENTATIONS = ['portrait', 'landscape'] as const;
 
 function orientation(v: unknown, path: string): CardOrientation {
 	const value = v as CardOrientation;
@@ -114,15 +115,19 @@ function parseDeck(v: unknown, path: string): PackDeckDef {
 	return deck;
 }
 
-const PIECE_KINDS = ['token', 'pawn', 'counter', 'die', 'bag'] as const;
+/** Exported so llms-txt.ts can render this list in prose instead of hand-writing it. */
+export const PIECE_KINDS = ['token', 'pawn', 'counter', 'die', 'bag'] as const;
 const DIE_SIDES = [4, 6, 8, 10, 12, 20] as const;
 /**
  * What a bag may contain: the piece kinds that are just an image and a name,
  * plus cards. No `bag` (containers don't nest) and no `die` — a die's shape and
  * roll state have nowhere to live in an item, so a bag is not where one goes.
+ *
+ * Exported so llms-txt.ts can render this list in prose instead of hand-writing it.
  */
-const BAG_ITEM_KINDS = ['token', 'pawn', 'counter', 'card'] as const;
-const BAG_DRAW_MODES = ['random', 'lifo', 'fifo'] as const;
+export const BAG_ITEM_KINDS = ['token', 'pawn', 'counter', 'card'] as const;
+/** Exported so llms-txt.ts can render this list in prose instead of hand-writing it. */
+export const BAG_DRAW_MODES = ['random', 'lifo', 'fifo'] as const;
 
 /**
  * One entry of a bag's `contents`. A `card` item carries the face-ref grammar;

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -174,7 +174,7 @@ Resolution is asynchronous and failure is non-fatal: an unreachable sheet falls 
 - **`scope`** — `"table"` or `"player"`. `table` is the shared game loaded once per lobby by the host (board, communal decks). `player` is what one participant brings and is spawned per seat — a deck-builder export is a player pack. When in doubt for a card game, use `player`.
 - **`decks[]`** — `slot` (stable id within the pack), `name`, `back` (a face ref), optional `isFaceUp`, and `cards[]`.
   - **`cards[]`** — `code` (stable id within the deck), optional `name`, `face` (a face ref), and optional `orientation` — `"portrait"` (default) or `"landscape"`. A landscape card rests turned 90° everywhere it renders (board, hand, preview) while its art stays portrait in the image; use it for cards that are played sideways (the analog of Tabletop Simulator's `SidewaysCard`).
-- **`pieces[]`** _(optional)_ — `kind` (`"token"`, `"pawn"`, `"counter"` or `"bag"`), `name`, optional `color` (hex string, used when there is no image), optional `imageUrl` (a face ref), optional `states` and `state` (§6.2), optional `radius`, optional `maxValue` (counters), optional `snap` (default `true`; `false` opts the piece out of snap points and grids — it drops as if Alt were held), and `position` as `[x, z]`. A bag adds the three fields in §6.3.
+- **`pieces[]`** _(optional)_ — `kind` (`"token"`, `"pawn"`, `"counter"`, `"die"` or `"bag"`), `name`, optional `color` (hex string, used when there is no image), optional `imageUrl` (a face ref), optional `states` and `state` (§6.2), optional `radius`, optional `maxValue` (counters), optional `snap` (default `true`; `false` opts the piece out of snap points and grids — it drops as if Alt were held), and `position` as `[x, z]`. A bag adds the three fields in §6.3.
 - **`overlays[]`** _(optional)_ — board/map images: `imageUrl` (a face ref), `ratio` (image width ÷ height), `scale` (world size along the long axis).
 - **`source`** _(optional)_ — provenance stamp written by converters; the only value is `"tts"`. Omit it in hand-authored packs.
 
@@ -570,8 +570,8 @@ A drawn card arrives **facedown**; a drawn piece arrives as an ordinary piece of
 	},
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"x-tableplace-spec-version": "1.5.0",
-	"x-generated-at": "2026-07-27T09:20:28.352Z",
-	"x-tableplace-source-sha": "0cfcb6c1c13190aed0c94dc3d9f8024fdd32bf40-dirty"
+	"x-generated-at": "2026-07-27T11:18:24.645Z",
+	"x-tableplace-source-sha": "d4c6d84ba0deab38d0bcb2048664f8b113ce3fb6-dirty"
 }
 ```
 
@@ -1670,8 +1670,8 @@ They are inert data. Nothing spawns from them, they claim no ids, they are drawn
 	},
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"x-tableplace-spec-version": "0.1.8",
-	"x-generated-at": "2026-07-27T09:20:28.352Z",
-	"x-tableplace-source-sha": "0cfcb6c1c13190aed0c94dc3d9f8024fdd32bf40-dirty"
+	"x-generated-at": "2026-07-27T11:18:24.645Z",
+	"x-tableplace-source-sha": "d4c6d84ba0deab38d0bcb2048664f8b113ce3fb6-dirty"
 }
 ```
 

--- a/static/pack.schema.json
+++ b/static/pack.schema.json
@@ -329,6 +329,6 @@
 	},
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"x-tableplace-spec-version": "1.5.0",
-	"x-generated-at": "2026-07-27T09:20:28.352Z",
-	"x-tableplace-source-sha": "0cfcb6c1c13190aed0c94dc3d9f8024fdd32bf40-dirty"
+	"x-generated-at": "2026-07-27T11:18:24.645Z",
+	"x-tableplace-source-sha": "d4c6d84ba0deab38d0bcb2048664f8b113ce3fb6-dirty"
 }

--- a/static/scenario.schema.json
+++ b/static/scenario.schema.json
@@ -907,6 +907,6 @@
 	},
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"x-tableplace-spec-version": "0.1.8",
-	"x-generated-at": "2026-07-27T09:20:28.352Z",
-	"x-tableplace-source-sha": "0cfcb6c1c13190aed0c94dc3d9f8024fdd32bf40-dirty"
+	"x-generated-at": "2026-07-27T11:18:24.645Z",
+	"x-tableplace-source-sha": "d4c6d84ba0deab38d0bcb2048664f8b113ce3fb6-dirty"
 }


### PR DESCRIPTION
## Summary

`static/llms.txt` §6.1 hand-wrote the pack piece `kind` list as `"token"`, `"pawn"`, `"counter"` or `"bag"` — omitting `die` — while three other places in the same document/repo agreed it exists: the embedded JSON Schema (derived from `PackPieceKind`), §4's `PIECE_RADIUS.die`/`DIE_SIDES` constants, and `src/lib/packs/types.ts`. A reader with no repo access (the whole premise of this document) would conclude dice can't be authored in packs.

- `src/lib/packs/file.ts` already has runtime kind arrays (`PIECE_KINDS`, `BAG_ITEM_KINDS`, `BAG_DRAW_MODES`, `CARD_ORIENTATIONS`) that the parser validates against — these are now exported.
- `scripts/llms-txt.ts` gets an `enumProse()` helper that renders one of these arrays as `` `"a"`, `"b"` or `"c"` `` prose, optionally with a parenthetical note per value (e.g. marking a default).
- `scripts/llms.template.md` §6 now uses `{{PIECE_KINDS}}`, `{{CARD_ORIENTATIONS}}`, `{{BAG_PIECE_ITEM_KINDS}}`, `{{BAG_DRAW_MODES}}` placeholders instead of hand-written lists, so the generator — not the artifact — is fixed.
- Regenerated `static/llms.txt`, `static/pack.schema.json`, `static/scenario.schema.json` via `bun run schemas`.

Left `scope` (`"table"`/`"player"`) alone: it has no backing runtime array and is a stable architectural binary, not an extensible tag set like the piece/bag/drawMode kinds — not the same failure mode.

## Test plan

- [x] `bun run schemas` — regenerated static artifacts, confirmed idempotent on a second run
- [x] `bun run build`
- [x] `bun run test` — 832 tests pass, including `contract.test.ts` (fails if checked-in static files drift from a fresh build)
- [x] `bun run lint` — fails, but identically to main/baseline; none of the changed files are among the 27 pre-existing warnings
- [x] Manually confirmed `static/llms.txt` §6.1 now reads `` `"token"`, `"pawn"`, `"counter"`, `"die"` or `"bag"` ``, and the other §6 enum prose (orientation, bag item kinds, drawMode) renders byte-identical to before, now generated instead of hand-typed

Task: tableplace-139
Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H7uGXrfuXaeyQATa5VwEdr