### PR TITLE
tableplace-145: Alt-drop rests on top of overlapping cards instead of coplanar

### DIFF
--- a/e2e/specs.ts
+++ b/e2e/specs.ts
@@ -340,6 +340,100 @@ export const SPECS: Spec[] = [
 	},
 	{
 		/**
+		 * tableplace-145: Alt opts out of the XZ square-up, not of resting on
+		 * top. An Alt-drop overlapping a resting card must land at the pointer's
+		 * XZ (no pull onto the pile) but one card thickness ABOVE the card under
+		 * it — two coplanar cards z-fight no matter how good the depth buffer is,
+		 * which is exactly what the broken build rendered.
+		 */
+		name: 'alt drop: overlapping a resting card rests on top, at the pointer',
+		run: (context) =>
+			withTable(context, 'alt-drop', async (table) => {
+				const CARD_REST = 0.26; // felt rest height for a card
+				const CARD_THICKNESS = 0.03;
+
+				// same retry-on-slip shape as the model-surface spec: what's being
+				// retried is puppeteer's pointer delivery under SwiftShader, and each
+				// hop proves the drag ARRIVED before its landing is judged
+				const dragToArrives = async (
+					id: string,
+					x: number,
+					z: number,
+					label: string,
+					options: { alt?: boolean } = {}
+				) => {
+					for (let attempt = 0; attempt < 3; attempt++) {
+						await table.dragTo(id, x, z, options);
+						await table.settle(900);
+						const position = await table.positionOf(id);
+						if (position && Math.hypot(position[0] - x, position[2] - z) < 1.0) return position;
+					}
+					const stuck = await table.positionOf(id);
+					throw new Error(
+						`${label} (${id}) never arrived at (${x}, ${z}) after 3 drags: ${JSON.stringify(stuck)}`
+					);
+				};
+
+				// a two-card deck clear of the HUD panes. The cards come out ONE AT A
+				// TIME, each parked before the next is drawn — two cards drawn
+				// together land fanned only 0.42 apart, and a press at the lower
+				// one's centre grabs the top one instead
+				const deck = await table.page.evaluate(() => {
+					const cards = ['AS', 'KH'].map((code) => ({
+						id: `card:std:alt-${code}`,
+						faceImageUrl: `gen:std52/${code}`,
+						backImageUrl: 'gen:std52/back'
+					}));
+					return String(
+						window.__tableplace!.actions.addDeck({ cards, position: [-2, 0.4, -2] } as never) ?? ''
+					);
+				});
+				await table.settle(1000);
+				const draw = async () => {
+					const id = await table.page.evaluate(
+						(deckId) => window.__tableplace!.actions.drawFromTop(deckId, 1)[0]?.id ?? '',
+						deck
+					);
+					ok(!!id, 'nothing came off the top of the deck');
+					await table.settle(1500); // draw springs done before the grab
+					return id;
+				};
+
+				// the resting card, parked on bare felt in the clear lane
+				const under = await dragToArrives(await draw(), -4, 1, 'the resting card');
+				ok(
+					Math.abs((under[1] ?? 9) - CARD_REST) < 0.02,
+					`the resting card is not at felt rest (${CARD_REST}): ${JSON.stringify(under)}`
+				);
+
+				// Alt-drop the second card overlapping it, released off its centre
+				const dropped = await dragToArrives(await draw(), -3.4, 1.4, 'the Alt-dropped card', {
+					alt: true
+				});
+
+				// Alt held: no square-up — the landing stays at the pointer, planar
+				// distance from the card under it well clear of zero (a squared-up
+				// drop would sit at EXACTLY its XZ) yet still overlapping
+				const apart = planarDistance(under, dropped);
+				ok(
+					apart > 0.2 && apart < 1.6,
+					`the Alt-drop did not stay at the pointer: ${JSON.stringify(dropped)} vs ${JSON.stringify(under)} (planar ${apart.toFixed(3)})`
+				);
+
+				// …and the height merged anyway: one thickness above the resting
+				// card, never coplanar with it (tableplace-145's z-fight)
+				ok(
+					Math.abs((dropped[1] ?? 9) - ((under[1] ?? 0) + CARD_THICKNESS)) < 0.005,
+					`the Alt-drop did not rest one thickness above the card under it: ` +
+						`${JSON.stringify(dropped)} over ${JSON.stringify(under)}`
+				);
+
+				await assertDraggable(table, deck, 'deck (after an Alt-drop)');
+				assertClean(table, 'after Alt-dropping onto an overlapping card');
+			})
+	},
+	{
+		/**
 		 * tableplace-135: a catalog model (GLB over HTTP) renders, drags, and
 		 * rotates VISIBLY — the piece-rotation binding this ticket fixed — while
 		 * the deck and a die stay interactive beside it. `requestfailed` is part

--- a/e2e/table.ts
+++ b/e2e/table.ts
@@ -34,8 +34,18 @@ export type Table = {
 		id: string
 	) => Promise<{ meshes: number; materials: unknown[]; size: [number, number, number] } | null>;
 	dragBy: (id: string, dx: number, dy: number) => Promise<void>;
-	/** drag an entity and release it over a table-plane world position */
-	dragTo: (id: string, worldX: number, worldZ: number) => Promise<void>;
+	/**
+	 * drag an entity and release it over a table-plane world position;
+	 * `alt` holds the Alt key through the whole gesture — the release's
+	 * pointerup then carries `altKey`, which is what the app reads for the
+	 * no-snap drop (see TableScene's onPointerUp)
+	 */
+	dragTo: (
+		id: string,
+		worldX: number,
+		worldZ: number,
+		options?: { alt?: boolean }
+	) => Promise<void>;
 	positionOf: (id: string) => Promise<number[] | null>;
 	settle: (ms?: number) => Promise<void>;
 	close: () => Promise<void>;
@@ -155,7 +165,12 @@ export async function openTable(browser: Browser, servers: Servers, lobby: strin
 	 * interactivity context's raycast on the last move.
 	 */
 	/** press on the entity, walk the pointer to a screen point, release there */
-	const dragFromTo = async (id: string, from: ScreenPoint, to: ScreenPoint) => {
+	const dragFromTo = async (
+		id: string,
+		from: ScreenPoint,
+		to: ScreenPoint,
+		options: { alt?: boolean } = {}
+	) => {
 		// A HUD pane over the entity swallows the press, and the failure looks
 		// exactly like a dead table — which cost an hour of chasing a bag that was
 		// never broken. Fail on the real reason instead: put the entity somewhere
@@ -166,19 +181,27 @@ export async function openTable(browser: Browser, servers: Servers, lobby: strin
 				`${id} draws at (${Math.round(from.x)}, ${Math.round(from.y)}), where the HUD covers the table (${cover}) — move it clear of the panes`
 			);
 		}
-		await page.mouse.move(from.x, from.y);
-		await sleep(80);
-		await page.mouse.down();
-		await sleep(80);
-		for (let step = 1; step <= 12; step++) {
-			await page.mouse.move(
-				from.x + ((to.x - from.x) * step) / 12,
-				from.y + ((to.y - from.y) * step) / 12
-			);
-			await sleep(20);
+		// held for the whole gesture: puppeteer stamps keyboard modifiers onto
+		// every mouse event it dispatches, so the release's pointerup carries
+		// altKey exactly like a user holding Alt
+		if (options.alt) await page.keyboard.down('Alt');
+		try {
+			await page.mouse.move(from.x, from.y);
+			await sleep(80);
+			await page.mouse.down();
+			await sleep(80);
+			for (let step = 1; step <= 12; step++) {
+				await page.mouse.move(
+					from.x + ((to.x - from.x) * step) / 12,
+					from.y + ((to.y - from.y) * step) / 12
+				);
+				await sleep(20);
+			}
+			await sleep(150);
+			await page.mouse.up();
+		} finally {
+			if (options.alt) await page.keyboard.up('Alt');
 		}
-		await sleep(150);
-		await page.mouse.up();
 		await sleep(400);
 	};
 
@@ -193,7 +216,12 @@ export async function openTable(browser: Browser, servers: Servers, lobby: strin
 	 * pointer's raycast hits the table, so the target pixel is the projection
 	 * of that spot on the felt — where a snap grid can then pull it from.
 	 */
-	const dragTo = async (id: string, worldX: number, worldZ: number) => {
+	const dragTo = async (
+		id: string,
+		worldX: number,
+		worldZ: number,
+		options: { alt?: boolean } = {}
+	) => {
 		const from = await locate(id);
 		if (!from) throw new Error(`cannot locate ${id} on screen`);
 		const to = await page.evaluate(
@@ -202,7 +230,7 @@ export async function openTable(browser: Browser, servers: Servers, lobby: strin
 			worldZ
 		);
 		if (!to) throw new Error(`world (${worldX}, ${worldZ}) projects off-screen`);
-		await dragFromTo(id, from, to);
+		await dragFromTo(id, from, to, options);
 	};
 
 	return {

--- a/src/lib/utils/transforms/__tests__/drop.test.ts
+++ b/src/lib/utils/transforms/__tests__/drop.test.ts
@@ -376,16 +376,37 @@ describe('resolveDrop', () => {
 
 		it('commits at the raw point instead of squaring up to the pile', () => {
 			const drop = resolveDrop(overlapping(), 'a', { x: 0.5, z: 0.4 }, {}, { noSnap: true });
-			expect(drop).toMatchObject({ kind: 'table', position: [0.5, CARD_REST_Y, 0.4] });
+			expect(drop?.position[0]).toBe(0.5);
+			expect(drop?.position[2]).toBe(0.4);
 		});
 
-		it('rests on the felt rather than on top of the card it overlaps', () => {
-			const snapped = resolveDrop(overlapping(), 'a', { x: 0.5, z: 0.4 });
-			expect(snapped?.kind).toBe('stack');
-			expect(snapped?.position[1]).toBe(CARD_REST_Y + CARD_THICKNESS);
-			expect(
-				resolveDrop(overlapping(), 'a', { x: 0.5, z: 0.4 }, {}, { noSnap: true })?.position[1]
-			).toBe(CARD_REST_Y);
+		it('still rests on top of the card it overlaps — coplanar cards z-fight', () => {
+			const drop = resolveDrop(overlapping(), 'a', { x: 0.5, z: 0.4 }, {}, { noSnap: true });
+			expect(drop).toMatchObject({
+				kind: 'stack',
+				position: [0.5, CARD_REST_Y + CARD_THICKNESS, 0.4],
+				footprintY: CARD_REST_Y + CARD_THICKNESS
+			});
+		});
+
+		it('keeps climbing on repeated Alt-drops onto the same overlap', () => {
+			const s = state({
+				cards: {
+					a: card(0, 2, 0),
+					resting: card(0.2, CARD_REST_Y, 0.2),
+					previous: card(0.5, CARD_REST_Y + CARD_THICKNESS, 0.4)
+				}
+			});
+			const drop = resolveDrop(s, 'a', { x: 0.7, z: 0.5 }, {}, { noSnap: true });
+			expect(drop?.position[0]).toBe(0.7);
+			expect(drop?.position[2]).toBe(0.5);
+			expect(drop?.position[1]).toBeCloseTo(CARD_REST_Y + 2 * CARD_THICKNESS);
+		});
+
+		it('rests on the felt when nothing is under the pointer', () => {
+			const s = state({ cards: { a: card(0, 2, 0) } });
+			const drop = resolveDrop(s, 'a', { x: 0.5, z: 0.4 }, {}, { noSnap: true });
+			expect(drop).toMatchObject({ kind: 'table', position: [0.5, CARD_REST_Y, 0.4] });
 		});
 
 		it('still clamps to the felt', () => {

--- a/src/lib/utils/transforms/drop.ts
+++ b/src/lib/utils/transforms/drop.ts
@@ -73,9 +73,10 @@ export interface DropHover {
 export interface DropOptions {
 	/**
 	 * Alt held at release: place the card exactly where the pointer is, with
-	 * no XZ square-up onto a nearby pile, no stack-height merge, and no pull
-	 * onto an authored snap point. The escape hatch for laying cards out next
-	 * to each other on purpose.
+	 * no XZ square-up onto a nearby pile and no pull onto an authored snap
+	 * point. The escape hatch for laying cards out next to each other on
+	 * purpose. Height still merges — an overlapping card rests on top of what
+	 * is under it, because coplanar cards z-fight (see resolveStack).
 	 */
 	noSnap?: boolean;
 	/**
@@ -306,19 +307,19 @@ export function resolveDrop(
 		};
 	}
 
-	// Alt beats the pile: commit at the pointer, resting on the felt rather
-	// than merging into whatever the card happens to overlap. Checked after
-	// the deck and tray, which are aimed-at targets rather than a side effect
-	// of proximity.
+	// Alt beats the pile's pull, not its height: commit at the pointer, but
+	// still rest on top of whatever the card overlaps — coplanar cards z-fight
+	// (see resolveStack), and resting on top is physics, not snapping. Checked
+	// after the deck and tray, which are aimed-at targets rather than a side
+	// effect of proximity.
 	if (options.noSnap) {
-		const floor = floorAt(x, z);
-		const restY = floor + (CARD_REST_Y - TABLE_TOP_Y);
+		const stack = resolveStack(state?.cards, dragId, x, z, floorAt(x, z));
 		return {
-			kind: 'table',
-			position: [x, restY, z],
+			kind: stack.count > 0 ? 'stack' : 'table',
+			position: [x, stack.restY, z],
 			rotation,
 			footprint,
-			footprintY: restY
+			footprintY: stack.restY
 		};
 	}
 


### PR DESCRIPTION
## What

Alt-dropping a card overlapping one already resting on the table left both at `CARD_REST_Y`, z-fighting where they overlap. The `noSnap` branch in `resolveDrop` (introduced in e666285) opted out of the stack-height merge along with the XZ square-up — but resting on top is a physical concern, not a snapping one.

## How

- `drop.ts` `noSnap` branch: keep the pointer XZ (the whole point of Alt), but take `position[1]`/`footprintY` from `resolveStack` with the tableplace-135 floor injection (`floorAt`) intact. Repeated Alt-drops keep climbing one thickness per drop, same as every other landing; bare felt is unchanged.
- `kind` reports `'stack'` when the drop lands on cards: `commit.ts` only branches on tray/deck/bag and `DropIndicator` uses kind only for color, so this can't reintroduce the square-up — it just makes the indicator color truthful.
- Non-Alt paths untouched; no existing non-Alt test needed edits.

## Tests

- Unit (`drop.test.ts`): the old flat-`CARD_REST_Y` assertion deliberately replaced with rest-on-top; new tests for repeated climbing and the bare-felt fallback. 856/856 pass, `svelte-check` 0 errors.
- e2e: `dragTo` grows an `{ alt }` option (puppeteer holds the real Alt key so the release's pointerup carries `altKey`, exactly what `TableScene.onPointerUp` reads), and a new spec Alt-drops one card overlapping another with a real mouse and asserts it lands at the pointer XZ, one card thickness above — never coplanar. 12/12 specs pass locally.

Known edge (pre-existing, out of scope): the sliver overlap where centre distance is between `CARD_STACK_RADIUS` (1.7) and actual card overlap (~2.4) still lands coplanar — true for non-Alt drops too.

Task: tableplace-145
Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnuQJqryPccnqhQ7mukfRA