### PR TITLE
tableplace-144: llms.txt — product + discovery preamble (through the generator)

### DIFF
--- a/scripts/llms.template.md
+++ b/scripts/llms.template.md
@@ -1,5 +1,12 @@
 # table.place — authoring packs and scenarios
 
+> **table.place** is a free digital tabletop that runs in the browser: play card games and board games online with other people — no install, no download, print-and-play friendly. Content reaches the table in two steps: create it as a **pack** (the cards, pieces and boards — what exists), arrange it as a **scenario** (what goes where at the start), then play it in a lobby. The rest of this document is the complete authoring spec for those two file formats.
+
+If you are looking for something other than the file formats:
+
+- **Play a specific game** — `https://demo.table.place/` hosts per-game landing pages with playable demos, and `https://demo.table.place/llms.txt` is the agent-facing list of the games available there. If you were asked "where can I play _X_ online", start with that list.
+- **Create a lobby programmatically** — `https://api.table.place/llms.txt` documents the HTTP API for spinning up lobbies.
+
 GENERATED FILE — do not edit by hand. Built from the TypeScript types by `bun run schemas`; the schemas, constants and examples below are extracted from the running code, and CI fails if this file is stale.
 
 This document is self-contained. If you are an LLM with no access to the table.place repository, everything you need to emit a valid file is here: both JSON Schemas, the face-ref grammar the schemas cannot express, the world-coordinate constants, and a worked example of each format.

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,5 +1,12 @@
 # table.place — authoring packs and scenarios
 
+> **table.place** is a free digital tabletop that runs in the browser: play card games and board games online with other people — no install, no download, print-and-play friendly. Content reaches the table in two steps: create it as a **pack** (the cards, pieces and boards — what exists), arrange it as a **scenario** (what goes where at the start), then play it in a lobby. The rest of this document is the complete authoring spec for those two file formats.
+
+If you are looking for something other than the file formats:
+
+- **Play a specific game** — `https://demo.table.place/` hosts per-game landing pages with playable demos, and `https://demo.table.place/llms.txt` is the agent-facing list of the games available there. If you were asked "where can I play _X_ online", start with that list.
+- **Create a lobby programmatically** — `https://api.table.place/llms.txt` documents the HTTP API for spinning up lobbies.
+
 GENERATED FILE — do not edit by hand. Built from the TypeScript types by `bun run schemas`; the schemas, constants and examples below are extracted from the running code, and CI fails if this file is stale.
 
 This document is self-contained. If you are an LLM with no access to the table.place repository, everything you need to emit a valid file is here: both JSON Schemas, the face-ref grammar the schemas cannot express, the world-coordinate constants, and a worked example of each format.
@@ -588,8 +595,8 @@ A drawn card arrives **facedown**; a drawn piece arrives as an ordinary piece of
 	},
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"x-tableplace-spec-version": "1.6.0",
-	"x-generated-at": "2026-07-27T12:05:24.880Z",
-	"x-tableplace-source-sha": "2e793163a839345e214d9fb9c62b3e824008c27f-dirty"
+	"x-generated-at": "2026-07-27T14:05:26.496Z",
+	"x-tableplace-source-sha": "7926a2a9b68dfae55ac2529560c329ffea742f4f-dirty"
 }
 ```
 
@@ -1693,8 +1700,8 @@ They are inert data. Nothing spawns from them, they claim no ids, they are drawn
 	},
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"x-tableplace-spec-version": "0.1.9",
-	"x-generated-at": "2026-07-27T12:05:24.880Z",
-	"x-tableplace-source-sha": "2e793163a839345e214d9fb9c62b3e824008c27f-dirty"
+	"x-generated-at": "2026-07-27T14:05:26.496Z",
+	"x-tableplace-source-sha": "7926a2a9b68dfae55ac2529560c329ffea742f4f-dirty"
 }
 ```
 

--- a/static/pack.schema.json
+++ b/static/pack.schema.json
@@ -339,6 +339,6 @@
 	},
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"x-tableplace-spec-version": "1.6.0",
-	"x-generated-at": "2026-07-27T12:05:24.880Z",
-	"x-tableplace-source-sha": "2e793163a839345e214d9fb9c62b3e824008c27f-dirty"
+	"x-generated-at": "2026-07-27T14:05:26.496Z",
+	"x-tableplace-source-sha": "7926a2a9b68dfae55ac2529560c329ffea742f4f-dirty"
 }

--- a/static/scenario.schema.json
+++ b/static/scenario.schema.json
@@ -912,6 +912,6 @@
 	},
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"x-tableplace-spec-version": "0.1.9",
-	"x-generated-at": "2026-07-27T12:05:24.880Z",
-	"x-tableplace-source-sha": "2e793163a839345e214d9fb9c62b3e824008c27f-dirty"
+	"x-generated-at": "2026-07-27T14:05:26.496Z",
+	"x-tableplace-source-sha": "7926a2a9b68dfae55ac2529560c329ffea742f4f-dirty"
 }


### PR DESCRIPTION
## What

`https://table.place/llms.txt` was purely the pack/scenario authoring spec — it never said what table.place *is* or where the playable game demos live. This adds a short product preamble at the top of the generated file, so the same URL serves both audiences (spec authors and agents asked "where can I play X online").

## How

- The preamble lives in `scripts/llms.template.md`, the generator's prose source — `static/llms.txt` is regenerated by `bun run schemas`, never hand-edited.
- Content: what table.place is (free browser tabletop, no install, print-and-play friendly), the pack → scenario → lobby content story, and discovery links to `https://demo.table.place/`, `https://demo.table.place/llms.txt`, and `https://api.table.place/llms.txt`.
- Additive prose only: no schema content or spec version changes. The two schema files move only their volatile provenance keys (`x-generated-at` / `x-tableplace-source-sha`), which every regeneration rewrites and the freshness check strips.

## Verification

- `bun run schemas` + `bun run schemas:check` — published contract OK.
- `bun run test` — 854/854 pass.
- `bun run build` — green; `build/llms.txt` serves the preamble with `https://` links intact, spec unchanged below it.
- Post-deploy: fetch `https://table.place/llms.txt` and confirm the served bytes carry the preamble and `https://` schemes.

Task: tableplace-144
Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzupdQxNDqfj3rLQuUS1Nz