### PR TITLE
tableplace-151: e2e harness captures a per-spec screenshot, guarded against blank frames

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,14 @@ jobs:
         run: bun run test:e2e
         env:
           CHROME_PATH: /usr/bin/google-chrome
+
+      # One PNG per spec (e2e/table.ts `snap`): the visual-polish train's
+      # before/after evidence. Uploaded even when the harness fails — the
+      # screenshots that did get written are exactly what a failure needs.
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-screenshots
+          path: e2e/screenshots/
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ Thumbs.db
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
+# E2E render harness evidence (uploaded as a CI artifact, never committed)
+/e2e/screenshots
+
 # Go
 *.exe
 *.exe~

--- a/e2e/specs.ts
+++ b/e2e/specs.ts
@@ -141,6 +141,7 @@ export const SPECS: Spec[] = [
 				await assertRenders(table, deck, 'deck');
 				await assertDraggable(table, deck, 'deck');
 				assertClean(table, 'with a deck alone on the table');
+				await table.snap('deck-alone');
 			})
 	},
 	{
@@ -155,6 +156,7 @@ export const SPECS: Spec[] = [
 				await assertDraggable(table, deck, 'deck (with a d20 on the table)');
 				await assertDraggable(table, die, 'the d20 itself');
 				assertClean(table, 'after dragging with a d20 on the table');
+				await table.snap('die');
 			})
 	},
 	{
@@ -173,6 +175,7 @@ export const SPECS: Spec[] = [
 					await assertRenders(table, id, `the d${shapes[index]}`);
 				}
 				await assertDraggable(table, deck, 'deck (with d4…d20 on the table)');
+				await table.snap('die-shapes');
 			})
 	},
 	{
@@ -187,6 +190,7 @@ export const SPECS: Spec[] = [
 				await assertDraggable(table, deck, 'deck (with a bag on the table)');
 				await assertDraggable(table, bag, 'the bag itself');
 				assertClean(table, 'after dragging with a bag on the table');
+				await table.snap('bag');
 			})
 	},
 	{
@@ -215,6 +219,7 @@ export const SPECS: Spec[] = [
 				await assertDraggable(table, deck, 'a deck spawned after a die');
 				await assertRenders(table, die, 'the d6');
 				assertClean(table, 'with a pack spawned after a die');
+				await table.snap('white-pack');
 			})
 	},
 	{
@@ -285,6 +290,7 @@ export const SPECS: Spec[] = [
 				await assertDraggable(table, cardId, 'the landscape card');
 				await assertDraggable(table, deck, 'deck (with a landscape card out)');
 				assertClean(table, 'with a landscape card on the table');
+				await table.snap('landscape');
 			})
 	},
 	{
@@ -336,6 +342,7 @@ export const SPECS: Spec[] = [
 				await assertDraggable(table, deck, 'deck (after grid snapping)');
 				await assertDraggable(table, token, 'the token (after grid snapping)');
 				assertClean(table, 'after snapping onto a grid');
+				await table.snap('snap-grid');
 			})
 	},
 	{
@@ -430,6 +437,7 @@ export const SPECS: Spec[] = [
 
 				await assertDraggable(table, deck, 'deck (after an Alt-drop)');
 				assertClean(table, 'after Alt-dropping onto an overlapping card');
+				await table.snap('alt-drop');
 			})
 	},
 	{
@@ -517,6 +525,7 @@ export const SPECS: Spec[] = [
 				} finally {
 					await remote.close();
 				}
+				await table.snap('model');
 			} finally {
 				await table.close();
 			}
@@ -598,6 +607,7 @@ export const SPECS: Spec[] = [
 
 				await assertDraggable(table, deck, 'deck (with surface rest in play)');
 				assertClean(table, 'after resting a token on a model surface');
+				await table.snap('model-surface');
 			})
 	},
 	{
@@ -632,6 +642,7 @@ export const SPECS: Spec[] = [
 				await assertDraggable(table, deck, 'deck (in the 30-tile cave scene)');
 				await assertDraggable(table, die, 'the d6 (in the 30-tile cave scene)');
 				assertClean(table, 'at the end of the 30-tile cave scene');
+				await table.snap('model-scene');
 			})
 	},
 	{
@@ -801,6 +812,7 @@ export const SPECS: Spec[] = [
 				await assertDraggable(table, deck, 'the draw deck (cataclysm table)');
 				await assertDraggable(table, bag, 'the damage-counter bag (cataclysm table)');
 				assertClean(table, 'at the end of the cataclysm arcade table');
+				await table.snap('cataclysm');
 			})
 	},
 	{
@@ -962,6 +974,7 @@ export const SPECS: Spec[] = [
 				ok((await deckCount()) === moved!.count, `moving the pile changed its card count`);
 
 				assertClean(table, 'after the deck gesture suite');
+				await table.snap('deck-gestures');
 			})
 	},
 	{
@@ -1123,6 +1136,7 @@ export const SPECS: Spec[] = [
 
 				await assertDraggable(table, deck, 'deck (after the composed alt-drops)');
 				assertClean(table, 'after alt-dropping drag-drawn cards');
+				await table.snap('deck-alt');
 			})
 	},
 	{
@@ -1163,6 +1177,7 @@ export const SPECS: Spec[] = [
 				await table.settle();
 				await assertDraggable(table, deck, 'deck (after cycling a piece state)');
 				assertClean(table, 'at the end of the mixed table');
+				await table.snap('mixed');
 			})
 	}
 ];

--- a/e2e/table.ts
+++ b/e2e/table.ts
@@ -9,7 +9,11 @@
  */
 
 import type { Browser, ConsoleMessage, Page } from 'puppeteer-core';
+import { mkdirSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
 import type { Servers } from './servers';
 
 export type Problem = { kind: 'console' | 'pageerror' | 'requestfailed'; text: string };
@@ -48,8 +52,16 @@ export type Table = {
 	) => Promise<void>;
 	positionOf: (id: string) => Promise<number[] | null>;
 	settle: (ms?: number) => Promise<void>;
+	/**
+	 * capture the page to e2e/screenshots/<name>.png — the visual-polish
+	 * train's evidence artifact — failing if the frame is silently blank
+	 */
+	snap: (name: string) => Promise<string>;
 	close: () => Promise<void>;
 };
+
+/** gitignored; CI uploads it as the `e2e-screenshots` artifact */
+const SCREENSHOT_DIR = fileURLToPath(new URL('./screenshots/', import.meta.url));
 
 /**
  * Noise that is the *environment*, never the app: SwiftShader's warnings, and a
@@ -257,6 +269,97 @@ export async function openTable(browser: Browser, servers: Servers, lobby: strin
 		await dragFromTo(id, from, to, { ...options, hold: holdFor(id) });
 	};
 
+	/**
+	 * One PNG per spec, written after a settle so the springs are done posing.
+	 *
+	 * The flat-color guard exists because SwiftShader's failure mode is not an
+	 * error but an empty frame: the harness's structural assertions (mesh
+	 * counts, raycasts) all keep passing while the canvas draws nothing. So the
+	 * check reads pixels back from the PNG that was actually written — not from
+	 * the live canvas, whose drawing buffer may not even be preserved — by
+	 * loading it into the page and sampling a grid of points inside the table
+	 * canvas's own box. Points the HUD panes cover are skipped: a pane's chrome
+	 * would count as "variation" over a canvas that rendered nothing at all.
+	 */
+	const snap = async (name: string) => {
+		await settle();
+		mkdirSync(SCREENSHOT_DIR, { recursive: true });
+		const file = join(SCREENSHOT_DIR, `${name}.png`);
+		const png = new Uint8Array(await page.screenshot({ type: 'png' }));
+		await writeFile(file, png);
+
+		const sampled = await page.evaluate(
+			async (dataUrl) => {
+				const image = new Image();
+				await new Promise<void>((resolve, reject) => {
+					image.onload = () => resolve();
+					image.onerror = () => reject(new Error('the captured PNG did not decode'));
+					image.src = dataUrl;
+				});
+				const surface = document.createElement('canvas');
+				surface.width = image.width;
+				surface.height = image.height;
+				const context = surface.getContext('2d');
+				if (!context) return { points: 0, spread: 0 };
+				context.drawImage(image, 0, 0);
+
+				// the WebGL table is the biggest canvas on the page — the HUD's
+				// Tweakpane panes each carry small canvases of their own
+				const table = [...document.querySelectorAll('canvas')].sort(
+					(a, b) => b.clientWidth * b.clientHeight - a.clientWidth * a.clientHeight
+				)[0];
+				const box = table?.getBoundingClientRect();
+				if (!table || !box || !box.width || !box.height) return { points: 0, spread: 0 };
+				// the screenshot is in device pixels; the box is in CSS pixels
+				const scaleX = image.width / window.innerWidth;
+				const scaleY = image.height / window.innerHeight;
+
+				const low = [255, 255, 255];
+				const high = [0, 0, 0];
+				let points = 0;
+				const STEPS = 8;
+				for (let row = 1; row < STEPS; row++) {
+					for (let column = 1; column < STEPS; column++) {
+						const cssX = box.left + (box.width * column) / STEPS;
+						const cssY = box.top + (box.height * row) / STEPS;
+						if (document.elementFromPoint(cssX, cssY) !== table) continue;
+						const pixel = context.getImageData(
+							Math.round(cssX * scaleX),
+							Math.round(cssY * scaleY),
+							1,
+							1
+						).data;
+						points++;
+						for (const channel of [0, 1, 2]) {
+							low[channel] = Math.min(low[channel]!, pixel[channel]!);
+							high[channel] = Math.max(high[channel]!, pixel[channel]!);
+						}
+					}
+				}
+				// how far apart the sampled pixels are, on the widest RGB channel.
+				// A blank canvas shows the page background through: measured ≤5
+				// even with a HUD pane's drop shadow grazing a sample, while the
+				// felt's own shading alone spans ≥29 — so 16 splits them cleanly
+				// without caring what color anything is.
+				const spread = Math.max(high[0]! - low[0]!, high[1]! - low[1]!, high[2]! - low[2]!);
+				return { points, spread };
+			},
+			`data:image/png;base64,${Buffer.from(png).toString('base64')}`
+		);
+
+		if (sampled.points === 0) {
+			throw new Error(`screenshot ${name}.png: found no table canvas pixels to sample`);
+		}
+		if (sampled.spread < 16) {
+			throw new Error(
+				`screenshot ${name}.png is one flat color across ${sampled.points} sampled canvas ` +
+					`points (RGB spread ${sampled.spread}) — SwiftShader rendered a blank frame. ` +
+					`The PNG is at ${file}.`
+			);
+		}
+		return file;
+	};
+
 	return {
 		page,
 		problems,
@@ -271,6 +374,7 @@ export async function openTable(browser: Browser, servers: Servers, lobby: strin
 		dragTo,
 		positionOf,
 		settle,
+		snap,
 		close: () => page.close()
 	};
 }


### PR DESCRIPTION
## What

Car 0 of the visual-polish train: the render harness now leaves judgeable image evidence on every PR.

- **`snap(name)` on the `Table` harness** (`e2e/table.ts`): settles, captures the fixed 1280×900 viewport to gitignored `e2e/screenshots/<name>.png`.
- **Every spec ends with a snap** — 15 specs, 15 PNGs per run.
- **CI uploads `e2e/screenshots/` as the `e2e-screenshots` artifact** from the `render` job, with `if: always()` so a failing run still ships the screenshots it wrote.
- **Blank-frame guard**: SwiftShader can render nothing without erroring, and every structural assertion (mesh counts, raycasts) keeps passing. `snap` therefore samples a pixel grid inside the WebGL canvas's box from the PNG it just wrote (biggest canvas on the page — the Tweakpane panes carry small canvases of their own; HUD-covered points are skipped) and fails the spec unless the RGB spread is ≥16. Measured: a blanked canvas spans ≤5 even with a pane drop-shadow grazing a sample; the live felt's shading alone spans ≥29.

No `src/` changes; no golden images or pixel diffing — evidence only.

## Verification

- `bun run test:e2e`: **15/15 green locally**, one PNG per spec in `e2e/screenshots/`.
- Guard self-test: with the WebGL canvas forced invisible (captured pixels become the flat page background, hit-testing intact), `snap` fails with `RGB spread 5` — the flat-color branch fires.
- `bun run test` (863 passed), `bun run build`, `svelte-check` (0 errors) all green; prettier + eslint clean on the changed files (repo lint is red at baseline, unchanged).

Task: tableplace-151
Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwudNAJZ45htyW6d6nes8S