### PR TITLE
tableplace-156: unify counter/label styling into badges

### DIFF
--- a/e2e/specs.ts
+++ b/e2e/specs.ts
@@ -1140,6 +1140,110 @@ export const SPECS: Spec[] = [
 			})
 	},
 	{
+		/**
+		 * tableplace-156: every floating label is the same LabelBadge, and the
+		 * restyle must not have changed WHEN one shows or how it reacts. Pinned
+		 * here with a real pointer: a counter's value, a bag's count and a deck's
+		 * card count wear their badges with no hover anywhere; a plain piece's
+		 * name badge mounts under the pointer and unmounts when it leaves; and a
+		 * real click on the counter kicks the value-change pulse (the badge's
+		 * scale springs toward 1.6, then settles back to rest).
+		 */
+		name: 'badges: hover-only labels, always-on counts, and the value pulse',
+		run: (context) =>
+			withTable(context, 'badges', async (table) => {
+				const deck = await table.seedDeck();
+				const counter = await table.spawn('counter', {
+					name: 'HP',
+					maxValue: 17,
+					value: 5,
+					position: LANE(0)
+				});
+				const bag = await table.spawn('bag', { position: LANE(1) });
+				const token = await table.spawn('token', { name: 'Guard', position: LANE(2) });
+				await table.settle(1500);
+				assertClean(table, 'with a counter, a bag and a named token on the table');
+
+				const badge = (id: string) =>
+					table.page.evaluate((entityId) => window.__tableplace!.badge(entityId), id);
+
+				// always-on: the pointer has not been near any of these
+				for (const [id, label] of [
+					[counter, 'the counter'],
+					[bag, 'the bag'],
+					[deck, 'the deck']
+				] as const) {
+					ok(!!(await badge(id)), `${label} (${id}) has no badge mounted without hover`);
+				}
+
+				// hover-only: the plain token wears its name only under the pointer
+				ok(!(await badge(token)), 'the plain token mounted a badge with no pointer near it');
+				const over = await table.locate(token);
+				ok(over, 'the token never mounted — nothing to hover');
+				await table.page.mouse.move(over!.x, over!.y);
+				const hovered = await eventually(
+					() => badge(token),
+					(b) => !!b
+				);
+				ok(!!hovered, 'hovering the token never mounted its name badge');
+				// park the pointer on bare felt, well clear of everything
+				const felt = await table.page.evaluate(() => window.__tableplace!.project([0, 0.26, 6]));
+				ok(felt, 'the felt parking spot projects off-screen');
+				await table.page.mouse.move(felt!.x, felt!.y);
+				const unhovered = await eventually(
+					() => badge(token),
+					(b) => !b
+				);
+				ok(!unhovered, 'the token badge stayed mounted after the pointer left');
+
+				// the pulse: a real click deals 1 damage (counter-input's plain-click
+				// branch; shift-click is the heal) and the badge scale kicks toward
+				// 1.6 before springing back to rest. The kick is watched FIRST — it
+				// is instant on the value change, so waiting on the value and then
+				// looking for the kick could miss a fast pulse entirely.
+				const at = await table.locate(counter);
+				ok(at, 'the counter never mounted — nothing to click');
+				await table.page.mouse.click(at!.x, at!.y);
+				const kicked = await eventually(
+					() => badge(counter),
+					(b) => !!b && b.scale > 1.15,
+					5000
+				);
+				ok(
+					!!kicked && kicked.scale > 1.15,
+					`the value change never kicked the badge pulse: ${JSON.stringify(kicked)}`
+				);
+				const value = await eventually(
+					() =>
+						table.page.evaluate(
+							(id) => window.__tableplace!.state()?.pieces?.[id]?.value ?? null,
+							counter
+						),
+					(v) => v === 4
+				);
+				ok(value === 4, `the click did not damage the counter to 4: ${JSON.stringify(value)}`);
+				const rested = await eventually(
+					() => badge(counter),
+					(b) => !!b && Math.abs(b.scale - 1) < 0.05
+				);
+				ok(
+					!!rested && Math.abs(rested.scale - 1) < 0.05,
+					`the pulse never settled back to rest: ${JSON.stringify(rested)}`
+				);
+
+				// badges must not have cost the table its raycast
+				await assertDraggable(table, counter, 'the counter (wearing its badge)');
+				await assertDraggable(table, deck, 'deck (with badges on the table)');
+				assertClean(table, 'at the end of the badge suite');
+
+				// the train's visual evidence: counter, bag and deck badges always-on,
+				// and the token hovered so its name badge is in the frame too
+				const pose = await table.locate(token);
+				if (pose) await table.page.mouse.move(pose.x, pose.y);
+				await table.snap('badges');
+			})
+	},
+	{
 		// acceptance criterion 4: one table carrying all four at once
 		name: 'mixed table: deck + die + bag + multi-state piece',
 		run: (context) =>
@@ -1175,6 +1279,11 @@ export const SPECS: Spec[] = [
 					token
 				);
 				await table.settle();
+				// the loop's straight-down drag already walked the deck to the bottom
+				// edge; park it back mid-table first, so the liveness drag below has
+				// screen left to travel into instead of running off the canvas
+				await table.dragTo(deck, 2, -2);
+				await table.settle(900);
 				await assertDraggable(table, deck, 'deck (after cycling a piece state)');
 				assertClean(table, 'at the end of the mixed table');
 				await table.snap('mixed');

--- a/src/lib/Deck.svelte
+++ b/src/lib/Deck.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import * as THREE from 'three';
 	import { T } from '@threlte/core';
-	import { Text, Billboard, ImageMaterial } from '@threlte/extras';
+	import { ImageMaterial } from '@threlte/extras';
 	import type { IntersectionEvent } from '@threlte/extras';
 	import { Spring } from 'svelte/motion';
 	import { dragStart, dragStore, setDeckHover } from '$lib/store/dragStore.svelte';
@@ -23,6 +23,7 @@
 	import { claimPointerDown } from '$lib/utils/single-hit-dispatch';
 	import { DRAG_THRESHOLD_PX } from '$lib/utils/counter-input';
 	import DropFootprint from './drop/DropFootprint.svelte';
+	import LabelBadge from './LabelBadge.svelte';
 	import { selectedDeckId, DECK_SELECT_COLOR } from '$lib/store/deckSelection';
 
 	// No interactivity() here on purpose. It calls setContext, so a per-deck call
@@ -247,14 +248,11 @@
 	onpointerenter={() => setDeckHover(id)}
 	onpointerleave={() => setDeckHover(null)}
 >
-	<Billboard>
-		<Text
-			fontSize={0.5}
-			text={(cards ?? [])?.length?.toString() ?? '0'}
-			position={[0, 1.75, 0]}
-			anchorX="center"
-		/>
-	</Billboard>
+	<LabelBadge
+		text={(cards ?? [])?.length?.toString() ?? '0'}
+		fontSize={0.5}
+		position={[0, 1.75, 0]}
+	/>
 	{#if cards?.length > 0}
 		{#key displayedImage}
 			<T.Mesh castShadow receiveShadow rotation.x={-Math.PI / 2} position.y={height / 2 + 0.01}>

--- a/src/lib/LabelBadge.svelte
+++ b/src/lib/LabelBadge.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+	import * as THREE from 'three';
+	import type { ComponentProps } from 'svelte';
+	import { T } from '@threlte/core';
+	import { Billboard, Text } from '@threlte/extras';
+
+	/**
+	 * The one floating label every entity wears: a billboarded pill — rounded
+	 * dark plate behind light text — so a counter's "17/17", a bag's "∞" and a
+	 * deck's card count all read as the same deliberate piece of game UI instead
+	 * of three different debug overlays.
+	 *
+	 * The plate is cut to the text's LAID-OUT bounds (troika reports them after
+	 * every sync), not estimated from character count — a bag hovering into
+	 * "Damage counters · ∞" grows its plate to fit, and the pill's corner radius
+	 * rides the text height so every badge keeps the same shape at any fontSize.
+	 *
+	 * Neither mesh raycasts. The old troika label DID (an accident tableplace-84
+	 * had to guard the counter against), and the plate's padding made that fatal:
+	 * a hovered model tile's floating name eclipsed a grab aimed at the token
+	 * standing on it, and the tile got dragged instead. A label is a readout, not
+	 * a hitbox — the pointer always means the body under it.
+	 */
+	let {
+		text,
+		fontSize = 0.45,
+		position = [0, 0, 0],
+		scale = 1
+	}: {
+		text: string;
+		fontSize?: number;
+		position?: [number, number, number];
+		/** the value-change pulse drives this; it scales plate and text together */
+		scale?: number;
+	} = $props();
+
+	// troika's textRenderInfo isn't in Threlte's Text types, only on the
+	// underlying object — this is the one field the plate needs from it.
+	// (TextMesh itself isn't exported from the package index, so the ref type
+	// is derived from the component's own props.)
+	type SyncedText = NonNullable<ComponentProps<typeof Text>['ref']> & {
+		textRenderInfo?: { blockBounds: [number, number, number, number] };
+	};
+
+	let textRef = $state<SyncedText>();
+	// the text block's local-space bounds, refreshed on every troika sync — the
+	// plate re-cuts whenever the label re-lays-out (hover renames a bag, a
+	// counter ticks from 9/17 to 10/17)
+	let bounds = $state<[number, number, number, number] | null>(null);
+
+	function handleSync() {
+		const block = textRef?.textRenderInfo?.blockBounds;
+		if (block) bounds = [block[0], block[1], block[2], block[3]];
+	}
+
+	function pillShape(width: number, height: number): THREE.Shape {
+		const radius = Math.min(width, height) / 2;
+		const x = -width / 2;
+		const y = -height / 2;
+		const shape = new THREE.Shape();
+		shape.moveTo(x + radius, y);
+		shape.lineTo(x + width - radius, y);
+		shape.absarc(x + width - radius, y + radius, radius, -Math.PI / 2, 0, false);
+		shape.lineTo(x + width, y + height - radius);
+		shape.absarc(x + width - radius, y + height - radius, radius, 0, Math.PI / 2, false);
+		shape.lineTo(x + radius, y + height);
+		shape.absarc(x + radius, y + height - radius, radius, Math.PI / 2, Math.PI, false);
+		shape.lineTo(x, y + radius);
+		shape.absarc(x + radius, y + radius, radius, Math.PI, Math.PI * 1.5, false);
+		return shape;
+	}
+
+	const plate = $derived.by(() => {
+		if (!bounds) return null;
+		const [minX, minY, maxX, maxY] = bounds;
+		// padding rides the fontSize so every badge keeps the same proportions
+		const padX = fontSize * 0.42;
+		const padY = fontSize * 0.24;
+		const width = maxX - minX + padX * 2;
+		const height = maxY - minY + padY * 2;
+		return {
+			geometry: new THREE.ShapeGeometry(pillShape(width, height), 12),
+			// centred on the text block, wherever the anchors put it
+			center: [(minX + maxX) / 2, (minY + maxY) / 2] as [number, number]
+		};
+	});
+
+	// each re-layout cuts a fresh geometry; the old one holds GPU buffers
+	$effect(() => {
+		const geometry = plate?.geometry;
+		return () => geometry?.dispose();
+	});
+
+	// see the component comment: the badge must never answer the raycaster
+	const noRaycast = () => null;
+</script>
+
+<Billboard {position}>
+	<!-- userData.badge is the test bridge's handle on this group (visibility and
+	     the pulse scale) — a NAME here would steal the raycast attribution from
+	     the entity's own group, which `hits()` resolves by nearest named ancestor -->
+	<T.Group {scale} userData={{ badge: true }}>
+		{#if plate}
+			<!-- explicit renderOrder: plate then text — both are transparent and sit
+			     ~coplanar, so distance sorting between them is a coin flip -->
+			<T.Mesh
+				geometry={plate.geometry}
+				position={[plate.center[0], plate.center[1], -0.015]}
+				renderOrder={1}
+				raycast={noRaycast}
+			>
+				<T.MeshBasicMaterial color="#16130f" transparent opacity={0.72} depthWrite={false} />
+			</T.Mesh>
+		{/if}
+		<!-- troika's default TOP anchor, exactly like the labels this replaces: the
+		     badge hangs below `position`, so entity bounding boxes (which the e2e
+		     harness aims its pointer at) keep their old extents, and the pulse
+		     scales around the same origin it always did -->
+		<Text
+			bind:ref={textRef}
+			onsync={handleSync}
+			{text}
+			{fontSize}
+			raycast={noRaycast}
+			anchorX="center"
+			color="#f6f2e9"
+			outlineWidth={fontSize * 0.02}
+			outlineColor="#16130f"
+			renderOrder={2}
+		/>
+	</T.Group>
+</Billboard>

--- a/src/lib/Piece.svelte
+++ b/src/lib/Piece.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { T } from '@threlte/core';
-	import { Billboard, Text, ImageMaterial } from '@threlte/extras';
+	import { ImageMaterial } from '@threlte/extras';
 	import type { IntersectionEvent } from '@threlte/extras';
 	import { Spring } from 'svelte/motion';
 	import { clearBagHover, dragStart, dragStore, setBagHover } from './store/dragStore.svelte';
@@ -14,6 +14,7 @@
 	import { createBagInput } from '$lib/utils/bag-input';
 	import { DEG2RAD } from 'three/src/math/MathUtils.js';
 	import Die from './Die.svelte';
+	import LabelBadge from './LabelBadge.svelte';
 	import Model from './models/Model.svelte';
 	import DropFootprint from './drop/DropFootprint.svelte';
 	import {
@@ -371,28 +372,22 @@
 		<!-- a bag's remaining count is always on, like a counter's value: it's the
 		     only thing about a bag that is legible from across the table -->
 		{#if label && (kind === 'counter' || kind === 'bag' || isHovered)}
-			<Billboard>
-				<Text
-					text={label}
-					fontSize={kind === 'counter' ? 0.55 : kind === 'bag' ? 0.45 : 0.35}
-					position={[
-						0,
-						kind === 'pawn'
-							? 1.5
-							: kind === 'bag'
-								? BAG_HEIGHT + 0.45
-								: kind === 'model'
-									? 2.4
-									: 0.75,
-						0
-					]}
-					scale={kind === 'counter' ? labelScale.current : 1}
-					anchorX="center"
-					color="#ffffff"
-					outlineWidth={0.02}
-					outlineColor="#000000"
-				/>
-			</Billboard>
+			<LabelBadge
+				text={label}
+				fontSize={kind === 'counter' ? 0.55 : kind === 'bag' ? 0.45 : 0.35}
+				position={[
+					0,
+					kind === 'pawn'
+						? 1.5
+						: kind === 'bag'
+							? BAG_HEIGHT + 0.45
+							: kind === 'model'
+								? 2.4
+								: 0.75,
+					0
+				]}
+				scale={kind === 'counter' ? labelScale.current : 1}
+			/>
 		{/if}
 	</T.Group>
 {/if}

--- a/src/lib/dev/test-bridge.ts
+++ b/src/lib/dev/test-bridge.ts
@@ -47,6 +47,13 @@ export type TestBridge = {
 	};
 	/** what an entity is actually made of — null if it never mounted at all */
 	describe: (id: string) => EntityShape | null;
+	/**
+	 * The entity's floating label badge (LabelBadge.svelte), or null while none
+	 * is mounted — which is itself the assertion for hover-only labels. `scale`
+	 * is the live pulse spring, so a spec can watch a counter's value-change
+	 * kick (jumps toward 1.6) and settle back to 1.
+	 */
+	badge: (id: string) => { scale: number } | null;
 };
 
 /**
@@ -79,6 +86,34 @@ type SceneHandles = {
 };
 
 /**
+ * Walk an entity's rendered meshes, skipping its floating label badge
+ * (LabelBadge.svelte tags its group `userData.badge`). The badge billboards
+ * ABOVE the body — folding it into the bounding box drags the box centre off
+ * the body, and a pointer aimed there grabs whatever happens to be behind the
+ * label instead of the entity it belongs to. A player aims at the body; so
+ * does everything here.
+ */
+function eachBodyMesh(node: THREE.Object3D, visit: (mesh: THREE.Mesh) => void): void {
+	if (node.userData.badge) return;
+	const mesh = node as THREE.Mesh;
+	if (mesh.isMesh) visit(mesh);
+	for (const child of node.children) eachBodyMesh(child, visit);
+}
+
+function bodyBox(object: THREE.Object3D): THREE.Box3 {
+	object.updateWorldMatrix(true, true);
+	const box = new THREE.Box3();
+	const meshBox = new THREE.Box3();
+	eachBodyMesh(object, (mesh) => {
+		mesh.geometry.computeBoundingBox();
+		if (!mesh.geometry.boundingBox) return;
+		meshBox.copy(mesh.geometry.boundingBox).applyMatrix4(mesh.matrixWorld);
+		box.union(meshBox);
+	});
+	return box;
+}
+
+/**
  * Where an entity actually *draws*, not where the store says it is.
  *
  * The two differ enough to matter: a die sits a shape-dependent distance above
@@ -90,7 +125,7 @@ type SceneHandles = {
 function renderedCentre(scene: THREE.Scene, id: string): THREE.Vector3 | null {
 	const object = scene.getObjectByName(id);
 	if (!object) return null;
-	const box = new THREE.Box3().setFromObject(object);
+	const box = bodyBox(object);
 	if (box.isEmpty()) return object.getWorldPosition(new THREE.Vector3());
 	return box.getCenter(new THREE.Vector3());
 }
@@ -163,14 +198,14 @@ export function installTestBridge(handles: SceneHandles): void {
 		describe: (id) => {
 			const object = handles.scene()?.getObjectByName(id);
 			if (!object) return null;
-			const box = new THREE.Box3().setFromObject(object);
+			// body only, like locate: the badge is a readout riding along, and its
+			// meshes/materials would pollute every "did the body mount right" check
+			const box = bodyBox(object);
 			const size = box.isEmpty()
 				? ([0, 0, 0] as [number, number, number])
 				: (box.getSize(new THREE.Vector3()).toArray() as [number, number, number]);
 			const shape: EntityShape = { meshes: 0, materials: [], size };
-			object.traverse((node) => {
-				const mesh = node as THREE.Mesh;
-				if (!mesh.isMesh) return;
+			eachBodyMesh(object, (mesh) => {
 				shape.meshes++;
 				for (const material of [mesh.material].flat()) {
 					const standard = material as THREE.MeshStandardMaterial;
@@ -182,6 +217,17 @@ export function installTestBridge(handles: SceneHandles): void {
 				}
 			});
 			return shape;
+		},
+		badge: (id) => {
+			const object = handles.scene()?.getObjectByName(id);
+			if (!object) return null;
+			// found by userData, not by name: naming the badge group would steal
+			// the raycast attribution `hits()` resolves by nearest named ancestor
+			let group: THREE.Object3D | null = null;
+			object.traverse((node) => {
+				if (!group && node.userData.badge) group = node;
+			});
+			return group ? { scale: (group as THREE.Object3D).scale.x } : null;
 		}
 	};
 }


### PR DESCRIPTION
## What

Extracts `LabelBadge.svelte` — a billboarded pill badge (rounded dark plate cut to troika's laid-out text bounds, light text) — and uses it for every floating label: piece names, counter values, bag counts and deck counts, replacing the two divergent bare-`Text` treatments (white+outline on pieces, unstyled default on decks).

Behaviour is pinned unchanged: hover-only visibility for plain pieces, always-on for counters/bags/decks, the value-change pulse spring, and bag `∞`/name prefixing — verified by a new e2e spec (`badges: hover-only labels, always-on counts, and the value pulse`) that hovers, clicks and watches the pulse with a real pointer via a new `badge(id)` bridge probe.

**Badges do not raycast.** The old troika label did (an accident tableplace-84 had to guard the counter against), and the plate's padding made it fatal: in the `model surface` spec, the hovered tile's floating name eclipsed the grab aimed at the token standing on it, and the tile got dragged away instead. A label is a readout, not a hitbox. The test bridge's `locate`/`describe` likewise aim at the body only, excluding the badge.

The optional custom font was deliberately skipped: labels render `∞ · —` and most distinctive display fonts lack `∞`; troika's default covers it.

## Evidence (#151 harness)

`bun run test:e2e` — **16/16 green** locally on this head (rebased onto #158's screenshot harness); per-spec PNGs in the `e2e-screenshots` CI artifact, including the new `badges.png`.

Before/after on the cataclysm spec's table: before, counters render as bare white text — `99/99` disappears into the red damage counter, `Damage counters · ∞` floats as loose glyphs, the deck count is unstyled. After, every label is the same pill badge and stays legible over any body or felt.

## Notes

- The `mixed table` spec now parks the deck mid-table before its final liveness drag: the two straight-down drags walk it to the bottom edge, where a further 150px drag runs off-canvas — the old aim (bbox centre inflated by the label) threaded that needle by accident.

Task: tableplace-156
Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015riggw3H9ezKD3PGZztNv7