### PR TITLE
tableplace-164: harden the drag pipeline against long frame gaps (queued-pointer press race)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,12 @@ with 0 errors and a clean build, because no test in the repo could see it.
   controls cannot be driven synthetically.
 - Anything a spec clicks must draw clear of the HUD panes; `dragBy` fails with
   that diagnosis rather than looking like a frozen table.
+- `table.stall({ ms, everyMs })` holds the page's main thread on a duty cycle —
+  the long frame gaps a loaded CI runner produces, on demand, and the tool for
+  any change that adds per-frame cost. It reproduces the queued-pointer drag
+  race (#164) exactly: with `{ ms: 800, everyMs: 20 }` a pre-fix build drags the
+  raised tile to the token's drop point. `stall(null)` stops it and returns how
+  many stalls ran, so a spec can prove the injection was live.
 - Needs Chrome (`CHROME_PATH` overrides discovery) and Go for the relay. Reuses
   a relay already on `:8080`; takes a random high port for the web server so it
   can never disturb a dev server you are using.

--- a/e2e/specs.ts
+++ b/e2e/specs.ts
@@ -612,6 +612,136 @@ export const SPECS: Spec[] = [
 	},
 	{
 		/**
+		 * tableplace-164: the same tile → felt → tile gesture as `model surface`,
+		 * run while the page's main thread is deliberately held for long
+		 * stretches — the frame gaps a shared CI runner, a slow GPU or a
+		 * backgrounded window produce.
+		 *
+		 * What it is guarding, precisely: a press aims at where an entity is
+		 * DRAWN, and is dispatched against wherever the scene has got to by the
+		 * time the main thread frees up. When frames are scarce those two states
+		 * drift apart — an entity still animating toward its resting place is
+		 * drawn at a stale place, the press queues behind the stall, and the
+		 * raycast at the aimed pixel finds whatever is underneath instead. That
+		 * is how the token's press relocated the TILE on CI (#157/#159), which
+		 * is why the tile's own position is asserted here: it is the sharpest
+		 * signature of the race, and it holds no matter which drag attempt won.
+		 */
+		name: 'frame stalls: a drag survives long frame gaps',
+		run: (context) =>
+			withTable(context, 'frame-stalls', async (table) => {
+				const PIECE_FELT_REST = 0.335; // TABLE_TOP_Y + half the disc thickness
+
+				/**
+				 * Tuned, not guessed. The gap has to outlast the harness's own
+				 * settles so an entity is still mid-flight when the next press aims
+				 * at it, and the free window has to be about one frame wide —
+				 * svelte's springs clamp their integration to 1/30s per tick, so a
+				 * wider window lets a whole flight finish in one catch-up and there
+				 * is nothing left to race. At these numbers the pre-fix build
+				 * relocates the tile to (6, 1): CI's exact failing position.
+				 */
+				const STALL = { ms: 800, everyMs: 20 };
+
+				/**
+				 * The invariant the whole ticket is about: an entity's own pixel has
+				 * to belong to that entity. It is checked with no settle in front of
+				 * it, because the window where it fails is the flight itself — a
+				 * token still rising onto a raised tile is UNDER that tile's top
+				 * surface, so the pointer aimed at the token grabs the tile and
+				 * drags it away (#157/#159, and reproduced here to the millimetre).
+				 */
+				const assertAimBelongsTo = async (id: string, when: string) => {
+					const point = await table.locate(id);
+					ok(point, `${id} could not be located ${when}`);
+					const hits = await table.hits(point!);
+					ok(
+						hits[0] === id,
+						`${when}, the pixel ${id} is DRAWN at belongs to ${hits[0] ?? 'nothing'} — ` +
+							`a press aimed at it would grab that instead (hits: ${hits.join(', ')})`
+					);
+				};
+
+				/** as `model surface`: what is retried is pointer delivery, not the property under test */
+				const dragToArrives = async (id: string, x: number, z: number, label: string) => {
+					for (let attempt = 0; attempt < 3; attempt++) {
+						await table.dragTo(id, x, z);
+						await table.settle(900);
+						const position = await table.positionOf(id);
+						if (position && Math.hypot(position[0] - x, position[2] - z) < 1.0) return position;
+					}
+					const stuck = await table.positionOf(id);
+					throw new Error(
+						`${label} (${id}) never arrived at (${x}, ${z}) after 3 drags: ${JSON.stringify(stuck)}`
+					);
+				};
+
+				const deck = await table.seedDeck();
+				const tile = await table.spawn('model', {
+					name: 'raised',
+					model: 'model:kenney-cave/template-floor-layer-raised',
+					radius: 2.83,
+					position: [-4, 0.16, 1]
+				});
+				const token = await table.spawn('token', { position: [4, 0.16, 1] });
+				await table.settle(2500);
+				assertClean(table, 'with a raised tile and a token on the table');
+
+				const tileAtRest = await table.positionOf(tile);
+				ok(tileAtRest, `the raised tile (${tile}) never landed in the store`);
+
+				let injected = 0;
+				try {
+					await table.stall(STALL);
+
+					// onto the tile — then, with no settle, the moment the race lives in
+					await table.dragTo(token, -4, 1);
+					await assertAimBelongsTo(token, 'just after the token was dropped on the raised tile');
+
+					const onTile = await dragToArrives(token, -4, 1, 'the token (onto the tile)');
+					ok(
+						(onTile[1] ?? 0) > 0.5,
+						`under frame stalls the token sank to felt height instead of resting on the tile: ${JSON.stringify(onTile)}`
+					);
+
+					// and off again: the drop that must fall back to felt rest
+					await table.dragTo(token, 6, 1);
+					await assertAimBelongsTo(token, 'just after the token was dragged off the tile');
+
+					const onFelt = await dragToArrives(token, 6, 1, 'the token (off the tile)');
+					ok(
+						Math.abs((onFelt[1] ?? 9) - PIECE_FELT_REST) < 0.02,
+						`under frame stalls the token did not return to felt rest (${PIECE_FELT_REST}) after ` +
+							`leaving the tile: ${JSON.stringify(onFelt)}`
+					);
+				} finally {
+					injected = await table.stall(null);
+				}
+
+				// the injector is the whole point of the spec: if it never ran, the
+				// green above means nothing
+				ok(
+					injected > 5,
+					`the stall injector only ran ${injected} times — this spec did not test what it claims to`
+				);
+
+				// the race's own fingerprint: a press meant for the token, dispatched
+				// against a scene it could no longer see, grabs the tile and drags THAT
+				const tileNow = await table.positionOf(tile);
+				ok(
+					planarDistance(tileAtRest, tileNow) < 0.5,
+					`a press meant for the token grabbed the raised tile underneath it and moved it: ` +
+						`${JSON.stringify(tileAtRest)} → ${JSON.stringify(tileNow)}`
+				);
+
+				await table.settle(1200); // frames are free again; let the scene catch up
+				await assertDraggable(table, deck, 'deck (after a run of frame stalls)');
+				assertClean(table, 'after dragging through injected frame stalls');
+				await table.snap('frame-stalls');
+			})
+	},
+	{
+		/**
 		 * Scene sanity (tableplace-135 acceptance): a template-built ~30-tile
 		 * cave plus decks and dice stays interactive — thirty clones of one GLB,
 		 * one texture, and the shared raycast still answers for everything.

--- a/e2e/table.ts
+++ b/e2e/table.ts
@@ -53,6 +53,13 @@ export type Table = {
 	positionOf: (id: string) => Promise<number[] | null>;
 	settle: (ms?: number) => Promise<void>;
 	/**
+	 * Hold the page's main thread for `ms` at a time, freeing it for `everyMs`
+	 * in between — the long frame gaps a shared CI runner produces, on demand.
+	 * `null` stops it and returns how many stalls were injected, so a spec can
+	 * prove the injection was live rather than assume it.
+	 */
+	stall: (options: { ms: number; everyMs?: number } | null) => Promise<number>;
+	/**
 	 * capture the page to e2e/screenshots/<name>.png — the visual-polish
 	 * train's evidence artifact — failing if the frame is silently blank
 	 */
@@ -161,6 +168,9 @@ export async function openTable(browser: Browser, servers: Servers, lobby: strin
 
 	const describe = (id: string) =>
 		page.evaluate((entityId) => window.__tableplace!.describe(entityId), id);
+
+	const stall = (options: { ms: number; everyMs?: number } | null) =>
+		page.evaluate((injection) => window.__tableplace!.stall(injection), options);
 
 	const positionOf = (id: string) =>
 		page.evaluate((entityId) => {
@@ -374,6 +384,7 @@ export async function openTable(browser: Browser, servers: Servers, lobby: strin
 		dragTo,
 		positionOf,
 		settle,
+		stall,
 		snap,
 		close: () => page.close()
 	};

--- a/src/lib/Card.svelte
+++ b/src/lib/Card.svelte
@@ -24,6 +24,7 @@
 	import { fanOffset } from '$lib/utils/transforms/stacking';
 	import { pickCard, pickedCard } from './store/cardPick';
 	import { resolveCardImage, sheetRefCache } from '$lib/packs';
+	import { driveSpring } from '$lib/utils/frame-stall.svelte';
 	import { claimPointerDown } from '$lib/utils/single-hit-dispatch';
 	type Vec3Array = [number, number, number];
 
@@ -70,10 +71,15 @@
 	// connector meets the card. Otherwise: stays lifted while a flip is
 	// mid-rotation (so the card can't clip the table), settles to the store's
 	// stack height once the rotation completes.
+	//
+	// Every target goes through driveSpring so a starved frame loop puts the
+	// card at its store height at once: a card still visibly airborne over the
+	// pile it just landed in is a card the next press cannot grab
+	// (tableplace-164).
 	$effect(() => {
 		if (isDragging) {
-			height.target = CARD_DRAG_Y + 0.2;
-			const handle = setTimeout(() => (height.target = CARD_DRAG_Y), 150);
+			driveSpring(height, CARD_DRAG_Y + 0.2);
+			const handle = setTimeout(() => driveSpring(height, CARD_DRAG_Y), 150);
 			return () => clearTimeout(handle);
 		}
 		const flipping = Math.abs(rotation.current - rotation.target) > 2;
@@ -81,7 +87,7 @@
 		// and only here: the store keeps the squared-up resting position, same
 		// as the hover fan
 		const restY = (cardState?.position?.[1] ?? CARD_REST_Y) + (isPicked ? CARD_PICK_LIFT : 0);
-		height.target = flipping ? Math.max(1.5, restY) : restY;
+		driveSpring(height, flipping ? Math.max(1.5, restY) : restY);
 	});
 
 	const rotation = new Spring((cardState?.rotation as Vec3Array)?.[0] ?? 0, {
@@ -146,8 +152,8 @@
 	$effect(() => {
 		const [x = 0, , z = 0] = cardState?.position ?? [];
 		const [fanX, fanZ] = fanShift;
-		if (isDragging) planar.set({ x, z }, { instant: true });
-		else planar.target = { x: x + fanX, z: z + fanZ };
+		if (isDragging) driveSpring(planar, { x, z }, true);
+		else driveSpring(planar, { x: x + fanX, z: z + fanZ });
 	});
 
 	// Create derived values for each component
@@ -165,8 +171,8 @@
 
 	// Flip / tap rotation targets
 	$effect(() => {
-		rotation.target = baseRotation[0];
-		rotationTap.target = baseRotation[2];
+		driveSpring(rotation, baseRotation[0]);
+		driveSpring(rotationTap, baseRotation[2]);
 	});
 
 	// px the pointer may travel between down and up and still count as a click

--- a/src/lib/Deck.svelte
+++ b/src/lib/Deck.svelte
@@ -20,6 +20,7 @@
 	import { gameStore } from './store/game/gameStore.svelte';
 	import { gameActions } from './store/game/actions';
 	import { resolveCardImage, sheetRefCache, CARD_BACK_DEFAULT } from '$lib/packs';
+	import { driveSpring } from '$lib/utils/frame-stall.svelte';
 	import { claimPointerDown } from '$lib/utils/single-hit-dispatch';
 	import { DRAG_THRESHOLD_PX } from '$lib/utils/counter-input';
 	import DropFootprint from './drop/DropFootprint.svelte';
@@ -89,10 +90,14 @@
 		damping: 0.7,
 		precision: 0.0001
 	});
+	// driveSpring: on a starved frame loop the pile lands at its store height at
+	// once rather than gliding down through the pointer that is about to press
+	// on it (tableplace-164)
 	$effect(() => {
-		lift.target = isDragged
-			? CARD_DRAG_Y
-			: (deck.position?.[1] ?? 0) + (moveArmed ? DECK_ARM_LIFT : 0);
+		driveSpring(
+			lift,
+			isDragged ? CARD_DRAG_Y : (deck.position?.[1] ?? 0) + (moveArmed ? DECK_ARM_LIFT : 0)
+		);
 	});
 
 	const planar = new Spring(
@@ -101,8 +106,7 @@
 	);
 	$effect(() => {
 		const [x = 0, , z = 0] = deck.position ?? [];
-		if (isDragged) planar.set({ x, z }, { instant: true });
-		else planar.target = { x, z };
+		driveSpring(planar, { x, z }, isDragged);
 	});
 
 	// Shuffle wiggle: a decaying yaw twitch, kicked whenever `shuffledAt`

--- a/src/lib/Piece.svelte
+++ b/src/lib/Piece.svelte
@@ -8,6 +8,7 @@
 	import { gameActions } from './store/game/actions';
 	import { resolveCardImage, sheetRefCache } from '$lib/packs';
 	import { claimPointerDown } from '$lib/utils/single-hit-dispatch';
+	import { driveSpring } from '$lib/utils/frame-stall.svelte';
 	import { createCounterInput, DRAG_THRESHOLD_PX } from '$lib/utils/counter-input';
 	import { setPieceHover, clearPieceHover, openPieceMenu, openModelMenu } from '$lib/store/pieceUi';
 	import { createDieInput } from '$lib/utils/die-input';
@@ -70,8 +71,13 @@
 	// Entirely derived from this piece's own drag ownership and store state —
 	// see the matching comment on Card's height effect — so a piece that
 	// starts a drag it never actually wins can't stay stuck airborne.
+	//
+	// driveSpring, not `height.target =`, so a starved frame loop lands the
+	// piece at its store height at once instead of leaving it visibly airborne
+	// over the tile it just landed on — where the next press aimed at it hits
+	// the tile instead (tableplace-164).
 	$effect(() => {
-		height.target = isDragging ? PIECE_DRAG_Y : (piece?.position?.[1] ?? REST_Y);
+		driveSpring(height, isDragging ? PIECE_DRAG_Y : (piece?.position?.[1] ?? REST_Y));
 	});
 
 	// Horizontal glide: remote drags only arrive every ~200ms (network throttle),
@@ -84,8 +90,7 @@
 
 	$effect(() => {
 		const [x = 0, , z = 0] = piece?.position ?? [];
-		if (isDragging) planar.set({ x, z }, { instant: true });
-		else planar.target = { x, z };
+		driveSpring(planar, { x, z }, isDragging);
 	});
 
 	const position: [number, number, number] = $derived([

--- a/src/lib/TableScene.svelte
+++ b/src/lib/TableScene.svelte
@@ -23,6 +23,7 @@
 	import { playerColor } from './hud/players';
 	import { clampToTable } from './utils/transforms/drop';
 	import { cancelActiveDrag, commitActiveDrag } from './drop/commit';
+	import { watchFrameStalls } from '$lib/utils/frame-stall.svelte';
 	import { onMount } from 'svelte';
 	import { get } from 'svelte/store';
 	import { CARD_DRAG_Y } from '$lib/utils/constants-cards';
@@ -127,7 +128,13 @@
 	//   read off the pointer event at release so the commit agrees with what
 	//   the indicator was drawing. Blur clears it — alt-tabbing away never
 	//   delivers the keyup.
+	// - and the frame-loop watcher, whose whole job is to notice when frames
+	//   have stopped arriving so the entity springs stop pretending to animate
+	//   (see utils/frame-stall.svelte.ts). Registered here because this is the
+	//   scene those springs belong to; it costs one rAF callback that reads a
+	//   timestamp.
 	onMount(() => {
+		const unwatch = watchFrameStalls();
 		const onPointerUp = (event: PointerEvent) => {
 			setNoSnap(event.altKey);
 			commitActiveDrag();
@@ -144,6 +151,7 @@
 		window.addEventListener('keyup', onKeyUp);
 		window.addEventListener('blur', onBlur);
 		return () => {
+			unwatch();
 			window.removeEventListener('pointerup', onPointerUp);
 			window.removeEventListener('pointercancel', onPointerUp);
 			window.removeEventListener('keydown', onKeyDown);

--- a/src/lib/dev/test-bridge.ts
+++ b/src/lib/dev/test-bridge.ts
@@ -54,6 +54,29 @@ export type TestBridge = {
 	 * kick (jumps toward 1.6) and settle back to 1.
 	 */
 	badge: (id: string) => { scale: number } | null;
+	/**
+	 * Inject artificial main-thread stalls — the long frame gaps a shared CI
+	 * runner, a slow GPU or a backgrounded window produce, made deterministic.
+	 *
+	 * `{ ms: 400, everyMs: 250 }` holds the thread for 400ms, frees it for
+	 * 250ms, repeats; `null` stops it. A busy-wait, not a sleep: what breaks a
+	 * drag is the main thread being *unavailable* — frames stop arriving, the
+	 * springs that draw every entity fall behind the store, and pointer events
+	 * queue up to land against a scene that no longer matches what is on screen
+	 * (see `frame-stall.svelte.ts`). Nothing short of occupying the thread
+	 * reproduces that; `emulateCPUThrottling` does not, because it never
+	 * touches the GPU process, which is what a SwiftShader runner actually
+	 * starves (#157).
+	 *
+	 * Scheduled on a timer rather than per animation frame on purpose: the page
+	 * this has to reproduce a stall on may already be down to 3 fps, and
+	 * "every Nth frame" would then inject three stalls a second by accident of
+	 * the load rather than by the spec's intent.
+	 *
+	 * Returns the number of stalls injected since the last call, so a spec can
+	 * assert the injection really happened rather than trusting that it did.
+	 */
+	stall: (options: { ms: number; everyMs?: number } | null) => number;
 };
 
 /**
@@ -134,6 +157,40 @@ function renderedCentre(scene: THREE.Scene, id: string): THREE.Vector3 | null {
 	const box = bodyBox(object);
 	if (box.isEmpty()) return object.getWorldPosition(new THREE.Vector3());
 	return box.getCenter(new THREE.Vector3());
+}
+
+/**
+ * The stall injector's whole state. Module-level rather than per-install so a
+ * bridge that remounts (an effect re-run) cannot leave a second busy-waiting
+ * timer running behind the first.
+ */
+let stallOptions: { ms: number; everyMs: number } | null = null;
+let stallCount = 0;
+let stallLoop: ReturnType<typeof setTimeout> | null = null;
+
+function setStall(options: { ms: number; everyMs?: number } | null): number {
+	const injected = stallCount;
+	stallCount = 0;
+	stallOptions = options ? { ms: options.ms, everyMs: Math.max(0, options.everyMs ?? 0) } : null;
+	if (stallLoop) clearTimeout(stallLoop);
+	stallLoop = null;
+	if (!stallOptions) return injected;
+
+	const tick = () => {
+		const current = stallOptions;
+		if (!current) return;
+		stallCount++;
+		// deliberately a spin, not a sleep: only occupying the thread stops the
+		// frames and queues the pointer events behind it, which is the condition
+		// under test
+		const until = performance.now() + current.ms;
+		while (performance.now() < until) {
+			/* hold the main thread */
+		}
+		stallLoop = setTimeout(tick, current.everyMs);
+	};
+	stallLoop = setTimeout(tick, stallOptions.everyMs);
+	return injected;
 }
 
 export function installTestBridge(handles: SceneHandles): void {
@@ -236,10 +293,12 @@ export function installTestBridge(handles: SceneHandles): void {
 				if (!group && node.userData.badge) group = node;
 			});
 			return group ? { scale: (group as THREE.Object3D).scale.x } : null;
-		}
+		},
+		stall: setStall
 	};
 }
 
 export function removeTestBridge(): void {
+	setStall(null);
 	delete window.__tableplace;
 }

--- a/src/lib/utils/__tests__/frame-stall.test.ts
+++ b/src/lib/utils/__tests__/frame-stall.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { driveSpring, framesAreStalling, noteFrame, resetFrameStalls } from '../frame-stall.svelte';
+
+/**
+ * The rule these pin down: a starved frame loop turns every positional spring
+ * into a teleport, because a spring that cannot be integrated smoothly is not
+ * smoothing anything — it is only drawing entities where they are not, which is
+ * what let a press meant for a token grab the tile underneath it (#157/#159).
+ */
+
+/** the shape driveSpring actually needs from svelte's Spring */
+function fakeSpring(value: number) {
+	return {
+		target: value,
+		current: value,
+		instantSets: 0,
+		set(next: number, options?: { instant?: boolean }) {
+			if (options?.instant) {
+				this.instantSets++;
+				this.current = next;
+			}
+			this.target = next;
+			return Promise.resolve();
+		}
+	};
+}
+
+describe('frame-stall', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		resetFrameStalls();
+	});
+	afterEach(() => {
+		resetFrameStalls();
+		vi.useRealTimers();
+	});
+
+	it('treats an ordinary frame rate as healthy', () => {
+		for (let frame = 0; frame < 30; frame++) noteFrame(frame * 16.7);
+		expect(framesAreStalling()).toBe(false);
+	});
+
+	it('is not fooled by a 20fps client — that is slow, not stalled', () => {
+		for (let frame = 0; frame < 20; frame++) noteFrame(frame * 50);
+		expect(framesAreStalling()).toBe(false);
+	});
+
+	it('calls one long gap a stall', () => {
+		noteFrame(0);
+		noteFrame(16);
+		noteFrame(900); // the shader-recompile storm, or a backgrounded tab
+		expect(framesAreStalling()).toBe(true);
+	});
+
+	it('ignores the very first frame, which has no gap to measure', () => {
+		noteFrame(9_999_999);
+		expect(framesAreStalling()).toBe(false);
+	});
+
+	it('keeps smoothing off until frames have stayed healthy for a while', () => {
+		noteFrame(0);
+		noteFrame(900);
+		expect(framesAreStalling()).toBe(true);
+
+		vi.advanceTimersByTime(500);
+		expect(framesAreStalling()).toBe(true); // a storm's next gap is still coming
+
+		vi.advanceTimersByTime(600);
+		expect(framesAreStalling()).toBe(false);
+	});
+
+	it('re-arms recovery on every fresh stall, so a storm never flickers back', () => {
+		noteFrame(0);
+		noteFrame(900);
+		vi.advanceTimersByTime(800);
+		noteFrame(2000); // another long one, just before recovery would have fired
+		vi.advanceTimersByTime(500);
+		expect(framesAreStalling()).toBe(true);
+	});
+
+	it('springs smoothly while frames are healthy', () => {
+		const spring = fakeSpring(0);
+		driveSpring(spring, 5);
+		expect(spring.target).toBe(5);
+		expect(spring.instantSets).toBe(0);
+	});
+
+	it('snaps to the target while frames are stalling', () => {
+		noteFrame(0);
+		noteFrame(900);
+		const spring = fakeSpring(0);
+		driveSpring(spring, 5);
+		expect(spring.instantSets).toBe(1);
+		expect(spring.current).toBe(5);
+	});
+
+	it('honours an explicit instant even when frames are fine — a local drag', () => {
+		const spring = fakeSpring(0);
+		driveSpring(spring, 5, true);
+		expect(spring.instantSets).toBe(1);
+	});
+});

--- a/src/lib/utils/frame-stall.svelte.ts
+++ b/src/lib/utils/frame-stall.svelte.ts
@@ -1,0 +1,133 @@
+/**
+ * Frame-loop health — and the one thing the table does about it.
+ *
+ * Every entity on the table is drawn through springs: the store holds where a
+ * card/deck/piece IS, the spring holds where it is currently DRAWN, and the
+ * two agree a few hundred milliseconds after any move. That gap is the whole
+ * point of the springs (a remote drag arrives at 5 Hz and would otherwise
+ * teleport), and it is harmless as long as frames are cheap.
+ *
+ * It stops being harmless when frames are not. A pointer press aims at where
+ * an entity is DRAWN and is dispatched against wherever the scene has got to
+ * when the main thread frees up; svelte's springs clamp their own integration
+ * to 1/30s per tick, so on a page running at 3 fps they advance in *slow
+ * motion* — an entity can still be visibly airborne seconds after it landed in
+ * the store, and a press aimed at it lands somewhere else entirely. That is
+ * the queued-pointer race behind #157/#159: a press meant for a token grabbed
+ * the raised tile underneath it and dragged the tile away.
+ *
+ * So: when frames stop arriving, stop animating. A spring that cannot be
+ * integrated smoothly is not smoothing anything — it is only lying about where
+ * things are. Snapping to the store position costs a little polish in exactly
+ * the conditions where there was no polish to be had (a starved GPU, a
+ * throttled background tab, a shader-recompile storm) and buys back the one
+ * invariant that matters for input: what you see is what you can grab.
+ *
+ * Frames are watched here rather than through Threlte's task scheduler because
+ * this is about the *browser's* animation frames — the same clock svelte's
+ * springs integrate on — and it must keep answering even when the render loop
+ * is the thing that stopped. A hidden tab, whose rAF is suspended entirely,
+ * comes back with one enormous gap and is caught by the same rule.
+ */
+
+/** a frame gap past this is not a frame rate any more, it is a stall */
+const STALL_MS = 120;
+
+/**
+ * How long after the last long frame smoothing stays off. Long enough to span
+ * the gaps *between* stalls in a storm (a runner that produced one 400ms frame
+ * is about to produce another), short enough that a single hiccup doesn't cost
+ * a second of animation.
+ */
+const RECOVERY_MS = 900;
+
+let stalling = $state(false);
+let recovery: ReturnType<typeof setTimeout> | null = null;
+let watchers = 0;
+let loop = 0;
+/** -1 until the first frame: a rAF timestamp of 0 is a real timestamp */
+let previousFrame = -1;
+
+/**
+ * Whether the frame loop is currently too starved to animate through.
+ *
+ * Reactive: reading this inside an effect re-runs that effect when a stall
+ * starts, which is what lets a spring already in flight snap to its target
+ * instead of finishing its descent in slow motion under a press.
+ */
+export function framesAreStalling(): boolean {
+	return stalling;
+}
+
+/**
+ * Feed the watcher a frame timestamp. Exported for the unit tests, which have
+ * no rAF to drive it with; the app calls it from `watchFrameStalls`.
+ */
+export function noteFrame(now: number): void {
+	const first = previousFrame < 0;
+	const gap = now - previousFrame;
+	previousFrame = now;
+	if (first || gap <= STALL_MS) return;
+	stalling = true;
+	if (recovery) clearTimeout(recovery);
+	recovery = setTimeout(() => {
+		recovery = null;
+		stalling = false;
+	}, RECOVERY_MS);
+}
+
+/**
+ * Start watching animation frames; returns the stop function. Reference
+ * counted, so two scenes mounting at once share one rAF loop and the last one
+ * to leave turns it off.
+ */
+export function watchFrameStalls(): () => void {
+	watchers++;
+	if (watchers === 1) {
+		previousFrame = -1;
+		const tick = (now: number) => {
+			loop = requestAnimationFrame(tick);
+			noteFrame(now);
+		};
+		loop = requestAnimationFrame(tick);
+	}
+	let stopped = false;
+	return () => {
+		if (stopped) return;
+		stopped = true;
+		watchers--;
+		if (watchers > 0) return;
+		cancelAnimationFrame(loop);
+		loop = 0;
+		resetFrameStalls();
+	};
+}
+
+/**
+ * Point a spring at `value` — smoothly when frames allow it, instantly when
+ * they do not (or when the caller already wanted it instant, as a local drag
+ * does: a spring between the pointer and the thing it is holding reads as
+ * input lag).
+ *
+ * Every entity that is drawn through a spring AND can be pointed at goes
+ * through here, because "drawn where the store says" is what makes a press
+ * land on the thing it was aimed at. Purely decorative springs — a counter's
+ * value pulse, a deck's shuffle wiggle — deliberately do not: they move
+ * nothing a pointer can miss.
+ */
+export function driveSpring<T>(
+	spring: { set: (value: T, options?: { instant?: boolean }) => unknown; target: T },
+	value: T,
+	instant = false
+): void {
+	if (instant || framesAreStalling()) spring.set(value, { instant: true });
+	else spring.target = value;
+}
+
+/** Drop all stall state — unmount, and the unit tests' `beforeEach`. */
+export function resetFrameStalls(): void {
+	if (recovery) clearTimeout(recovery);
+	recovery = null;
+	stalling = false;
+	previousFrame = -1;
+}


### PR DESCRIPTION
Task: tableplace-164
Closes #164

## The race, reproduced before anything was fixed

A press aims at where an entity is **drawn** and is dispatched against whatever
the scene has become when the main thread frees up. Svelte's springs clamp their
own integration to 1/30s per tick, so on a starved page they advance in *slow
motion*: an entity is still visibly airborne seconds after it landed in the
store. And the specific geometry that made this bite — a token still rising onto
a raised tile is **under that tile's top surface**, so the pixel the token draws
at belongs to the tile. Press there and you drag the tile away.

That is the failure #157 and #159 both hit, at the same landing to the
millimetre.

**Reproduced deliberately first**, with a new DEV-only hook —
`__tableplace.stall({ ms, everyMs })` holds the page's main thread on a duty
cycle. Tuned, not guessed: the gap has to outlast the harness's own settles
(400ms drag tail + 900ms) so an entity is still mid-flight when the next press
aims at it, and the free window has to be about one frame wide, because a wider
one lets a whole flight finish in a single catch-up and there is nothing left to
race. At `{ ms: 800, everyMs: 20 }`, on the pre-fix build:

```
tile  [-4, 0.16, 1] → [6.002425109175663, 0.335, 1.000404258468055]
```

CI's exact failing XZ. The retry then drops the token onto the relocated tile,
which is where `y ≈ 1.81` in the CI reports comes from.

Also confirmed along the way: `Raycaster` never updates world matrices, so
dispatch always sees the **last rendered** pose — the divergence is real, not an
artifact of how the harness aims.

## The fix

When frames stop arriving, stop animating. `utils/frame-stall.svelte.ts` watches
animation frames; a gap over 120ms means the loop is not a frame *rate* any
more, and smoothing stays off until frames have been healthy for 900ms.
`driveSpring` then puts every **positional** spring on `Card`, `Deck` and
`Piece` at its store position instantly instead of gliding there.

A spring that cannot be integrated smoothly is not smoothing anything — it is
only drawing entities where they are not. The cost is a little polish in exactly
the conditions where there was no polish to be had (a starved GPU, a
shader-recompile storm, a throttled tab); what it buys back is the invariant
input depends on: what you see is what you can grab.

- Decorative springs are deliberately left alone (the counter's value pulse, the
  deck's shuffle wiggle): they move nothing a pointer can miss.
- The single `interactivity()` context is untouched — the #86 guard test stays
  green.
- Falls out for free: a hidden tab's suspended rAF comes back as one enormous
  gap and is caught by the same rule (relevant to #165).

## Proof

1. **With stalls injected** — new spec `frame stalls: a drag survives long frame
   gaps`. It asserts the invariant *directly* (an entity's own pixel must belong
   to that entity, checked with **no settle in front of it**, in the window the
   race lives in), plus the tile-never-moved fingerprint, the felt-return
   heights, and that the injector actually ran. Red without the fix:
   > just after the token was dropped on the raised tile, the pixel
   > `piece:…:token-0` is DRAWN at belongs to `piece:…:raised-0` — a press aimed
   > at it would grab that instead
   Green with it.
2. **Without injection** — full suite green (17/17), `model surface` included.
   No existing spec's waits or assertions were touched.
3. **PR #157 rebased onto this fix, unchanged** — #166 is that acceptance run,
   and its `render` job **passed** (17m37s) against the 3/3 failures that head
   was getting. Both of #157's commits replayed clean and are byte-identical to
   the originals; #157's own branch was not touched.

CI on this PR: `render` green, 17/17 specs including the new one; `test` green.

Unit tests: 872 green (9 new, pinning the stall threshold, the recovery window,
the storm re-arm, and snap-vs-smooth). `bun run check` 0 errors. Changed files
pass prettier + eslint (repo lint is red at baseline on unrelated files).

The stall hook stays in the harness as the regression tool for future
per-frame-cost work — documented in AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XX5RaXRi39XdsYXLbfa75p
