### PR TITLE
tableplace-169: intent channel — emit named action verbs alongside state patches

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -183,6 +183,8 @@ Discrete actions and continuous drags have opposite needs, so they ride the same
 
 In `local` mode both tiers collapse to direct store application. The 200ms client-side drag throttle from the legacy server is retired in `ws-v2` — the ephemeral tier exists precisely so drags can run at full rate.
 
+**Intent channel (shipped, `legacy-ws`).** Until an action protocol exists, the verb behind each patch rides *with* it: an `update` message's `value` may carry a reserved `__intents` array of `{seq, seat, verb, args}`, minted by the acting client (`store/game/intents.ts`) and published to `onIntent` observers on both the local and inbound apply paths. `seq` counts per actor and is never renumbered on arrival, so every client's stream is identical. Piggybacked rather than sent separately so the relay's 7 msg/s limit is spent once, and inside `value` because the relay carries that as an opaque `json.RawMessage` — no relay change, and none of it is game state: every client strips `__intents` before merging, and a `sync` snapshot's copy is discarded rather than replayed. It is a readout only — no validation, no ordering authority. That is what the action protocol above is for.
+
 ## 4d. Game packs — the content system
 
 A **pack** is a named, serializable definition of a game's contents — how many decks, what each is composed of, tokens, board — decoupled from any live game state. Everything that puts objects on the table goes through a pack:

--- a/e2e/specs.ts
+++ b/e2e/specs.ts
@@ -18,7 +18,7 @@ import type { Browser } from 'puppeteer-core';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { ok, planarDistance } from './assert';
 import type { Servers } from './servers';
-import { openTable, type Table } from './table';
+import { openTable, type Intent, type Table } from './table';
 
 export type Spec = {
 	name: string;
@@ -1934,5 +1934,147 @@ export const SPECS: Spec[] = [
 				assertClean(table, 'at the end of the mixed table');
 				await table.snap('mixed');
 			})
+	},
+	{
+		/**
+		 * The intent channel (tableplace-169): every named action has to reach
+		 * BOTH clients, in the same order, carrying the same `{seq, seat, verb,
+		 * args}` — the patch alone was never enough to say what happened.
+		 *
+		 * Two browser contexts, not two tabs: tabs share localStorage and would
+		 * therefore share `myPlayerId`, which makes them one player the relay
+		 * excludes from its own broadcast (see `TableOptions.isolated`). The
+		 * gesture list is deliberately mixed — a mouse drag whose patch goes
+		 * through the position throttle, two immediate deck verbs, and one action
+		 * from the *other* client, because an observer wired to only one of the
+		 * two apply paths is blind to half the game.
+		 */
+		name: 'intents: two clients see the same verbs in the same order',
+		run: async (context) => {
+			const lobby = nextLobby('intents');
+			const host = await openTable(context.browser, context.servers, lobby);
+			try {
+				const deck = await host.seedDeck();
+				const token = await host.spawn('token', { name: 'Scout', position: LANE(1) });
+				await host.settle(1200);
+
+				const guest = await openTable(context.browser, context.servers, lobby, {
+					isolated: true
+				});
+				try {
+					await guest.settle(1500); // join, sync, prewarm the seeded deck's faces
+					// the guest acts on the token below, so it has to have arrived —
+					// a fixed sleep here would read a slow sync as a lost intent
+					ok(
+						await eventually(
+							() => guest.positionOf(token),
+							(position) => !!position
+						),
+						'the seeded token never reached the second client — nothing to act on'
+					);
+					const seats = await Promise.all([
+						host.page.evaluate(() => window.__tableplace!.actions.getMyId() ?? ''),
+						guest.page.evaluate(() => window.__tableplace!.actions.getMyId() ?? '')
+					]);
+					ok(
+						seats[0] && seats[1] && seats[0] !== seats[1],
+						`the two clients are the same player (${seats[0]} / ${seats[1]}) — ` +
+							`the relay excludes a sender from its own broadcast, so neither would ` +
+							`ever receive the other`
+					);
+
+					// everything up to here is setup — join handshakes, the seeded
+					// deck, seat rows. The comparison is about the scripted gesture.
+					await host.clearIntents();
+					await guest.clearIntents();
+
+					// a card off the top, then flipped: two collections in one patch,
+					// then a rotation-only one
+					const card = await host.page.evaluate((deckId) => {
+						const before = new Set(Object.keys(window.__tableplace!.state()?.cards ?? {}));
+						window.__tableplace!.actions.drawFromTop(deckId, 1);
+						return (
+							Object.keys(window.__tableplace!.state()?.cards ?? {}).find(
+								(id) => !before.has(id)
+							) ?? ''
+						);
+					}, deck);
+					ok(card, 'drawFromTop put no new card on the table to flip');
+					await host.settle(500);
+					await host.page.evaluate((id) => window.__tableplace!.actions.flipCard(id), card);
+					await host.settle(500);
+					await host.page.evaluate((id) => window.__tableplace!.actions.shuffleDeck(id), deck);
+					await host.settle(500);
+					// a real mouse drag: its landing patch carries a position, so it
+					// goes through the 200ms coalescing throttle on its way out
+					await host.dragBy(token, 0, 130);
+					await host.settle(900);
+					// and one from the other side, so this is not a one-way street
+					await guest.page.evaluate(
+						(id) => window.__tableplace!.actions.rotatePiece(id, 90),
+						token
+					);
+					await guest.settle(900);
+
+					const EXPECTED = ['drawFromTop', 'flipCard', 'shuffleDeck', 'moveEntity', 'rotatePiece'];
+					const key = (intents: Intent[]) =>
+						JSON.stringify(intents.map((i) => [i.seat, i.seq, i.verb, i.args]));
+
+					let hostSaw: Intent[] = [];
+					let guestSaw: Intent[] = [];
+					await eventually(
+						async () => {
+							[hostSaw, guestSaw] = await Promise.all([host.intents(), guest.intents()]);
+							return hostSaw.length >= EXPECTED.length && key(hostSaw) === key(guestSaw);
+						},
+						(matched) => matched,
+						12_000
+					);
+
+					ok(
+						key(hostSaw) === key(guestSaw),
+						`the two clients disagree about what happened:\n  host  ${key(hostSaw)}\n  guest ${key(guestSaw)}`
+					);
+					ok(
+						JSON.stringify(hostSaw.map((i) => i.verb)) === JSON.stringify(EXPECTED),
+						`the scripted gesture did not read as ${JSON.stringify(EXPECTED)}: ` +
+							`${JSON.stringify(hostSaw.map((i) => i.verb))}`
+					);
+					// the verb is only half of it — an engine needs what it was aimed at
+					ok(
+						hostSaw[1]?.args?.[0] === card && hostSaw[2]?.args?.[0] === deck,
+						`the arguments did not survive the wire: ${JSON.stringify(hostSaw.slice(1, 3))}`
+					);
+					// four from the host, the last from the guest — and numbered by
+					// whoever acted, on their own counter, rather than renumbered on
+					// arrival (which is what lets both clients agree on the list at all)
+					const hostSeqs = hostSaw.slice(0, 4).map((i) => i.seq);
+					ok(
+						hostSaw.slice(0, 4).every((i) => i.seat === seats[0]) &&
+							hostSeqs.every((seq, n) => n === 0 || seq > hostSeqs[n - 1]!) &&
+							hostSaw[4]?.seat === seats[1],
+						`the intents are not attributed to the seat that acted: ` +
+							`${JSON.stringify(hostSaw.map((i) => [i.seat, i.seq]))}`
+					);
+					// and none of it leaked into game state on either client
+					const leaked = await Promise.all(
+						[host, guest].map((table) =>
+							table.page.evaluate(() => Object.keys(window.__tableplace!.state() ?? {}))
+						)
+					);
+					ok(
+						!leaked.flat().includes('__intents'),
+						`the piggybacked intents were merged into game state: ${JSON.stringify(leaked)}`
+					);
+
+					assertClean(host, 'on the acting client after the scripted gesture');
+					assertClean(guest, 'on the watching client after the scripted gesture');
+				} finally {
+					await guest.close();
+				}
+			} finally {
+				await host.close();
+			}
+		}
 	}
 ];

--- a/e2e/table.ts
+++ b/e2e/table.ts
@@ -18,6 +18,7 @@ import type { Servers } from './servers';
 
 export type Problem = { kind: 'console' | 'pageerror' | 'requestfailed'; text: string };
 export type ScreenPoint = { x: number; y: number };
+export type Intent = { seq: number; seat: string; verb: string; args: unknown[] };
 
 export type Table = {
 	page: Page;
@@ -52,6 +53,14 @@ export type Table = {
 	cameraPose: () => Promise<{ position: number[]; direction: number[] } | null>;
 	/** is the lobby socket still open (the relay drops rate-limit offenders) */
 	connected: () => Promise<boolean>;
+	/**
+	 * The named actions this client has seen, its own and its peers', oldest
+	 * first — the intent channel (tableplace-169). `{seq, seat}` is stamped by
+	 * whoever acted, so two clients in one lobby must report identical lists.
+	 */
+	intents: () => Promise<Intent[]>;
+	/** drop the log, so a spec compares only the gesture it is about to make */
+	clearIntents: () => Promise<void>;
 	/** how an entity is rendered right now; null if it never mounted */
 	describe: (
 		id: string
@@ -109,8 +118,29 @@ function ignorable(text: string): boolean {
 const SUITS = ['S', 'H', 'D', 'C'];
 const RANKS = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
 
-export async function openTable(browser: Browser, servers: Servers, lobby: string): Promise<Table> {
-	const page = await browser.newPage();
+export type TableOptions = {
+	/**
+	 * Open in a browser context of its own — a genuinely SECOND player.
+	 *
+	 * Every page in one browser shares an origin and therefore shares
+	 * localStorage, including the `myPlayerId` the app rolls on first visit. Two
+	 * plain tabs in one lobby are consequently the same player as far as the
+	 * relay is concerned, and the relay excludes a sender from its own broadcast
+	 * — so neither tab ever receives the other's patches, only the merged `sync`
+	 * they get on joining. A spec about live traffic between two clients has to
+	 * separate their storage, which is what a fresh context does.
+	 */
+	isolated?: boolean;
+};
+
+export async function openTable(
+	browser: Browser,
+	servers: Servers,
+	lobby: string,
+	options: TableOptions = {}
+): Promise<Table> {
+	const context = options.isolated ? await browser.createBrowserContext() : null;
+	const page = await (context ?? browser).newPage();
 	const problems: Problem[] = [];
 
 	page.on('console', (message: ConsoleMessage) => {
@@ -152,11 +182,16 @@ export async function openTable(browser: Browser, servers: Servers, lobby: strin
 	const url =
 		`${servers.web}/play?lobby=${encodeURIComponent(lobby)}` +
 		`&server=${encodeURIComponent(servers.relay)}`;
-	await page.goto(url, { waitUntil: 'networkidle2', timeout: 60_000 });
+	// A fresh context starts with a cold HTTP cache, so it re-fetches every
+	// unbundled dev module and warms every shader again, alongside a first table
+	// that is already holding a software WebGL context. Give it room rather than
+	// let a slow second client read as a broken one.
+	const readyMs = options.isolated ? 120_000 : 60_000;
+	await page.goto(url, { waitUntil: 'networkidle2', timeout: readyMs });
 
 	// the bridge mounts inside the Canvas, which mounts only once the socket is
 	// open — so waiting on it is also the connection assertion
-	await page.waitForFunction('window.__tableplace?.ready === true', { timeout: 60_000 });
+	await page.waitForFunction('window.__tableplace?.ready === true', { timeout: readyMs });
 
 	const settle = (ms = 700) => sleep(ms);
 	await settle(600);
@@ -258,6 +293,8 @@ export async function openTable(browser: Browser, servers: Servers, lobby: strin
 
 	const cameraPose = () => page.evaluate(() => window.__tableplace!.camera());
 	const connected = () => page.evaluate(() => window.__tableplace!.connected());
+	const intents = () => page.evaluate(() => window.__tableplace!.intents()) as Promise<Intent[]>;
+	const clearIntents = () => page.evaluate(() => window.__tableplace!.clearIntents());
 
 	const positionOf = (id: string) =>
 		page.evaluate((entityId) => {
@@ -501,6 +538,8 @@ export async function openTable(browser: Browser, servers: Servers, lobby: strin
 		openRadial,
 		cameraPose,
 		connected,
+		intents,
+		clearIntents,
 		describe,
 		dragBy,
 		dragTo,
@@ -508,6 +547,9 @@ export async function openTable(browser: Browser, servers: Servers, lobby: strin
 		settle,
 		stall,
 		snap,
-		close: () => page.close()
+		close: async () => {
+			await page.close();
+			await context?.close();
+		}
 	};
 }

--- a/src/lib/dev/test-bridge.ts
+++ b/src/lib/dev/test-bridge.ts
@@ -24,6 +24,7 @@ import { dragStore } from '$lib/store/dragStore.svelte';
 import { gameStore } from '$lib/store/game/gameStore.svelte';
 import { gameActions } from '$lib/store/game/actions';
 import { isWebSocketConnected } from '$lib/websocket/connection';
+import { clearIntentLog, intentLog, type IntentEvent } from '$lib/store/game/intents';
 import type { GameDTO } from '$lib/store/game/types';
 
 export type ScreenPoint = { x: number; y: number };
@@ -61,6 +62,15 @@ export type TestBridge = {
 	 * streaming a pose per frame.
 	 */
 	connected: () => boolean;
+	/**
+	 * Every named action this client has seen — its own and its peers' — oldest
+	 * first (tableplace-169). Two clients in one lobby must agree on this list
+	 * exactly, which is the only way to prove the verb survived the wire rather
+	 * than only the patch it caused.
+	 */
+	intents: () => IntentEvent[];
+	/** forget the log, so a spec can bracket one gesture and compare just that */
+	clearIntents: () => void;
 	/** what an entity is actually made of — null if it never mounted at all */
 	describe: (id: string) => EntityShape | null;
 	/**
@@ -277,6 +287,8 @@ export function installTestBridge(handles: SceneHandles): void {
 			return { isDragging, isHovered, isBagHovered, isDeckHovered };
 		},
 		connected: () => isWebSocketConnected(),
+		intents: () => intentLog(),
+		clearIntents: () => clearIntentLog(),
 		camera: () => {
 			const camera = handles.camera();
 			if (!camera) return null;

--- a/src/lib/drop/commit.ts
+++ b/src/lib/drop/commit.ts
@@ -2,6 +2,7 @@ import { get } from 'svelte/store';
 import { dragEnd, dragStore } from '$lib/store/dragStore.svelte';
 import { gameStore } from '$lib/store/game/gameStore.svelte';
 import { gameActions } from '$lib/store/game/actions';
+import { withIntent } from '$lib/store/game/intents';
 import { tableFeatures } from '$lib/store/tableFeatures';
 import { modelSurfaceYAt } from '$lib/models/surface';
 import { resolveDrop, type DropTarget } from '$lib/utils/transforms/drop';
@@ -51,16 +52,32 @@ export function commitActiveDrag() {
 		// client between the preview and this release) — then the entity has to
 		// land somewhere rather than stay floating at drag height
 		if (!gameActions.returnToBag(drop.targetId, id)) commitActiveDragAtRest(id);
-	} else if (drop && id.startsWith('piece:')) {
-		gameStore.updateState({ pieces: { [id]: dropPatch(drop) } });
-	} else if (drop && id.startsWith('deck:')) {
-		gameStore.updateState({ decks: { [id]: dropPatch(drop) } });
 	} else if (drop) {
-		gameStore.updateState({ cards: { [id]: dropPatch(drop) } });
+		land(id, dropPatch(drop));
 	}
 
 	dragEnd();
 }
+
+/** What a landing writes: position, and rotation when the drop turned it. */
+type Landing = { position: [number, number, number]; rotation?: [number, number, number] };
+
+/**
+ * A landing on plain felt — the one branch of a release with no `gameActions`
+ * verb behind it. Named for the intent channel (tableplace-169) so a drag reads
+ * as `moveEntity` in a game log rather than as an anonymous position patch; the
+ * tray / deck / bag landings above already carry verbs of their own.
+ *
+ * The per-frame positions a drag streams while it is in flight are deliberately
+ * NOT named: they go straight to `gameStore.updateState` from TableScene, and a
+ * verb per pointer move is a flood, not a log. Only where it comes to rest is
+ * an intent.
+ */
+const land = withIntent('moveEntity', (id: string, patch: Landing) => {
+	if (id.startsWith('piece:')) gameStore.updateState({ pieces: { [id]: patch } });
+	else if (id.startsWith('deck:')) gameStore.updateState({ decks: { [id]: patch } });
+	else gameStore.updateState({ cards: { [id]: patch } });
+});
 
 /**
  * The state patch a landing writes. Position always; rotation only when the
@@ -68,10 +85,7 @@ export function commitActiveDrag() {
  * other kind resolves the rotation the entity already has, and re-sending it
  * would put an unchanged field on the wire on every single drop.
  */
-function dropPatch(drop: DropTarget): {
-	position: [number, number, number];
-	rotation?: [number, number, number];
-} {
+function dropPatch(drop: DropTarget): Landing {
 	return drop.snap?.rotation !== undefined
 		? { position: drop.position, rotation: drop.rotation }
 		: { position: drop.position };
@@ -93,18 +107,13 @@ export function cancelActiveDrag() {
 		return;
 	}
 
-	if (id.startsWith('piece:')) gameStore.updateState({ pieces: { [id]: { position: origin } } });
-	else if (id.startsWith('deck:')) gameStore.updateState({ decks: { [id]: { position: origin } } });
-	else gameStore.updateState({ cards: { [id]: { position: origin } } });
+	land(id, { position: origin });
 
 	dragEnd();
 }
 
 function commitActiveDragAtRest(id: string) {
 	const drop = resolveDrop(get(gameStore), id, null, {}, { surfaceYAt: modelSurfaceYAt(id) });
-	if (drop && id.startsWith('piece:')) gameStore.updateState({ pieces: { [id]: dropPatch(drop) } });
-	else if (drop && id.startsWith('deck:'))
-		gameStore.updateState({ decks: { [id]: dropPatch(drop) } });
-	else if (drop) gameStore.updateState({ cards: { [id]: dropPatch(drop) } });
+	if (drop) land(id, dropPatch(drop));
 	dragEnd();
 }

--- a/src/lib/store/__tests__/intents.test.ts
+++ b/src/lib/store/__tests__/intents.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { gameActions } from '$lib/store/game/actions';
+import {
+	clearIntentLog,
+	intentLog,
+	onIntent,
+	withIntent,
+	withoutIntents,
+	type IntentEvent
+} from '$lib/store/game/intents';
+
+/**
+ * The intent channel (tableplace-169) as seen from the store: a named verb
+ * beside every patch, on the local path AND the inbound one, and nothing of it
+ * ever landing in game state.
+ *
+ * The wire half — the piggyback and its coalescing — is covered next door in
+ * `websocket/__tests__/intent-wire.test.ts`; here there is no websocket wrapper
+ * installed at all, which is itself the assertion that the channel does not
+ * depend on one (an offline table still writes a legible log).
+ */
+
+const CARD = 'card:std:AS';
+
+/**
+ * A fresh pair of identities per test. The replay guard is per-actor and
+ * deliberately outlives `clearIntentLog` — forgetting the log must not make the
+ * channel accept history it has already seen — so tests take new seats rather
+ * than reaching for a reset the app would never call.
+ */
+let run = 0;
+const me = () => `tester-${run}`;
+const peer = () => `peer-${run}`;
+
+function remote(intents: IntentEvent[], state: Record<string, unknown> = {}) {
+	return { ...state, __intents: intents } as Parameters<typeof gameStore.updateStateSilently>[0];
+}
+
+describe('the intent channel', () => {
+	beforeEach(() => {
+		run++;
+		localStorage.clear();
+		localStorage.setItem('myPlayerId', me());
+		gameStore.set({
+			players: {},
+			decks: {},
+			cards: { [CARD]: { faceImageUrl: 'gen:std52/AS', rotation: [0, 0, 0], position: [0, 0, 0] } }
+		});
+		clearIntentLog();
+	});
+
+	it('names the verb and its arguments when an action patches state', () => {
+		gameActions.flipCard(CARD);
+
+		const [intent, ...rest] = intentLog();
+		expect(rest).toEqual([]);
+		expect(intent?.verb).toBe('flipCard');
+		expect(intent?.args).toEqual([CARD]);
+		expect(intent?.seat).toBe(me());
+	});
+
+	it('says nothing for a verb that only reads', () => {
+		gameActions.getCardState(CARD);
+		gameActions.getMe();
+		gameActions.getDeckLength('deck:none');
+		expect(intentLog()).toEqual([]);
+	});
+
+	it('numbers an actor monotonically, so nobody has to renumber on arrival', () => {
+		gameActions.flipCard(CARD);
+		gameActions.tapCard(false, CARD);
+		expect(intentLog().map((i) => i.seq)).toEqual([1, 2]);
+	});
+
+	it('mints once per action, under the verb the player asked for', () => {
+		// a verb built out of other verbs is still one thing the player did —
+		// `commitActiveDrag`'s tray/deck landings are exactly this shape
+		const putAway = withIntent('putAway', (id: string) => {
+			gameActions.flipCard(id);
+			gameActions.tapCard(false, id);
+		});
+		putAway(CARD);
+
+		expect(intentLog().map((i) => i.verb)).toEqual(['putAway']);
+	});
+
+	it('summarises an argument too big to be worth putting on the wire', () => {
+		gameActions.addPlayer(me());
+		clearIntentLog();
+		gameActions.addDeck({
+			cards: Array.from({ length: 52 }, (_, index) => ({
+				id: `card:bulk:${index}`,
+				faceImageUrl: 'gen:std52/AS'
+			}))
+		});
+
+		// the cards are already in the patch — repeating them here would double
+		// every deck spawn on the wire
+		expect(intentLog()[0]?.verb).toBe('addDeck');
+		expect(intentLog()[0]?.args[0]).toMatchObject({ elided: true });
+	});
+
+	it('publishes a peer’s intents from the patch they rode in on', () => {
+		const seen: IntentEvent[] = [];
+		const off = onIntent((intent) => void seen.push(intent));
+
+		gameStore.updateStateSilently(
+			remote([{ seq: 1, seat: peer(), verb: 'shuffleDeck', args: ['deck:peer:0'] }], {
+				decks: { 'deck:peer:0': { id: 'deck:peer:0', cards: [] } }
+			})
+		);
+		off();
+
+		expect(seen).toEqual([{ seq: 1, seat: peer(), verb: 'shuffleDeck', args: ['deck:peer:0'] }]);
+		// the patch still applied — this channel is a readout, never a gate
+		expect(get(gameStore).decks?.['deck:peer:0']).toBeTruthy();
+	});
+
+	it('never merges the piggybacked intents into game state', () => {
+		gameStore.updateStateSilently(
+			remote([{ seq: 1, seat: peer(), verb: 'flipCard', args: [CARD] }], {
+				cards: { [CARD]: { rotation: [180, 0, 0] } }
+			})
+		);
+
+		expect(Object.keys(get(gameStore))).not.toContain('__intents');
+		expect(get(gameStore).cards?.[CARD]?.rotation).toEqual([180, 0, 0]);
+	});
+
+	it('drops a replay — the relay hands a joiner back the last batch it merged', () => {
+		const batch = [{ seq: 1, seat: peer(), verb: 'flipCard', args: [CARD] }];
+		gameStore.updateStateSilently(remote(batch));
+		gameStore.updateStateSilently(remote(batch));
+		gameStore.updateStateSilently(remote([{ seq: 2, seat: peer(), verb: 'tapCard', args: [] }]));
+
+		expect(intentLog().map((i) => [i.seat, i.seq])).toEqual([
+			[peer(), 1],
+			[peer(), 2]
+		]);
+	});
+
+	it('ignores anything in the carrier that is not an intent', () => {
+		gameStore.updateStateSilently(
+			remote([{ nonsense: true } as unknown as IntentEvent, ...([] as IntentEvent[])])
+		);
+		expect(intentLog()).toEqual([]);
+	});
+
+	it('strips the carrier on demand, for the sync snapshot', () => {
+		const snapshot = { cards: {}, __intents: [{ seq: 9, seat: peer(), verb: 'x', args: [] }] };
+		expect(withoutIntents(snapshot)).toEqual({ cards: {} });
+	});
+});

--- a/src/lib/store/game/actions/index.ts
+++ b/src/lib/store/game/actions/index.ts
@@ -5,8 +5,15 @@ import { trayActions } from './tray';
 import { pieceActions } from './piece';
 import { snapActions } from './snap';
 import { bagActions } from './bag';
+import { withIntents } from '../intents';
 
-export const gameActions = {
+/**
+ * `withIntents` names every verb on the bag for the intent channel
+ * (tableplace-169). It changes no behaviour: the wrapper only marks which verb
+ * is running, and an event is minted at the patch seam — so the read-only verbs
+ * here (`getMe`, `getDeckLength`, `bagCount`, …) emit nothing at all.
+ */
+export const gameActions = withIntents({
 	...cardActions,
 	...deckActions,
 	...playerActions,
@@ -14,4 +21,4 @@ export const gameActions = {
 	...pieceActions,
 	...snapActions,
 	...bagActions
-};
+});

--- a/src/lib/store/game/gameStore.svelte.ts
+++ b/src/lib/store/game/gameStore.svelte.ts
@@ -1,6 +1,7 @@
 import { writable } from 'svelte/store';
 import type { GameDTO } from './types';
 import { merge } from '../transform-helpers';
+import { mintIntent, receiveIntents, splitIntents } from './intents';
 
 const initGameState = {
 	players: {},
@@ -73,7 +74,7 @@ type PartialWithNull<T> = {
 		: T[P] | null;
 };
 
-function updateState(update: PartialWithNull<GameDTO>) {
+function applyPatch(update: PartialWithNull<GameDTO>) {
 	const paths = findNullPaths(update);
 
 	game.update((state) => {
@@ -92,10 +93,36 @@ function updateState(update: PartialWithNull<GameDTO>) {
 	});
 }
 
+/**
+ * A local mutation. Naming what just happened (tableplace-169) happens HERE
+ * rather than in the action wrapper, so a verb that only reads — `getMe`,
+ * `getDeckLength` — stays silent without anything having to list them: no
+ * patch, no intent. `mintIntent` is idempotent per action call, so the
+ * websocket wrapper minting first (to put the event on the wire) leaves this
+ * one a no-op rather than a second event.
+ */
+function updateState(update: PartialWithNull<GameDTO>) {
+	mintIntent();
+	applyPatch(update);
+}
+
+/**
+ * An inbound mutation, applied without rebroadcasting it. Anything the sender
+ * piggybacked on the patch is peeled off and published to the intent observers
+ * before the merge — the intents are not game state and must never reach the
+ * store — which is what makes an observer on this client see the whole table
+ * instead of only its own half.
+ */
+function updateStateSilently(update: PartialWithNull<GameDTO>) {
+	const { state, intents } = splitIntents(update);
+	receiveIntents(intents);
+	applyPatch(state);
+}
+
 export const gameStore = {
 	...game,
 	// NOTE: wrapped in storeIntegration.ts to broadcast messages
 	updateState,
 	// NOTE: silent used in websocket/index.ts to sync received messages without rebroadcasting
-	updateStateSilently: updateState
+	updateStateSilently
 };

--- a/src/lib/store/game/intents.ts
+++ b/src/lib/store/game/intents.ts
@@ -1,0 +1,249 @@
+/**
+ * The intent channel (tableplace-169).
+ *
+ * The wire carries LWW JSON patches — "card x rotation became 180". That is
+ * enough to draw a table and hopeless to reason about: a rules engine, a game
+ * log, a replay and an undo stack all want the *verb* ("flipCard"), which today
+ * dies at the `gameActions` function boundary. This module keeps the verb alive
+ * beside the patch. It limits nothing and knows no rules.
+ *
+ * How it hangs together:
+ *
+ *  - `withIntents` wraps every function on the actions bag, so a call puts a
+ *    named frame on a stack for the duration of its body;
+ *  - `mintIntent()` is called at the patch seam (`gameStore.updateState`, and
+ *    ahead of it in the websocket wrapper). It mints AT MOST ONE event per
+ *    action call, and only when a patch is actually produced — which is what
+ *    keeps the read-only verbs on the bag (`getMe`, `getDeckLength`, …) silent
+ *    without needing a list of them anywhere;
+ *  - the minted event rides the outgoing patch message under `__intents`
+ *    (see `attachIntents`), so the relay's rate limit is not consumed twice and
+ *    the Go relay needs no change: `value` is a `json.RawMessage` it rebroadcasts
+ *    verbatim;
+ *  - `splitIntents` peels it back off on the receiving client, which publishes
+ *    it through the same bus its own actions publish through. An observer hooked
+ *    to `onIntent` therefore sees the whole table, not only its own half.
+ *
+ * `seq` is assigned by the client that acted and counts per actor, so an event
+ * is identical on every client that sees it — nobody renumbers anything on
+ * arrival. `admit()` uses that to drop replays (the relay merges `__intents`
+ * into lobby state like any other key, so the last batch comes back in a
+ * joiner's `sync` snapshot; see the strip in `websocket/index.ts`).
+ */
+
+/**
+ * Reserved key the intents ride under, inside a patch message's `value`.
+ * Double-underscored because it is NOT game state: every client strips it
+ * before the merge, so it never reaches `GameDTO` and never leaves in an export.
+ */
+export const INTENTS_KEY = '__intents';
+
+export type IntentEvent = {
+	/** monotonic per actor, assigned by the client that acted — never renumbered */
+	seq: number;
+	/**
+	 * The acting seat, identified by its player id. The numeric `PlayerDTO.seat`
+	 * would not do: it defaults to 0 for everyone until a seat is claimed, and
+	 * two actors sharing an identity would collide in `seq`.
+	 */
+	seat: string;
+	/** the `gameActions` verb, or a gesture named explicitly with `withIntent` */
+	verb: string;
+	/** the call's arguments, JSON-reduced (see `reduceArgs`) */
+	args: unknown[];
+};
+
+export type IntentListener = (intent: IntentEvent) => void;
+
+/** How much of one argument is worth carrying before it is summarised instead. */
+const MAX_ARG_BYTES = 512;
+
+/** Recent intents kept for the dev bridge / a future game log; oldest dropped. */
+const LOG_LIMIT = 500;
+
+const listeners = new Set<IntentListener>();
+const log: IntentEvent[] = [];
+
+/** highest `seq` admitted per actor — the mint counter and the replay guard in one */
+const lastSeq = new Map<string, number>();
+
+/**
+ * Subscribe to every intent this client sees, local and remote alike, in the
+ * order they were published. Returns the unsubscribe.
+ */
+export function onIntent(listener: IntentListener): () => void {
+	listeners.add(listener);
+	return () => {
+		listeners.delete(listener);
+	};
+}
+
+/** Everything published so far, oldest first (capped at `LOG_LIMIT`). */
+export function intentLog(): IntentEvent[] {
+	return [...log];
+}
+
+/** Forget the log. A spec brackets a gesture with this; nothing in the app calls it. */
+export function clearIntentLog(): void {
+	log.length = 0;
+}
+
+function publish(intent: IntentEvent): void {
+	log.push(intent);
+	if (log.length > LOG_LIMIT) log.splice(0, log.length - LOG_LIMIT);
+	for (const listener of listeners) {
+		try {
+			listener(intent);
+		} catch (error) {
+			// an observer that throws must not take the mutation down with it —
+			// this channel is a readout, never a gate
+			console.error('An intent listener threw:', error);
+		}
+	}
+}
+
+/**
+ * Admit an event once. Returns false for anything at or behind what this actor
+ * has already been seen doing — a `sync` replay, or a duplicate rebroadcast.
+ */
+function admit(intent: IntentEvent): boolean {
+	if ((lastSeq.get(intent.seat) ?? 0) >= intent.seq) return false;
+	lastSeq.set(intent.seat, intent.seq);
+	return true;
+}
+
+/**
+ * The identity the acting client stamps on its own intents — the same id
+ * `playerActions.getMe()` resolves from, read straight out of localStorage
+ * rather than imported so the intent channel has no cycle back through the
+ * actions bag that wraps itself with it.
+ */
+function actingSeat(): string {
+	try {
+		return localStorage.getItem('myPlayerId') ?? 'local';
+	} catch {
+		return 'local';
+	}
+}
+
+/**
+ * One argument, made safe to put on the wire: JSON-reducible values survive
+ * as-is, anything bigger than `MAX_ARG_BYTES` is summarised (a 52-card
+ * `addDeck` payload is already in the patch — repeating it in the intent would
+ * double every deck spawn), and anything unserialisable becomes a marker
+ * instead of throwing inside a mutation.
+ */
+function reduceArg(arg: unknown): unknown {
+	let json: string | undefined;
+	try {
+		json = JSON.stringify(arg);
+	} catch {
+		return { elided: true };
+	}
+	if (json === undefined) return null; // functions, undefined
+	if (json.length > MAX_ARG_BYTES) return { elided: true, bytes: json.length };
+	return JSON.parse(json);
+}
+
+function reduceArgs(args: unknown[]): unknown[] {
+	return args.map(reduceArg);
+}
+
+type Frame = { verb: string; args: unknown[]; minted: IntentEvent | null };
+
+/**
+ * The verbs currently executing. Nested `gameActions` calls (deck.ts reaches
+ * back through the bag) push their own frame, but only frame 0 is ever minted:
+ * the outermost verb is the one the player asked for.
+ */
+const frames: Frame[] = [];
+
+/**
+ * Name what a function does, for the intent channel. Wrapping is inert until
+ * the body actually patches state — see `mintIntent`.
+ */
+export function withIntent<F extends (...args: never[]) => unknown>(verb: string, fn: F): F {
+	return function (this: unknown, ...args: Parameters<F>) {
+		frames.push({ verb, args, minted: null });
+		try {
+			return fn.apply(this, args);
+		} finally {
+			frames.pop();
+		}
+	} as F;
+}
+
+/** `withIntent` across a whole actions bag, keyed by each function's own name. */
+export function withIntents<T extends Record<string, unknown>>(actions: T): T {
+	const named: Record<string, unknown> = {};
+	for (const [verb, value] of Object.entries(actions)) {
+		named[verb] =
+			typeof value === 'function'
+				? withIntent(verb, value as (...args: never[]) => unknown)
+				: value;
+	}
+	return named as T;
+}
+
+/**
+ * Mint the event for the action currently running, or null when there is no
+ * verb in scope (a raw `gameStore.updateState` — the per-frame drag stream, a
+ * scenario load) or when this action has already minted one.
+ *
+ * Idempotent on purpose: the websocket wrapper mints first so the event can
+ * ride the outgoing message, and the store's own call then finds it done.
+ */
+export function mintIntent(): IntentEvent | null {
+	const frame = frames[0];
+	if (!frame || frame.minted) return null;
+
+	const seat = actingSeat();
+	const seq = (lastSeq.get(seat) ?? 0) + 1;
+	lastSeq.set(seat, seq);
+
+	const intent: IntentEvent = { seq, seat, verb: frame.verb, args: reduceArgs(frame.args) };
+	frame.minted = intent;
+	publish(intent);
+	return intent;
+}
+
+/** A patch value with intents riding along, or the value untouched when there are none. */
+export function attachIntents<T extends object>(value: T, intents: IntentEvent[]): T {
+	if (!intents.length) return value;
+	return { ...value, [INTENTS_KEY]: intents };
+}
+
+function isIntent(candidate: unknown): candidate is IntentEvent {
+	const intent = candidate as Partial<IntentEvent> | null;
+	return (
+		!!intent &&
+		typeof intent === 'object' &&
+		typeof intent.seq === 'number' &&
+		typeof intent.seat === 'string' &&
+		typeof intent.verb === 'string' &&
+		Array.isArray(intent.args)
+	);
+}
+
+/**
+ * Peel the intents off an inbound patch. The state half is what gets merged —
+ * `__intents` must never reach the store, or it would show up in a scenario
+ * export and be re-broadcast forever.
+ */
+export function splitIntents<T>(update: T): { state: T; intents: IntentEvent[] } {
+	if (!update || typeof update !== 'object' || !(INTENTS_KEY in update))
+		return { state: update, intents: [] };
+	const { [INTENTS_KEY]: carried, ...state } = update as Record<string, unknown>;
+	const intents = Array.isArray(carried) ? carried.filter(isIntent) : [];
+	return { state: state as T, intents };
+}
+
+/** The state half of `splitIntents`, for callers that want the intents dropped. */
+export function withoutIntents<T>(update: T): T {
+	return splitIntents(update).state;
+}
+
+/** Publish intents that arrived from another client, skipping anything already seen. */
+export function receiveIntents(intents: IntentEvent[]): void {
+	for (const intent of intents) if (admit(intent)) publish(intent);
+}

--- a/src/lib/websocket/__tests__/intent-wire.test.ts
+++ b/src/lib/websocket/__tests__/intent-wire.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The wire half of the intent channel (tableplace-169).
+ *
+ * Two properties matter here and nowhere else:
+ *
+ *  - the verb rides the patch it caused, inside `value`, so the relay's 7 msg/s
+ *    budget is spent once and the Go relay (which carries `value` as an opaque
+ *    json.RawMessage) needs no change at all;
+ *  - the 200ms position throttle COALESCES patches, and coalescing must
+ *    concatenate the intents rather than overwrite them — otherwise a burst of
+ *    drops loses verbs the acting client already published locally, and the two
+ *    clients' streams stop matching, which is the one thing this channel exists
+ *    to guarantee.
+ */
+
+const mockConnection = vi.hoisted(() => {
+	const delivered: Sent[] = [];
+	return {
+		delivered,
+		sendMessage: vi.fn((message: Sent) => {
+			delivered.push(message);
+			return true;
+		})
+	};
+});
+
+vi.mock('../connection', () => ({ sendMessage: mockConnection.sendMessage }));
+
+import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { gameActions } from '$lib/store/game/actions';
+import { clearIntentLog, intentLog, type IntentEvent } from '$lib/store/game/intents';
+import { initWrappers } from '../storeIntegration';
+
+/** as much of an outgoing message as these assertions look at */
+type Sent = {
+	playerId: string;
+	value: {
+		cards?: Record<string, { rotation?: number[] }>;
+		pieces?: Record<string, { position?: number[] }>;
+		__intents?: IntentEvent[];
+	};
+};
+
+const CARD = 'card:std:AS';
+const PIECE = 'piece:token:0';
+
+/**
+ * `initWrappers` monkeypatches `gameStore.updateState` in place and the wrapper
+ * closes over the throttle's clock, so each test puts the untouched function
+ * back before re-wrapping: otherwise the wrapper wraps the wrapper (every patch
+ * sent twice) and the previous test's send time decides this one's throttling.
+ */
+const unwrapped = gameStore.updateState;
+
+/**
+ * A fresh seat per test. `seq` counts per actor for the life of the module and
+ * is deliberately not resettable — a replay guard that can be cleared is not
+ * one — so each test takes a seat of its own and starts from 1.
+ */
+let run = 0;
+const me = () => `tester-${run}`;
+
+/** the intents on a delivered message, or [] when it carried none */
+function carried(message: Sent | undefined): IntentEvent[] {
+	return message?.value?.__intents ?? [];
+}
+
+describe('intents on the wire', () => {
+	beforeEach(() => {
+		mockConnection.delivered.length = 0;
+		vi.clearAllMocks();
+		run++;
+		localStorage.clear();
+		localStorage.setItem('myPlayerId', me());
+		gameStore.set({
+			players: {},
+			decks: {},
+			cards: { [CARD]: { faceImageUrl: 'gen:std52/AS', rotation: [0, 0, 0] } },
+			pieces: { [PIECE]: { kind: 'token', name: 'Scout', position: [0, 0.16, 0] } }
+		});
+		clearIntentLog();
+		gameStore.updateState = unwrapped;
+		initWrappers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('sends the verb alongside the patch, in one message', () => {
+		gameActions.flipCard(CARD);
+
+		expect(mockConnection.sendMessage).toHaveBeenCalledTimes(1);
+		const [message] = mockConnection.delivered;
+		expect(message?.value.cards?.[CARD]?.rotation).toEqual([180, 0, 0]);
+		expect(carried(message)).toEqual([{ seq: 1, seat: me(), verb: 'flipCard', args: [CARD] }]);
+	});
+
+	it('publishes it locally exactly once, not once per seam it passes', () => {
+		gameActions.flipCard(CARD);
+		expect(intentLog().map((i) => i.verb)).toEqual(['flipCard']);
+	});
+
+	it('leaves a patch with no verb behind it alone — the drag stream', () => {
+		// what TableScene writes on every pointer move: no action, no intent, and
+		// no empty carrier riding along either
+		gameStore.updateState({ pieces: { [PIECE]: { position: [1, 0.16, 1] } } });
+		expect(mockConnection.delivered[0]?.value.__intents).toBeUndefined();
+		expect(intentLog()).toEqual([]);
+	});
+
+	it('concatenates the verbs the position throttle coalesces', () => {
+		vi.useFakeTimers();
+
+		gameActions.movePiece(PIECE, [1, 0.16, 1]); // leading send
+		vi.advanceTimersByTime(50);
+		gameActions.movePiece(PIECE, [2, 0.16, 2]); // queued
+		vi.advanceTimersByTime(50);
+		gameActions.movePiece(PIECE, [3, 0.16, 3]); // merged into the queue
+		vi.advanceTimersByTime(300); // the trailing send fires
+
+		expect(mockConnection.delivered).toHaveLength(2);
+		expect(carried(mockConnection.delivered[0]).map((i) => i.seq)).toEqual([1]);
+		// both of the coalesced moves, in the order they happened
+		expect(carried(mockConnection.delivered[1]).map((i) => i.seq)).toEqual([2, 3]);
+		expect(mockConnection.delivered[1]?.value.pieces?.[PIECE]?.position).toEqual([3, 0.16, 3]);
+	});
+
+	it('carries a queued verb out on the next immediate patch that flushes it', () => {
+		vi.useFakeTimers();
+
+		gameActions.movePiece(PIECE, [1, 0.16, 1]); // leading send
+		vi.advanceTimersByTime(20);
+		gameActions.movePiece(PIECE, [2, 0.16, 2]); // queued behind the throttle
+		gameActions.flipCard(CARD); // non-position: flushes the queue into itself
+
+		expect(mockConnection.delivered).toHaveLength(2);
+		expect(carried(mockConnection.delivered[1]).map((i) => i.verb)).toEqual([
+			'movePiece',
+			'flipCard'
+		]);
+	});
+});

--- a/src/lib/websocket/index.ts
+++ b/src/lib/websocket/index.ts
@@ -1,6 +1,7 @@
 import { connect, joinLobby, onMessage, sendMessage, type WebSocketMessage } from './connection';
 import { gameActions } from '$lib/store/game/actions';
 import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { withoutIntents } from '$lib/store/game/intents';
 import { prewarmGameState } from '$lib/packs/prewarm-state';
 import { remoteCameraActions } from '$lib/store/remoteCameraStore.svelte';
 import { requestCameraBroadcast } from '$lib/store/cameraStore.svelte';
@@ -107,12 +108,18 @@ function applyPresenceToCameras(value: unknown): void {
 function setupMessageHandlers(): void {
 	onMessage((message: WebSocketMessage) => {
 		switch (message.type) {
-			case 'sync':
+			case 'sync': {
 				console.log('Received sync message, updating local state', message);
-				gameStore.updateStateSilently(message.value);
+				// A sync is the relay's MERGED state, and the relay merges the
+				// intents a patch piggybacked (tableplace-169) like any other key
+				// — so the last batch before we joined is still sitting in it.
+				// Replaying that would invent history this client never saw, and
+				// put one client's intent stream out of step with everyone else's.
+				const synced = withoutIntents(message.value);
+				gameStore.updateStateSilently(synced);
 				// resolve all sheet refs in the synced state, then force one
 				// re-render sweep so everything repaints deterministically
-				prewarmGameState(message.value, ({ total, failed }) => {
+				prewarmGameState(synced, ({ total, failed }) => {
 					gameStore.updateStateSilently({});
 					toast(
 						failed > 0
@@ -122,6 +129,7 @@ function setupMessageHandlers(): void {
 					);
 				});
 				break;
+			}
 
 			case 'update':
 				console.log('Received update message', message);

--- a/src/lib/websocket/storeIntegration.ts
+++ b/src/lib/websocket/storeIntegration.ts
@@ -1,4 +1,5 @@
 import { gameStore } from '$lib/store/game/gameStore.svelte';
+import { attachIntents, INTENTS_KEY, mintIntent } from '$lib/store/game/intents';
 import type { GameDTO } from '$lib/store/game/types';
 import { purgeUndefinedValues } from '$lib/utils/transforms/data';
 import { createWsMetaData } from '$lib/utils/transforms/websocket';
@@ -94,6 +95,14 @@ export function wsWrapperUpdateDeck(fn: Function) {
 function mergePendingValue(pending: any, incoming: any) {
 	const merged = { ...pending };
 	for (const collection of Object.keys(incoming ?? {})) {
+		// the piggybacked intents are a log, not a collection: coalescing two
+		// patches must CONCATENATE them (pending first — it happened first), or a
+		// throttled drop would silently lose the verb that caused it and the two
+		// clients' intent streams would stop matching
+		if (collection === INTENTS_KEY) {
+			merged[INTENTS_KEY] = [...(pending?.[INTENTS_KEY] ?? []), ...(incoming[INTENTS_KEY] ?? [])];
+			continue;
+		}
 		const incomingEntities = incoming[collection];
 		if (!incomingEntities || typeof incomingEntities !== 'object') {
 			merged[collection] = incomingEntities;
@@ -126,9 +135,16 @@ export function wsWrapperUpdateGameState(fn: Function) {
 
 		const [...[rest]] = args;
 
+		// Name the verb behind this patch and send it along WITH the patch
+		// (tableplace-169) — a second message would consume the relay's 7/sec
+		// budget twice over. It rides inside `value`, which the Go relay carries
+		// as an opaque json.RawMessage, so nothing server-side has to learn about
+		// it. Minted here rather than left to the store call below so the event
+		// exists before the send; the store's own mint then finds it done.
+		const intent = mintIntent();
 		const payload = {
 			...createWsMetaData(),
-			value: { ...(rest as GameDTO) }
+			value: attachIntents({ ...(rest as GameDTO) }, intent ? [intent] : [])
 		};
 
 		// NOTE: This is a hacky way to check if there are any position updates
@@ -190,5 +206,8 @@ export function wsWrapperUpdateGameState(fn: Function) {
 export function initWrappers() {
 	const originalFn = gameStore.updateState;
 	gameStore.updateState = wsWrapperUpdateGameState(originalFn);
-	gameStore.updateStateSilently = originalFn;
+	// `updateStateSilently` is deliberately left alone: it is its own function
+	// now (it peels the piggybacked intents off an inbound patch), and pointing
+	// it back at the local one would blind every observer to the remote half of
+	// the game.
 }


### PR DESCRIPTION
Task: tableplace-169
Closes #169

Part of #168 (rules-engine epic) — Phase 1, step 1 of 4.

**api-impact: behaviour-only.** No spec-covered type changes (`store/game/types.ts` untouched, `bun scripts/check-schemas.ts --base origin/feat/rules-engine` clean, no version bump). The wire gains one reserved key inside an `update` message's `value`, `__intents`, which every client strips before merging — it never reaches `GameDTO`, a scenario export, or the relay's schema.

## What this adds

The wire carried only LWW patches; the verb (`flipCard`, `shuffleDeck`, `drawFromBag`) died at the `gameActions` boundary. It now survives.

- **`src/lib/store/game/intents.ts`** — the channel. `withIntents()` wraps the whole actions bag so a call marks which verb is running; `mintIntent()` runs at the *patch seam*, so exactly one `IntentEvent {seq, seat, verb, args}` is minted per action **and only when the action actually patches state** — the read-only verbs on the bag (`getMe`, `getDeckLength`, `bagCount`, …) stay silent without anything having to list them. `seq` counts per actor and is assigned by the client that acted, never renumbered on arrival, which is what lets every client agree on the same list.
- **Both apply paths.** Local goes through `gameStore.updateState`; inbound goes through `updateStateSilently`, which peels `__intents` off the patch and publishes it to the same bus. An observer on `onIntent` therefore sees the whole table, not only its own half. (`initWrappers` no longer points `updateStateSilently` back at the local function — that would have blinded it.)
- **Piggyback, not a second send.** Intents ride inside the patch message's `value`, so the relay's 7 msg/s budget is spent once and **the Go relay is unchanged** — it carries `value` as an opaque `json.RawMessage`. The 200ms position throttle coalesces patches, so `mergePendingValue` now *concatenates* the intent arrays rather than overwriting them; otherwise a throttled drop would lose the verb behind it and the two clients' streams would diverge.
- **Sync hygiene.** The relay merges `__intents` into lobby state like any other key, so a joiner's `sync` snapshot still holds the last batch. That copy is discarded at the call site rather than replayed as history the joiner never saw.
- **`onIntent(cb)`** is the subscribable surface future adapters / game log / replay consume; `intentLog()` is the readout.
- **`test-bridge.ts`** exposes `intents()` / `clearIntents()` for the harness.
- **`drop/commit.ts`**: the three duplicated felt-landing branches collapse into one `land()` helper named `moveEntity`, so a plain drag reads as a verb too. Identical branch logic — the per-frame drag stream stays deliberately unnamed (a verb per pointer move is a flood, not a log).

## Verification

- **`bun run test:e2e`** — new spec `intents: two clients see the same verbs in the same order`. Two *browser contexts* (tabs share `localStorage` and would therefore share `myPlayerId`, which makes them one player the relay excludes from its own broadcast). A scripted `drawFromTop → flipCard → shuffleDeck → real-mouse drag → rotatePiece from the other client` produces byte-identical, identically-ordered `{seat, seq, verb, args}` streams on both, with `__intents` absent from game state on both. Green 3/3 locally; the `render` CI job runs it here.
- `bun run test` — 944 pass (15 new across `store/__tests__/intents.test.ts` and `websocket/__tests__/intent-wire.test.ts`, covering mint-once, silent readers, argument elision, replay rejection, and throttle coalescing).
- `bun run check` 0 errors; `bun run build` clean; `bun scripts/check-schemas.ts --base origin/feat/rules-engine` clean. Lint is red at baseline on this repo (#123) — every file touched here is prettier-clean and adds no new eslint errors.

## Zero gameplay change

No validation, no legality, no engine. The channel is a readout: an observer that throws is caught and logged rather than taking the mutation with it, and nothing in the app reads it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVeFfiFiXp4CyjPiTvtFrV
